### PR TITLE
Fix #138 Add medium level of IntelliSense / limit to the analysis depth (Related to #88).

### DIFF
--- a/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NodejsTools.Analysis {
             MaxObjectLiteralProperties = 50;
             MaxObjectKeysTypes = 5;
             MaxMergeTypes = 5;
-            NestedModulesLimit = 4;
+            NestedModulesLimit = AnalysisConstants.MaxAnalysisDepthQualty;
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Microsoft.NodejsTools.Analysis {
         /// <returns>An <see cref="AnalysisLimits"/> object representing medium level Initellisense settings.</returns>
         public static AnalysisLimits MakeMediumAnalysisLimits() {
             return new AnalysisLimits() {
-                NestedModulesLimit = 2
+                NestedModulesLimit = AnalysisConstants.MaxAnalysisDepthFast
             };
         }
 

--- a/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
@@ -58,7 +58,6 @@ namespace Microsoft.NodejsTools.Analysis {
             //
             // All these examples are highly speculative and I specifically try to create such deep level. 
             // If you develop on windows with such deep level you already close to your limit, your maximum is probably 10. 
-            // </remarks>
             NestedModulesLimit = 4;
         }
 

--- a/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
@@ -34,6 +34,17 @@ namespace Microsoft.NodejsTools.Analysis {
             MaxObjectLiteralProperties = 50;
             MaxObjectKeysTypes = 5;
             MaxMergeTypes = 5;
+            NestedModulesLimit = 4;
+        }
+
+        /// <summary>
+        /// Creates instance of the <see cref="AnalysisLimits"/> for medium level of Intellisense support.
+        /// </summary>
+        /// <returns>An <see cref="AnalysisLimits"/> object representing medium level Initellisense settings.</returns>
+        public static AnalysisLimits MakeMediumAnalysisLimits() {
+            return new AnalysisLimits() {
+                NestedModulesLimit = 2
+            };
         }
 
         public static AnalysisLimits MakeLowAnalysisLimits() {
@@ -43,7 +54,8 @@ namespace Microsoft.NodejsTools.Analysis {
                 DictKeyTypes = 1,
                 DictValueTypes = 1,
                 IndexTypes = 1,
-                InstanceMembers = 1
+                InstanceMembers = 1,
+                NestedModulesLimit = 1
             };
         }
 
@@ -111,6 +123,11 @@ namespace Microsoft.NodejsTools.Analysis {
         /// </summary>
         public int MaxMergeTypes { get; set; }
 
+        /// <summary>
+        /// Gets the maximum levl  of dependency modules which could be analyzed.
+        /// </summary>
+        public int NestedModulesLimit { get; set; }
+
         public override bool Equals(object obj) {
             AnalysisLimits other = obj as AnalysisLimits;
             if (other != null) {
@@ -125,7 +142,8 @@ namespace Microsoft.NodejsTools.Analysis {
                     other.MaxArrayLiterals == MaxArrayLiterals &&
                     other.MaxObjectLiteralProperties == MaxObjectLiteralProperties &&
                     other.MaxObjectKeysTypes == MaxObjectKeysTypes &&
-                    other.MaxMergeTypes == MaxMergeTypes;
+                    other.MaxMergeTypes == MaxMergeTypes &&
+                    other.NestedModulesLimit == NestedModulesLimit;
             }
             return false;
         }
@@ -142,7 +160,8 @@ namespace Microsoft.NodejsTools.Analysis {
                 MaxArrayLiterals +
                 MaxObjectLiteralProperties +
                 MaxObjectKeysTypes +
-                MaxMergeTypes;
+                MaxMergeTypes +
+                NestedModulesLimit;
         }
     }
 }

--- a/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
@@ -151,9 +151,31 @@ namespace Microsoft.NodejsTools.Analysis {
         public int MaxMergeTypes { get; set; }
 
         /// <summary>
-        /// Gets the maximum levl  of dependency modules which could be analyzed.
+        /// Gets the maximum level of dependency modules which could be analyzed.
         /// </summary>
         public int NestedModulesLimit { get; set; }
+
+        /// <summary>
+        /// Checks whether relative path exceed the nested module limit.
+        /// </summary>
+        /// <param name="path">Path to module file which has to be checked for depth limit.</param>
+        /// <returns>True if path too deep in nesting tree; false overwise.</returns>
+        public bool IsPathExceedNestingLimit(string path) { 
+            int nestedModulesCount = 0;
+            int startIndex = 0;
+            int index = path.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
+            while (index != -1) {
+                nestedModulesCount++;
+                if (nestedModulesCount > this.NestedModulesLimit){
+                    return true;
+                }
+
+                startIndex = index + AnalysisConstants.NodeModulesFolder.Length;
+                index = path.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
 
         public override bool Equals(object obj) {
             AnalysisLimits other = obj as AnalysisLimits;

--- a/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLimits.cs
@@ -34,7 +34,32 @@ namespace Microsoft.NodejsTools.Analysis {
             MaxObjectLiteralProperties = 50;
             MaxObjectKeysTypes = 5;
             MaxMergeTypes = 5;
-            NestedModulesLimit = AnalysisConstants.MaxAnalysisDepthQualty;
+
+            // There no practical reasons to go deeper in dependencies analysis.
+            // Number 4 is very practical. Here the examples which hightlight idea.
+            // 
+            // Example 1
+            // 
+            // Level 0 - Large system. Some code should use properties of the object on level 4 here. 
+            // Level 1 - Subsystem - pass data from level 4
+            // Level 2 - Internal dependency for company - Do some work and pass data to level 1
+            // Level 3 - Framework on top of which created Internal dependency.
+            // Level 4 - Dependency of the framework. Objects from here still should be available.
+            // Level 5 - Dependency of the framework provide some usefull primitive which would be used very often on the level of whole system. Hmmm.
+            // 
+            // Example 2 (reason why I could increase to 5)
+            // 
+            // Level 0 - Large system. Some code should use properties of the object on level 4 here. 
+            // Level 1 - Subsystem - pass data from level 4
+            // Level 2 - Internal dependency for company - Wrap access to internal library and perform business logic. Do some work and pass data to level 1
+            // Level 3 - Internal library which wrap access to API.
+            // Level 4 - Http library.
+            // Level 5 - Promise Polyfill.
+            //
+            // All these examples are highly speculative and I specifically try to create such deep level. 
+            // If you develop on windows with such deep level you already close to your limit, your maximum is probably 10. 
+            // </remarks>
+            NestedModulesLimit = 4;
         }
 
         /// <summary>
@@ -43,7 +68,9 @@ namespace Microsoft.NodejsTools.Analysis {
         /// <returns>An <see cref="AnalysisLimits"/> object representing medium level Initellisense settings.</returns>
         public static AnalysisLimits MakeMediumAnalysisLimits() {
             return new AnalysisLimits() {
-                NestedModulesLimit = AnalysisConstants.MaxAnalysisDepthFast
+
+                // Maximum practical limit for the dependencies analysis oriented on producing faster results.
+                NestedModulesLimit = 2
             };
         }
 

--- a/Nodejs/Product/Analysis/AnalysisConstants.cs
+++ b/Nodejs/Product/Analysis/AnalysisConstants.cs
@@ -22,5 +22,40 @@ using System.Text;
 namespace Microsoft.NodejsTools {
     internal sealed class AnalysisConstants {
         internal const string NodeModulesFolder = "node_modules";
+
+        /// <summary>
+        /// Maximum practical limit for the dependencies analysis.
+        /// </summary>
+        /// <remarks>
+        /// There no practical reasons to go deeper in dependencies analysis.
+        /// Number 4 is very practical. Here the examples which hightlight idea.
+        /// 
+        /// Example 1
+        /// 
+        /// Level 0 - Large system. Some code should use properties of the object on level 4 here. 
+        /// Level 1 - Subsystem - pass data from level 4
+        /// Level 2 - Internal dependency for company - Do some work and pass data to level 1
+        /// Level 3 - Framework on top of which created Internal dependency.
+        /// Level 4 - Dependency of the framework. Objects from here still should be available.
+        /// Level 5 - Dependency of the framework provide some usefull primitive which would be used very often on the level of whole system. Hmmm.
+        /// 
+        /// Example 2 (reason why I could increase to 5)
+        /// 
+        /// Level 0 - Large system. Some code should use properties of the object on level 4 here. 
+        /// Level 1 - Subsystem - pass data from level 4
+        /// Level 2 - Internal dependency for company - Wrap access to internal library and perform business logic. Do some work and pass data to level 1
+        /// Level 3 - Internal library which wrap access to API.
+        /// Level 4 - Http library.
+        /// Level 5 - Promise Polyfill.
+        ///
+        /// All these examples are highly speculative and I specifically try to create such deep level. 
+        /// If you develop on windows with such deep level you already close to your limit, your maximum is probably 10. 
+        /// </remarks>
+        internal const int MaxAnalysisDepthQualty = 4;
+
+        /// <summary>
+        /// Maximum practical limit for the dependencies analysis oriented on producing faster results.
+        /// </summary>
+        internal const int MaxAnalysisDepthFast = 2;
     }
 }

--- a/Nodejs/Product/Analysis/AnalysisConstants.cs
+++ b/Nodejs/Product/Analysis/AnalysisConstants.cs
@@ -22,40 +22,5 @@ using System.Text;
 namespace Microsoft.NodejsTools {
     internal sealed class AnalysisConstants {
         internal const string NodeModulesFolder = "node_modules";
-
-        /// <summary>
-        /// Maximum practical limit for the dependencies analysis.
-        /// </summary>
-        /// <remarks>
-        /// There no practical reasons to go deeper in dependencies analysis.
-        /// Number 4 is very practical. Here the examples which hightlight idea.
-        /// 
-        /// Example 1
-        /// 
-        /// Level 0 - Large system. Some code should use properties of the object on level 4 here. 
-        /// Level 1 - Subsystem - pass data from level 4
-        /// Level 2 - Internal dependency for company - Do some work and pass data to level 1
-        /// Level 3 - Framework on top of which created Internal dependency.
-        /// Level 4 - Dependency of the framework. Objects from here still should be available.
-        /// Level 5 - Dependency of the framework provide some usefull primitive which would be used very often on the level of whole system. Hmmm.
-        /// 
-        /// Example 2 (reason why I could increase to 5)
-        /// 
-        /// Level 0 - Large system. Some code should use properties of the object on level 4 here. 
-        /// Level 1 - Subsystem - pass data from level 4
-        /// Level 2 - Internal dependency for company - Wrap access to internal library and perform business logic. Do some work and pass data to level 1
-        /// Level 3 - Internal library which wrap access to API.
-        /// Level 4 - Http library.
-        /// Level 5 - Promise Polyfill.
-        ///
-        /// All these examples are highly speculative and I specifically try to create such deep level. 
-        /// If you develop on windows with such deep level you already close to your limit, your maximum is probably 10. 
-        /// </remarks>
-        internal const int MaxAnalysisDepthQualty = 4;
-
-        /// <summary>
-        /// Maximum practical limit for the dependencies analysis oriented on producing faster results.
-        /// </summary>
-        internal const int MaxAnalysisDepthFast = 2;
     }
 }

--- a/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
@@ -1459,6 +1459,9 @@ namespace Microsoft.NodejsTools.Intellisense {
 
             if (NodejsPackage.Instance != null) {
                 switch (_analysisLevel) {
+                    case Options.AnalysisLevel.Medium:
+                        defaults = AnalysisLimits.MakeMediumAnalysisLimits();
+                        break;
                     case Options.AnalysisLevel.Low:
                         defaults = _lowLimits;
                         break;
@@ -1500,6 +1503,7 @@ namespace Microsoft.NodejsTools.Intellisense {
             limits.DictValueTypes = GetSetting(key, DictValueTypesId) ?? defaults.DictValueTypes;
             limits.IndexTypes = GetSetting(key, IndexTypesId) ?? defaults.IndexTypes;
             limits.AssignedTypes = GetSetting(key, AssignedTypesId) ?? defaults.AssignedTypes;
+            limits.NestedModulesLimit = GetSetting(key, NestedModulesLimitId) ?? defaults.NestedModulesLimit;
 
             return limits;
         }
@@ -1518,6 +1522,7 @@ namespace Microsoft.NodejsTools.Intellisense {
         private const string DictValueTypesId = "DictValueTypes";
         private const string IndexTypesId = "IndexTypes";
         private const string AssignedTypesId = "AssignedTypes";
+        private const string NestedModulesLimitId = "NestedModulesLimit";
 
         #endregion
     }

--- a/Nodejs/Product/Nodejs/Options/AnalysisLevel.cs
+++ b/Nodejs/Product/Nodejs/Options/AnalysisLevel.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NodejsTools.Options {
     enum AnalysisLevel {
         None,
         Low,
+        Medium,
         High
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
@@ -32,6 +32,7 @@
             this._noIntelliSenseRadioButton = new System.Windows.Forms.RadioButton();
             this._saveToDiskDisabledRadioButton = new System.Windows.Forms.RadioButton();
             this._saveToDiskEnabledRadioButton = new System.Windows.Forms.RadioButton();
+            this._mediumIntelliSenseRadioButton = new System.Windows.Forms.RadioButton();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this._analysisLogMax = new System.Windows.Forms.ComboBox();
             this._analysisLogMaxLabel = new System.Windows.Forms.Label();
@@ -41,7 +42,6 @@
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this._completionCommittedBy = new System.Windows.Forms.TextBox();
             this._completionCommittedByLabel = new System.Windows.Forms.Label();
-            this._mediumIntelliSenseRadioButton = new System.Windows.Forms.RadioButton();
             toolTip = new System.Windows.Forms.ToolTip(this.components);
             intellisenseLevelGroupBox = new System.Windows.Forms.GroupBox();
             saveToDiskGroupBox = new System.Windows.Forms.GroupBox();
@@ -85,6 +85,14 @@
             this._saveToDiskEnabledRadioButton.TabStop = true;
             toolTip.SetToolTip(this._saveToDiskEnabledRadioButton, resources.GetString("_saveToDiskEnabledRadioButton.ToolTip"));
             this._saveToDiskEnabledRadioButton.UseVisualStyleBackColor = true;
+            // 
+            // _mediumIntelliSenseRadioButton
+            // 
+            resources.ApplyResources(this._mediumIntelliSenseRadioButton, "_mediumIntelliSenseRadioButton");
+            this._mediumIntelliSenseRadioButton.Name = "_mediumIntelliSenseRadioButton";
+            this._mediumIntelliSenseRadioButton.TabStop = true;
+            toolTip.SetToolTip(this._mediumIntelliSenseRadioButton, resources.GetString("_mediumIntelliSenseRadioButton.ToolTip"));
+            this._mediumIntelliSenseRadioButton.UseVisualStyleBackColor = true;
             // 
             // intellisenseLevelGroupBox
             // 
@@ -168,14 +176,6 @@
             // 
             resources.ApplyResources(this._completionCommittedByLabel, "_completionCommittedByLabel");
             this._completionCommittedByLabel.Name = "_completionCommittedByLabel";
-            // 
-            // _mediumIntelliSenseRadioButton
-            // 
-            resources.ApplyResources(this._mediumIntelliSenseRadioButton, "_mediumIntelliSenseRadioButton");
-            this._mediumIntelliSenseRadioButton.Name = "_mediumIntelliSenseRadioButton";
-            this._mediumIntelliSenseRadioButton.TabStop = true;
-            toolTip.SetToolTip(this._mediumIntelliSenseRadioButton, resources.GetString("_mediumIntelliSenseRadioButton.ToolTip"));
-            this._mediumIntelliSenseRadioButton.UseVisualStyleBackColor = true;
             // 
             // NodejsIntellisenseOptionsControl
             // 

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
@@ -41,6 +41,7 @@
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this._completionCommittedBy = new System.Windows.Forms.TextBox();
             this._completionCommittedByLabel = new System.Windows.Forms.Label();
+            this._mediumIntelliSenseRadioButton = new System.Windows.Forms.RadioButton();
             toolTip = new System.Windows.Forms.ToolTip(this.components);
             intellisenseLevelGroupBox = new System.Windows.Forms.GroupBox();
             saveToDiskGroupBox = new System.Windows.Forms.GroupBox();
@@ -95,10 +96,11 @@
             // tableLayoutPanel2
             // 
             resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-            this.tableLayoutPanel2.Controls.Add(this._analysisLogMax, 1, 3);
-            this.tableLayoutPanel2.Controls.Add(this._noIntelliSenseRadioButton, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this._mediumIntelliSenseRadioButton, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this._analysisLogMax, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this._noIntelliSenseRadioButton, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this._fullIntelliSenseRadioButton, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this._analysisLogMaxLabel, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this._analysisLogMaxLabel, 0, 4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
             // _analysisLogMax
@@ -167,6 +169,14 @@
             resources.ApplyResources(this._completionCommittedByLabel, "_completionCommittedByLabel");
             this._completionCommittedByLabel.Name = "_completionCommittedByLabel";
             // 
+            // _mediumIntelliSenseRadioButton
+            // 
+            resources.ApplyResources(this._mediumIntelliSenseRadioButton, "_mediumIntelliSenseRadioButton");
+            this._mediumIntelliSenseRadioButton.Name = "_mediumIntelliSenseRadioButton";
+            this._mediumIntelliSenseRadioButton.TabStop = true;
+            toolTip.SetToolTip(this._mediumIntelliSenseRadioButton, resources.GetString("_mediumIntelliSenseRadioButton.ToolTip"));
+            this._mediumIntelliSenseRadioButton.UseVisualStyleBackColor = true;
+            // 
             // NodejsIntellisenseOptionsControl
             // 
             resources.ApplyResources(this, "$this");
@@ -207,6 +217,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
         private System.Windows.Forms.RadioButton _saveToDiskDisabledRadioButton;
         private System.Windows.Forms.RadioButton _saveToDiskEnabledRadioButton;
-
+        private System.Windows.Forms.RadioButton _mediumIntelliSenseRadioButton;
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
@@ -42,12 +42,10 @@ namespace Microsoft.NodejsTools.Options {
             get {
                 if (_fullIntelliSenseRadioButton.Checked) {
                     return AnalysisLevel.High;
+                } else if (_mediumIntelliSenseRadioButton.Checked) {
+                    return AnalysisLevel.Medium;
                 } else {
-                    if (_mediumIntelliSenseRadioButton.Checked) {
-                        return AnalysisLevel.Medium;
-                    } else {
-                        return AnalysisLevel.None;
-                    }
+                    return AnalysisLevel.None;
                 }
             }
             set {

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
@@ -43,13 +43,20 @@ namespace Microsoft.NodejsTools.Options {
                 if (_fullIntelliSenseRadioButton.Checked) {
                     return AnalysisLevel.High;
                 } else {
-                    return AnalysisLevel.None;
+                    if (_mediumIntelliSenseRadioButton.Checked) {
+                        return AnalysisLevel.Medium;
+                    } else {
+                        return AnalysisLevel.None;
+                    }
                 }
             }
             set {
                 switch (value) {
                     case AnalysisLevel.High:
                         _fullIntelliSenseRadioButton.Checked = true;
+                        break;
+                    case AnalysisLevel.Medium:
+                        _mediumIntelliSenseRadioButton.Checked = true;
                         break;
                     case AnalysisLevel.None:
                         _noIntelliSenseRadioButton.Checked = true;

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
@@ -139,13 +139,13 @@
     <value>NoControl</value>
   </data>
   <data name="_fullIntelliSenseRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>8, 4</value>
   </data>
   <data name="_fullIntelliSenseRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_fullIntelliSenseRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 17</value>
+    <value>127, 21</value>
   </data>
   <data name="_fullIntelliSenseRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -169,7 +169,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_fullIntelliSenseRadioButton.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="_noIntelliSenseRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -184,13 +184,13 @@
     <value>NoControl</value>
   </data>
   <data name="_noIntelliSenseRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 26</value>
+    <value>8, 62</value>
   </data>
   <data name="_noIntelliSenseRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_noIntelliSenseRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 17</value>
+    <value>123, 21</value>
   </data>
   <data name="_noIntelliSenseRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -214,7 +214,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_noIntelliSenseRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="_saveToDiskDisabledRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -229,13 +229,13 @@
     <value>NoControl</value>
   </data>
   <data name="_saveToDiskDisabledRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 26</value>
+    <value>8, 33</value>
   </data>
   <data name="_saveToDiskDisabledRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_saveToDiskDisabledRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 17</value>
+    <value>370, 21</value>
   </data>
   <data name="_saveToDiskDisabledRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -275,13 +275,13 @@
     <value>NoControl</value>
   </data>
   <data name="_saveToDiskEnabledRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>8, 4</value>
   </data>
   <data name="_saveToDiskEnabledRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_saveToDiskEnabledRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 17</value>
+    <value>81, 21</value>
   </data>
   <data name="_saveToDiskEnabledRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -322,6 +322,51 @@
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="_mediumIntelliSenseRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopLeft</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 33</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 4, 8, 4</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 21</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.Text" xml:space="preserve">
+    <value>&amp;Medium IntelliSense</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopLeft</value>
+  </data>
+  <data name="_mediumIntelliSenseRadioButton.ToolTip" xml:space="preserve">
+    <value>Medium completions (less memory/CPU usage)</value>
+  </data>
+  <data name="&gt;&gt;_mediumIntelliSenseRadioButton.Name" xml:space="preserve">
+    <value>_mediumIntelliSenseRadioButton</value>
+  </data>
+  <data name="&gt;&gt;_mediumIntelliSenseRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_mediumIntelliSenseRadioButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;_mediumIntelliSenseRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="_analysisLogMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
@@ -347,13 +392,13 @@
     <value>Max</value>
   </data>
   <data name="_analysisLogMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>145, 49</value>
+    <value>195, 91</value>
   </data>
   <data name="_analysisLogMax.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_analysisLogMax.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
+    <value>165, 24</value>
   </data>
   <data name="_analysisLogMax.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -368,7 +413,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_analysisLogMax.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="_analysisLogMaxLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -380,13 +425,13 @@
     <value>NoControl</value>
   </data>
   <data name="_analysisLogMaxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 53</value>
+    <value>8, 94</value>
   </data>
   <data name="_analysisLogMaxLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_analysisLogMaxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 13</value>
+    <value>171, 17</value>
   </data>
   <data name="_analysisLogMaxLabel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -404,22 +449,22 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;_analysisLogMaxLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 21</value>
+    <value>11, 25</value>
   </data>
   <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>611, 73</value>
+    <value>814, 119</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -437,22 +482,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_analysisLogMax" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_noIntelliSenseRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_fullIntelliSenseRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_analysisLogMaxLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_mediumIntelliSenseRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_analysisLogMax" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_noIntelliSenseRadioButton" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_fullIntelliSenseRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_analysisLogMaxLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="intellisenseLevelGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="intellisenseLevelGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>8, 4</value>
   </data>
   <data name="intellisenseLevelGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="intellisenseLevelGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>11, 10, 11, 10</value>
   </data>
   <data name="intellisenseLevelGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>627, 102</value>
+    <value>836, 154</value>
   </data>
   <data name="intellisenseLevelGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -491,16 +536,16 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 21</value>
+    <value>11, 25</value>
   </data>
   <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>611, 46</value>
+    <value>814, 58</value>
   </data>
   <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -524,16 +569,16 @@
     <value>Fill</value>
   </data>
   <data name="saveToDiskGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 111</value>
+    <value>8, 166</value>
   </data>
   <data name="saveToDiskGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="saveToDiskGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>11, 10, 11, 10</value>
   </data>
   <data name="saveToDiskGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>627, 75</value>
+    <value>836, 93</value>
   </data>
   <data name="saveToDiskGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -578,13 +623,13 @@
     <value>Left, Right</value>
   </data>
   <data name="_completionCommittedBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
+    <value>8, 29</value>
   </data>
   <data name="_completionCommittedBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_completionCommittedBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>609, 20</value>
+    <value>812, 22</value>
   </data>
   <data name="_completionCommittedBy.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -611,13 +656,13 @@
     <value>NoControl</value>
   </data>
   <data name="_completionCommittedByLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 3</value>
+    <value>8, 4</value>
   </data>
   <data name="_completionCommittedByLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
   </data>
   <data name="_completionCommittedByLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 13</value>
+    <value>292, 17</value>
   </data>
   <data name="_completionCommittedByLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -641,16 +686,16 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+    <value>4, 19</value>
   </data>
   <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>621, 45</value>
+    <value>828, 55</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -668,19 +713,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_completionCommittedBy" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_completionCommittedByLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,20" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_completionCommittedBy" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_completionCommittedByLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,27" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="_selectionInCompletionListGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="_selectionInCompletionListGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 192</value>
+    <value>8, 267</value>
   </data>
   <data name="_selectionInCompletionListGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 3, 6, 3</value>
+    <value>8, 4, 8, 4</value>
+  </data>
+  <data name="_selectionInCompletionListGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="_selectionInCompletionListGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>627, 64</value>
+    <value>836, 78</value>
   </data>
   <data name="_selectionInCompletionListGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -707,13 +755,13 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>639, 323</value>
+    <value>852, 398</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -731,19 +779,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_selectionInCompletionListGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="saveToDiskGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intellisenseLevelGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,22" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_selectionInCompletionListGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="saveToDiskGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intellisenseLevelGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,27" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>8, 16</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>639, 323</value>
+    <value>852, 398</value>
   </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
@@ -307,21 +307,6 @@
   <data name="&gt;&gt;_saveToDiskEnabledRadioButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <metadata name="intellisenseLevelGroupBox.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
-  <data name="intellisenseLevelGroupBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="_mediumIntelliSenseRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
@@ -341,19 +326,19 @@
     <value>8, 4, 8, 4</value>
   </data>
   <data name="_mediumIntelliSenseRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 21</value>
+    <value>141, 21</value>
   </data>
   <data name="_mediumIntelliSenseRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>1</value>
   </data>
   <data name="_mediumIntelliSenseRadioButton.Text" xml:space="preserve">
-    <value>&amp;Medium IntelliSense</value>
+    <value>&amp;Quick IntelliSense</value>
   </data>
   <data name="_mediumIntelliSenseRadioButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopLeft</value>
   </data>
   <data name="_mediumIntelliSenseRadioButton.ToolTip" xml:space="preserve">
-    <value>Medium completions (less memory/CPU usage)</value>
+    <value>Limited completions (reduced memory/CPU usage)</value>
   </data>
   <data name="&gt;&gt;_mediumIntelliSenseRadioButton.Name" xml:space="preserve">
     <value>_mediumIntelliSenseRadioButton</value>
@@ -366,6 +351,21 @@
   </data>
   <data name="&gt;&gt;_mediumIntelliSenseRadioButton.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <metadata name="intellisenseLevelGroupBox.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <data name="intellisenseLevelGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel2.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="_analysisLogMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -523,33 +523,6 @@
   <data name="saveToDiskGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="tableLayoutPanel4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel4.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 25</value>
-  </data>
-  <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>814, 58</value>
-  </data>
-  <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
   <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
     <value>tableLayoutPanel4</value>
   </data>
@@ -598,6 +571,48 @@
   <data name="&gt;&gt;saveToDiskGroupBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="tableLayoutPanel4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel4.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 25</value>
+  </data>
+  <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>814, 58</value>
+  </data>
+  <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.Parent" xml:space="preserve">
+    <value>saveToDiskGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel4.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_saveToDiskDisabledRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_saveToDiskEnabledRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
   <data name="tableLayoutPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -609,96 +624,6 @@
   </data>
   <data name="_selectionInCompletionListGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tableLayoutPanel3.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="_completionCommittedBy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="_completionCommittedBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 29</value>
-  </data>
-  <data name="_completionCommittedBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 4, 8, 4</value>
-  </data>
-  <data name="_completionCommittedBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>812, 22</value>
-  </data>
-  <data name="_completionCommittedBy.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedBy.Name" xml:space="preserve">
-    <value>_completionCommittedBy</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedBy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedBy.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedBy.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="_completionCommittedByLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="_completionCommittedByLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_completionCommittedByLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="_completionCommittedByLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 4</value>
-  </data>
-  <data name="_completionCommittedByLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 4, 8, 4</value>
-  </data>
-  <data name="_completionCommittedByLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>292, 17</value>
-  </data>
-  <data name="_completionCommittedByLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="_completionCommittedByLabel.Text" xml:space="preserve">
-    <value>Committed by typing the following characters:</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedByLabel.Name" xml:space="preserve">
-    <value>_completionCommittedByLabel</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedByLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedByLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;_completionCommittedByLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 19</value>
-  </data>
-  <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>828, 55</value>
-  </data>
-  <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -780,6 +705,135 @@
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_selectionInCompletionListGroupBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="saveToDiskGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="intellisenseLevelGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,Absolute,27" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanel3.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Name" xml:space="preserve">
+    <value>_completionCommittedBy</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Parent" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Name" xml:space="preserve">
+    <value>_completionCommittedByLabel</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 19</value>
+  </data>
+  <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>828, 55</value>
+  </data>
+  <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
+    <value>_selectionInCompletionListGroupBox</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_completionCommittedBy" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_completionCommittedByLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,27" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="_completionCommittedBy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="_completionCommittedBy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 29</value>
+  </data>
+  <data name="_completionCommittedBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 4, 8, 4</value>
+  </data>
+  <data name="_completionCommittedBy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>812, 22</value>
+  </data>
+  <data name="_completionCommittedBy.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Name" xml:space="preserve">
+    <value>_completionCommittedBy</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.Parent" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedBy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="_completionCommittedByLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="_completionCommittedByLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_completionCommittedByLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_completionCommittedByLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 4</value>
+  </data>
+  <data name="_completionCommittedByLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>8, 4, 8, 4</value>
+  </data>
+  <data name="_completionCommittedByLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>292, 17</value>
+  </data>
+  <data name="_completionCommittedByLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="_completionCommittedByLabel.Text" xml:space="preserve">
+    <value>Committed by typing the following characters:</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Name" xml:space="preserve">
+    <value>_completionCommittedByLabel</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.Parent" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
+  </data>
+  <data name="&gt;&gt;_completionCommittedByLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -490,6 +490,26 @@ namespace Microsoft.NodejsTools.Project {
             if (CommonUtils.IsSubpathOf(_intermediateOutputPath, fileNode.Url)) {
                 return false;
             }
+
+            int maxModulesDepth = AnalysisConstants.MaxAnalysisDepthQualty;
+            if (this._analyzer.AnalysisLevel == Options.AnalysisLevel.Medium) {
+                maxModulesDepth = AnalysisConstants.MaxAnalysisDepthFast;
+            }
+
+            var relativeFile = CommonUtils.GetRelativeFilePath(this.FullPathToChildren, fileNode.Url);
+            int nestedModulesCount = 0;
+            int startIndex = 0;
+            int index = relativeFile.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
+            while (index != -1) {
+                nestedModulesCount++;
+                if (nestedModulesCount > maxModulesDepth){
+                    return false;
+                }
+
+                startIndex = index + 1;
+                index = relativeFile.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
+            }
+
             foreach (var path in _analysisIgnoredDirs) {
                 if (url.IndexOf(path, 0, StringComparison.OrdinalIgnoreCase) != -1) {
                     return false;

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -491,11 +491,17 @@ namespace Microsoft.NodejsTools.Project {
                 return false;
             }
 
-            int maxModulesDepth = AnalysisConstants.MaxAnalysisDepthQualty;
-            if (this._analyzer.AnalysisLevel == Options.AnalysisLevel.Medium) {
-                maxModulesDepth = AnalysisConstants.MaxAnalysisDepthFast;
+            foreach (var path in _analysisIgnoredDirs) {
+                if (url.IndexOf(path, 0, StringComparison.OrdinalIgnoreCase) != -1) {
+                    return false;
+                }
+            }
+            if (new FileInfo(fileNode.Url).Length > _maxFileSize) {
+                // skip obviously generated files...
+                return false;
             }
 
+            int maxModulesDepth = this._analyzer.Project.Limits.NestedModulesLimit;
             var relativeFile = CommonUtils.GetRelativeFilePath(this.FullPathToChildren, fileNode.Url);
             int nestedModulesCount = 0;
             int startIndex = 0;
@@ -506,19 +512,10 @@ namespace Microsoft.NodejsTools.Project {
                     return false;
                 }
 
-                startIndex = index + 1;
+                startIndex = index + AnalysisConstants.NodeModulesFolder.Length;
                 index = relativeFile.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
             }
 
-            foreach (var path in _analysisIgnoredDirs) {
-                if (url.IndexOf(path, 0, StringComparison.OrdinalIgnoreCase) != -1) {
-                    return false;
-                }
-            }
-            if (new FileInfo(fileNode.Url).Length > _maxFileSize) {
-                // skip obviously generated files...
-                return false;
-            }
             return true;
         }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -501,19 +501,9 @@ namespace Microsoft.NodejsTools.Project {
                 return false;
             }
 
-            int maxModulesDepth = this._analyzer.Project.Limits.NestedModulesLimit;
             var relativeFile = CommonUtils.GetRelativeFilePath(this.FullPathToChildren, fileNode.Url);
-            int nestedModulesCount = 0;
-            int startIndex = 0;
-            int index = relativeFile.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
-            while (index != -1) {
-                nestedModulesCount++;
-                if (nestedModulesCount > maxModulesDepth){
-                    return false;
-                }
-
-                startIndex = index + AnalysisConstants.NodeModulesFolder.Length;
-                index = relativeFile.IndexOf(AnalysisConstants.NodeModulesFolder, startIndex, StringComparison.OrdinalIgnoreCase);
+            if (this._analyzer.Project.Limits.IsPathExceedNestingLimit(relativeFile)) {
+                return false;
             }
 
             return true;

--- a/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
@@ -131,6 +131,21 @@ namespace AnalysisTests {
             List<AnalysisFile> files = new List<AnalysisFile>();
             foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories)) {
                 if (String.Equals(Path.GetExtension(file), ".js", StringComparison.OrdinalIgnoreCase)) {
+                    var relativeFile = file.Substring(directory.Length);
+                    int nestedModulesCount = 0;
+                    int index = relativeFile.IndexOf("node_modules");
+                    while (index != -1)
+                    {
+                        nestedModulesCount++;
+                        relativeFile = relativeFile.Substring(index + 1);
+                        index = relativeFile.IndexOf("node_modules");
+                    }
+
+                    if (nestedModulesCount > 2)
+                    {
+                        continue;
+                    }
+
                     files.Add(new AnalysisFile(file, File.ReadAllText(file)));
                 } else if (String.Equals(Path.GetFileName(file), "package.json", StringComparison.OrdinalIgnoreCase)) {
                     JavaScriptSerializer serializer = new JavaScriptSerializer();

--- a/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
@@ -141,7 +141,7 @@ namespace AnalysisTests {
                         index = relativeFile.IndexOf("node_modules");
                     }
 
-                    if (nestedModulesCount > 2)
+                    if (nestedModulesCount > limits.NestedModulesLimit)
                     {
                         continue;
                     }

--- a/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
@@ -132,7 +132,7 @@ namespace AnalysisTests {
             foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories)) {
                 if (String.Equals(Path.GetExtension(file), ".js", StringComparison.OrdinalIgnoreCase)) {
                     var relativeFile = file.Substring(directory.Length);
-                    if (!CheckExceedsNestedModulesLimit(relativeFile, limits.NestedModulesLimit)) {
+                    if (!limits.IsPathExceedNestingLimit(relativeFile)) {
                         files.Add(new AnalysisFile(file, File.ReadAllText(file)));
                     }
                 } else if (String.Equals(Path.GetFileName(file), "package.json", StringComparison.OrdinalIgnoreCase)) {
@@ -152,30 +152,6 @@ namespace AnalysisTests {
             }
 
             return Analyze(limits, parseCallback, files.ToArray());
-        }
-
-        /// <summary>
-        /// Check that relative file path does not exceed required 
-        /// </summary>
-        /// <param name="relativeFile">Relative file path to check.</param>
-        /// <param name="maxDepth">Max depth of node dependencies.</param>
-        /// <returns>True if file contains in the dependency which is too deep down dependency tree; false otherwise.</returns>
-        private static bool CheckExceedsNestedModulesLimit(string relativeFile, int maxDepth)
-        {
-            int nestedModulesCount = 0;
-            int startIndex = 0;
-            int index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
-            while (index != -1) {
-                nestedModulesCount++;
-                if (nestedModulesCount > maxDepth) {
-                    return true;
-                }
-
-                startIndex = index + "node_modules".Length;
-                index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
-            }
-
-            return false;
         }
     }
 }

--- a/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
@@ -133,17 +133,16 @@ namespace AnalysisTests {
                 if (String.Equals(Path.GetExtension(file), ".js", StringComparison.OrdinalIgnoreCase)) {
                     var relativeFile = file.Substring(directory.Length);
                     int nestedModulesCount = 0;
-                    int index = relativeFile.IndexOf("node_modules");
-                    while (index != -1)
-                    {
+                    int startIndex = 0;
+                    int index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
+                    while (index != -1) {
                         nestedModulesCount++;
-                        relativeFile = relativeFile.Substring(index + 1);
-                        index = relativeFile.IndexOf("node_modules");
-                    }
+                        if (nestedModulesCount > limits.NestedModulesLimit) {
+                            continue;
+                        }
 
-                    if (nestedModulesCount > limits.NestedModulesLimit)
-                    {
-                        continue;
+                        startIndex = index + 1;
+                        index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
                     }
 
                     files.Add(new AnalysisFile(file, File.ReadAllText(file)));

--- a/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisFile.cs
@@ -132,20 +132,9 @@ namespace AnalysisTests {
             foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories)) {
                 if (String.Equals(Path.GetExtension(file), ".js", StringComparison.OrdinalIgnoreCase)) {
                     var relativeFile = file.Substring(directory.Length);
-                    int nestedModulesCount = 0;
-                    int startIndex = 0;
-                    int index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
-                    while (index != -1) {
-                        nestedModulesCount++;
-                        if (nestedModulesCount > limits.NestedModulesLimit) {
-                            continue;
-                        }
-
-                        startIndex = index + 1;
-                        index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
+                    if (!CheckExceedsNestedModulesLimit(relativeFile, limits.NestedModulesLimit)) {
+                        files.Add(new AnalysisFile(file, File.ReadAllText(file)));
                     }
-
-                    files.Add(new AnalysisFile(file, File.ReadAllText(file)));
                 } else if (String.Equals(Path.GetFileName(file), "package.json", StringComparison.OrdinalIgnoreCase)) {
                     JavaScriptSerializer serializer = new JavaScriptSerializer();
                     Dictionary<string, object> json;
@@ -163,6 +152,30 @@ namespace AnalysisTests {
             }
 
             return Analyze(limits, parseCallback, files.ToArray());
+        }
+
+        /// <summary>
+        /// Check that relative file path does not exceed required 
+        /// </summary>
+        /// <param name="relativeFile">Relative file path to check.</param>
+        /// <param name="maxDepth">Max depth of node dependencies.</param>
+        /// <returns>True if file contains in the dependency which is too deep down dependency tree; false otherwise.</returns>
+        private static bool CheckExceedsNestedModulesLimit(string relativeFile, int maxDepth)
+        {
+            int nestedModulesCount = 0;
+            int startIndex = 0;
+            int index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
+            while (index != -1) {
+                nestedModulesCount++;
+                if (nestedModulesCount > maxDepth) {
+                    return true;
+                }
+
+                startIndex = index + "node_modules".Length;
+                index = relativeFile.IndexOf("node_modules", startIndex, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Limit depth analysys to relative paths which contains only 2 node_modules. This should be sufficient enough to capture
a) Capture API of the root package
b) Capture API of the dependencies. This is obiviously the must to analyze (1 node_modules)
c) Capture API of subdependencies (2 node_modules). This is also the must, since a lot of packages are wrapper/glue for another library. For example using gulp-typescript require that gulp-typescript should be parsed (level b) and typescript should be parsed (level c) since typescritp provide some config options for gulp-typescript.

Related to #88 

#138 Added Medium level of Intellisense. This level now same as Full level, but limit analysis depth to the 2 nested modules depth. Full mode is now has limit to 4 modules depth which I almost sure practical enough, but could be increased if needed. Low level is analyse 1 level depth.