### PR TITLE
Fix #76 - Unchecking "Break when an exception is thrown" during debug…

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -398,7 +398,7 @@ namespace Microsoft.NodejsTools.Debugger {
 
         public void ClearExceptionTreatment() {
             DebuggerClient.RunWithRequestExceptionsHandled(async () => {
-                bool updated = _exceptionHandler.SetDefaultExceptionHitTreatment(ExceptionHitTreatment.BreakAlways);
+                bool updated = _exceptionHandler.SetDefaultExceptionHitTreatment(ExceptionHitTreatment.BreakNever);
                 updated |= _exceptionHandler.ResetExceptionTreatments();
 
                 if (updated) {


### PR DESCRIPTION
…ging session does not properly clear debugging settings

- Should set default exception hit treatment to BreakNever, not
  BreakAlways when clearing exception treatment.