### PR TITLE
Fix startup file issues

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -99,10 +99,13 @@ namespace Microsoft.NodejsTools.Debugger {
 
             _debuggerEndpointUri = new UriBuilder { Scheme = "tcp", Host = "localhost", Port = debuggerPortOrDefault }.Uri;
 
-            string allArgs = String.Format("--debug-brk={0} {1}", debuggerPortOrDefault, script);
-            if (!string.IsNullOrEmpty(interpreterOptions)) {
-                allArgs = interpreterOptions + " " + allArgs;
-            }
+            // Node usage: node [options] [ -e script | script.js ] [arguments]
+            string allArgs = String.Format(
+                "--debug-brk={0} {1} {2}",
+                debuggerPortOrDefault,
+                interpreterOptions,
+                script
+            );
 
             var psi = new ProcessStartInfo(exe, allArgs) {
                 CreateNoWindow = !createNodeWindow,

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
@@ -50,6 +50,7 @@ namespace Microsoft.NodejsTools.Project {
         public override void Apply() {
             Project.SetProjectProperty(NodejsConstants.NodeExePath, _control.NodeExePath);
             Project.SetProjectProperty(NodejsConstants.NodeExeArguments, _control.NodeExeArguments);
+            Project.SetProjectProperty(CommonConstants.StartupFile, _control.ScriptFile);
             Project.SetProjectProperty(NodejsConstants.ScriptArguments, _control.ScriptArguments);
             Project.SetProjectProperty(NodejsConstants.NodejsPort, _control.NodejsPort);
             Project.SetProjectProperty(NodejsConstants.StartWebBrowser, _control.StartWebBrowser.ToString());
@@ -65,6 +66,7 @@ namespace Microsoft.NodejsTools.Project {
             try {
                 _control.NodeExeArguments = Project.GetUnevaluatedProperty(NodejsConstants.NodeExeArguments);
                 _control.NodeExePath = Project.GetUnevaluatedProperty(NodejsConstants.NodeExePath);
+                _control.ScriptFile = Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
                 _control.ScriptArguments = Project.GetUnevaluatedProperty(NodejsConstants.ScriptArguments);
                 _control.WorkingDirectory = Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
                 _control.LaunchUrl = Project.GetUnevaluatedProperty(NodejsConstants.LaunchUrl);

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -45,34 +45,39 @@
             this._debuggerPortLabel = new System.Windows.Forms.Label();
             this._debuggerPort = new System.Windows.Forms.TextBox();
             this._envVarsLabel = new System.Windows.Forms.Label();
+            this._scriptLabel = new System.Windows.Forms.Label();
+            this._scriptFile = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).BeginInit();
             this.SuspendLayout();
             // 
             // _nodeExePathLabel
             // 
             this._nodeExePathLabel.AutoSize = true;
-            this._nodeExePathLabel.Location = new System.Drawing.Point(14, 22);
+            this._nodeExePathLabel.Location = new System.Drawing.Point(19, 27);
+            this._nodeExePathLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._nodeExePathLabel.Name = "_nodeExePathLabel";
-            this._nodeExePathLabel.Size = new System.Drawing.Size(80, 13);
+            this._nodeExePathLabel.Size = new System.Drawing.Size(104, 17);
             this._nodeExePathLabel.TabIndex = 0;
             this._nodeExePathLabel.Text = "Node.exe &path:";
             // 
             // _nodeArguments
             // 
             this._nodeArguments.AutoSize = true;
-            this._nodeArguments.Location = new System.Drawing.Point(14, 48);
+            this._nodeArguments.Location = new System.Drawing.Point(19, 59);
+            this._nodeArguments.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._nodeArguments.Name = "_nodeArguments";
-            this._nodeArguments.Size = new System.Drawing.Size(108, 13);
+            this._nodeArguments.Size = new System.Drawing.Size(122, 17);
             this._nodeArguments.TabIndex = 3;
-            this._nodeArguments.Text = "N&ode.exe arguments:";
+            this._nodeArguments.Text = "N&ode.exe options:";
             // 
             // _startBrowser
             // 
             this._startBrowser.AutoSize = true;
-            this._startBrowser.Location = new System.Drawing.Point(17, 258);
+            this._startBrowser.Location = new System.Drawing.Point(23, 350);
+            this._startBrowser.Margin = new System.Windows.Forms.Padding(4);
             this._startBrowser.Name = "_startBrowser";
-            this._startBrowser.Size = new System.Drawing.Size(161, 17);
-            this._startBrowser.TabIndex = 18;
+            this._startBrowser.Size = new System.Drawing.Size(209, 21);
+            this._startBrowser.TabIndex = 20;
             this._startBrowser.Text = "St&art web browser on launch";
             this._startBrowser.UseVisualStyleBackColor = true;
             this._startBrowser.CheckedChanged += new System.EventHandler(this.Changed);
@@ -83,9 +88,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this._nodeExePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this._nodeExePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystem;
-            this._nodeExePath.Location = new System.Drawing.Point(135, 19);
+            this._nodeExePath.Location = new System.Drawing.Point(180, 23);
+            this._nodeExePath.Margin = new System.Windows.Forms.Padding(4);
             this._nodeExePath.Name = "_nodeExePath";
-            this._nodeExePath.Size = new System.Drawing.Size(308, 20);
+            this._nodeExePath.Size = new System.Drawing.Size(409, 22);
             this._nodeExePath.TabIndex = 1;
             this._nodeExePath.TextChanged += new System.EventHandler(this.NodeExePathChanged);
             // 
@@ -93,104 +99,115 @@
             // 
             this._nodeExeArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._nodeExeArguments.Location = new System.Drawing.Point(135, 45);
+            this._nodeExeArguments.Location = new System.Drawing.Point(180, 55);
+            this._nodeExeArguments.Margin = new System.Windows.Forms.Padding(4);
             this._nodeExeArguments.Name = "_nodeExeArguments";
-            this._nodeExeArguments.Size = new System.Drawing.Size(340, 20);
+            this._nodeExeArguments.Size = new System.Drawing.Size(452, 22);
             this._nodeExeArguments.TabIndex = 4;
             this._nodeExeArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _nodejsPort
             // 
-            this._nodejsPort.Location = new System.Drawing.Point(135, 150);
+            this._nodejsPort.Location = new System.Drawing.Point(180, 217);
+            this._nodejsPort.Margin = new System.Windows.Forms.Padding(4);
             this._nodejsPort.Name = "_nodejsPort";
-            this._nodejsPort.Size = new System.Drawing.Size(105, 20);
-            this._nodejsPort.TabIndex = 13;
+            this._nodejsPort.Size = new System.Drawing.Size(139, 22);
+            this._nodejsPort.TabIndex = 15;
             this._nodejsPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _nodePortLabel
             // 
             this._nodePortLabel.AutoSize = true;
-            this._nodePortLabel.Location = new System.Drawing.Point(14, 153);
+            this._nodePortLabel.Location = new System.Drawing.Point(19, 220);
+            this._nodePortLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._nodePortLabel.Name = "_nodePortLabel";
-            this._nodePortLabel.Size = new System.Drawing.Size(67, 13);
-            this._nodePortLabel.TabIndex = 12;
+            this._nodePortLabel.Size = new System.Drawing.Size(89, 17);
+            this._nodePortLabel.TabIndex = 14;
             this._nodePortLabel.Text = "Node.&js port:";
             // 
             // _scriptArgsLabel
             // 
             this._scriptArgsLabel.AutoSize = true;
-            this._scriptArgsLabel.Location = new System.Drawing.Point(14, 74);
+            this._scriptArgsLabel.Location = new System.Drawing.Point(19, 123);
+            this._scriptArgsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._scriptArgsLabel.Name = "_scriptArgsLabel";
-            this._scriptArgsLabel.Size = new System.Drawing.Size(89, 13);
-            this._scriptArgsLabel.TabIndex = 5;
+            this._scriptArgsLabel.Size = new System.Drawing.Size(119, 17);
+            this._scriptArgsLabel.TabIndex = 7;
             this._scriptArgsLabel.Text = "Script ar&guments:";
             // 
             // _scriptArguments
             // 
             this._scriptArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptArguments.Location = new System.Drawing.Point(135, 71);
+            this._scriptArguments.Location = new System.Drawing.Point(180, 119);
+            this._scriptArguments.Margin = new System.Windows.Forms.Padding(4);
             this._scriptArguments.Name = "_scriptArguments";
-            this._scriptArguments.Size = new System.Drawing.Size(340, 20);
-            this._scriptArguments.TabIndex = 6;
+            this._scriptArguments.Size = new System.Drawing.Size(452, 22);
+            this._scriptArguments.TabIndex = 8;
             this._scriptArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _workingDirLabel
             // 
             this._workingDirLabel.AutoSize = true;
-            this._workingDirLabel.Location = new System.Drawing.Point(14, 100);
+            this._workingDirLabel.Location = new System.Drawing.Point(19, 155);
+            this._workingDirLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._workingDirLabel.Name = "_workingDirLabel";
-            this._workingDirLabel.Size = new System.Drawing.Size(93, 13);
-            this._workingDirLabel.TabIndex = 7;
+            this._workingDirLabel.Size = new System.Drawing.Size(123, 17);
+            this._workingDirLabel.TabIndex = 9;
             this._workingDirLabel.Text = "Working director&y:";
             // 
             // _workingDir
             // 
             this._workingDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._workingDir.Location = new System.Drawing.Point(135, 97);
+            this._workingDir.Location = new System.Drawing.Point(180, 151);
+            this._workingDir.Margin = new System.Windows.Forms.Padding(4);
             this._workingDir.Name = "_workingDir";
-            this._workingDir.Size = new System.Drawing.Size(308, 20);
-            this._workingDir.TabIndex = 8;
+            this._workingDir.Size = new System.Drawing.Size(409, 22);
+            this._workingDir.TabIndex = 10;
             this._workingDir.TextChanged += new System.EventHandler(this.WorkingDirTextChanged);
             // 
             // _launchUrl
             // 
             this._launchUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._launchUrl.Location = new System.Drawing.Point(135, 124);
+            this._launchUrl.Location = new System.Drawing.Point(180, 185);
+            this._launchUrl.Margin = new System.Windows.Forms.Padding(4);
             this._launchUrl.Name = "_launchUrl";
-            this._launchUrl.Size = new System.Drawing.Size(340, 20);
-            this._launchUrl.TabIndex = 11;
+            this._launchUrl.Size = new System.Drawing.Size(452, 22);
+            this._launchUrl.TabIndex = 13;
             this._launchUrl.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _launchUrlLabel
             // 
             this._launchUrlLabel.AutoSize = true;
-            this._launchUrlLabel.Location = new System.Drawing.Point(14, 127);
+            this._launchUrlLabel.Location = new System.Drawing.Point(19, 188);
+            this._launchUrlLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._launchUrlLabel.Name = "_launchUrlLabel";
-            this._launchUrlLabel.Size = new System.Drawing.Size(71, 13);
-            this._launchUrlLabel.TabIndex = 10;
+            this._launchUrlLabel.Size = new System.Drawing.Size(91, 17);
+            this._launchUrlLabel.TabIndex = 12;
             this._launchUrlLabel.Text = "Launch &URL:";
             // 
             // _envVars
             // 
             this._envVars.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._envVars.Location = new System.Drawing.Point(135, 202);
+            this._envVars.Location = new System.Drawing.Point(180, 281);
+            this._envVars.Margin = new System.Windows.Forms.Padding(4);
             this._envVars.Multiline = true;
             this._envVars.Name = "_envVars";
             this._envVars.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this._envVars.Size = new System.Drawing.Size(340, 50);
-            this._envVars.TabIndex = 17;
+            this._envVars.Size = new System.Drawing.Size(452, 61);
+            this._envVars.TabIndex = 19;
             this._envVars.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _browsePath
             // 
             this._browsePath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browsePath.Location = new System.Drawing.Point(449, 17);
+            this._browsePath.Location = new System.Drawing.Point(599, 21);
+            this._browsePath.Margin = new System.Windows.Forms.Padding(4);
             this._browsePath.Name = "_browsePath";
-            this._browsePath.Size = new System.Drawing.Size(26, 23);
+            this._browsePath.Size = new System.Drawing.Size(35, 28);
             this._browsePath.TabIndex = 2;
             this._browsePath.Text = "...";
             this._browsePath.UseVisualStyleBackColor = true;
@@ -199,10 +216,11 @@
             // _browseDirectory
             // 
             this._browseDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browseDirectory.Location = new System.Drawing.Point(449, 95);
+            this._browseDirectory.Location = new System.Drawing.Point(599, 149);
+            this._browseDirectory.Margin = new System.Windows.Forms.Padding(4);
             this._browseDirectory.Name = "_browseDirectory";
-            this._browseDirectory.Size = new System.Drawing.Size(26, 23);
-            this._browseDirectory.TabIndex = 9;
+            this._browseDirectory.Size = new System.Drawing.Size(35, 28);
+            this._browseDirectory.TabIndex = 11;
             this._browseDirectory.Text = "...";
             this._browseDirectory.UseVisualStyleBackColor = true;
             this._browseDirectory.Click += new System.EventHandler(this.BrowseDirectoryClick);
@@ -214,33 +232,59 @@
             // _debuggerPortLabel
             // 
             this._debuggerPortLabel.AutoSize = true;
-            this._debuggerPortLabel.Location = new System.Drawing.Point(14, 179);
+            this._debuggerPortLabel.Location = new System.Drawing.Point(19, 252);
+            this._debuggerPortLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._debuggerPortLabel.Name = "_debuggerPortLabel";
-            this._debuggerPortLabel.Size = new System.Drawing.Size(78, 13);
-            this._debuggerPortLabel.TabIndex = 14;
+            this._debuggerPortLabel.Size = new System.Drawing.Size(104, 17);
+            this._debuggerPortLabel.TabIndex = 16;
             this._debuggerPortLabel.Text = "&Debugger port:";
             // 
             // _debuggerPort
             // 
-            this._debuggerPort.Location = new System.Drawing.Point(135, 176);
+            this._debuggerPort.Location = new System.Drawing.Point(180, 249);
+            this._debuggerPort.Margin = new System.Windows.Forms.Padding(4);
             this._debuggerPort.Name = "_debuggerPort";
-            this._debuggerPort.Size = new System.Drawing.Size(105, 20);
-            this._debuggerPort.TabIndex = 15;
+            this._debuggerPort.Size = new System.Drawing.Size(139, 22);
+            this._debuggerPort.TabIndex = 17;
             this._debuggerPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _envVarsLabel
             // 
             this._envVarsLabel.AutoSize = true;
-            this._envVarsLabel.Location = new System.Drawing.Point(14, 205);
+            this._envVarsLabel.Location = new System.Drawing.Point(19, 284);
+            this._envVarsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._envVarsLabel.Name = "_envVarsLabel";
-            this._envVarsLabel.Size = new System.Drawing.Size(115, 13);
-            this._envVarsLabel.TabIndex = 16;
+            this._envVarsLabel.Size = new System.Drawing.Size(154, 17);
+            this._envVarsLabel.TabIndex = 18;
             this._envVarsLabel.Text = "Environment &Variables:";
+            // 
+            // _scriptLabel
+            // 
+            this._scriptLabel.AutoSize = true;
+            this._scriptLabel.Location = new System.Drawing.Point(19, 91);
+            this._scriptLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._scriptLabel.Name = "_scriptLabel";
+            this._scriptLabel.Size = new System.Drawing.Size(128, 17);
+            this._scriptLabel.TabIndex = 5;
+            this._scriptLabel.Text = "Script (startup file):";
+            // 
+            // _scriptFile
+            // 
+            this._scriptFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._scriptFile.Location = new System.Drawing.Point(180, 87);
+            this._scriptFile.Margin = new System.Windows.Forms.Padding(4);
+            this._scriptFile.Name = "_scriptFile";
+            this._scriptFile.Size = new System.Drawing.Size(452, 22);
+            this._scriptFile.TabIndex = 6;
+            this._scriptFile.TextChanged += new System.EventHandler(this.Changed);
             // 
             // NodejsGeneralPropertyPageControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this._scriptLabel);
+            this.Controls.Add(this._scriptFile);
             this.Controls.Add(this._envVarsLabel);
             this.Controls.Add(this._envVars);
             this.Controls.Add(this._debuggerPort);
@@ -260,9 +304,10 @@
             this.Controls.Add(this._scriptArguments);
             this.Controls.Add(this._nodeExeArguments);
             this.Controls.Add(this._nodeExePath);
-            this.MinimumSize = new System.Drawing.Size(303, 303);
+            this.Margin = new System.Windows.Forms.Padding(4);
+            this.MinimumSize = new System.Drawing.Size(404, 373);
             this.Name = "NodejsGeneralPropertyPageControl";
-            this.Size = new System.Drawing.Size(488, 305);
+            this.Size = new System.Drawing.Size(651, 392);
             ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -292,5 +337,7 @@
         private System.Windows.Forms.TextBox _envVars;
         private System.Windows.Forms.TextBox _debuggerPort;
         private System.Windows.Forms.Label _debuggerPortLabel;
+        private System.Windows.Forms.Label _scriptLabel;
+        private System.Windows.Forms.TextBox _scriptFile;
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -45,6 +45,7 @@ namespace Microsoft.NodejsTools.Project {
         private void AddToolTips() {
             _tooltip.SetToolTip(_nodeExePath, SR.GetString(SR.NodeExePathToolTip));
             _tooltip.SetToolTip(_nodeExeArguments, SR.GetString(SR.NodeExeArgumentsToolTip));
+            _tooltip.SetToolTip(_scriptFile, SR.GetString(SR.ScriptFileToolTip));
             _tooltip.SetToolTip(_scriptArguments, SR.GetString(SR.ScriptArgumentsToolTip));
             _tooltip.SetToolTip(_nodejsPort, SR.GetString(SR.NodejsPortToolTip));
             _tooltip.SetToolTip(_startBrowser, SR.GetString(SR.StartBrowserToolTip));
@@ -69,6 +70,15 @@ namespace Microsoft.NodejsTools.Project {
             }
             set {
                 _nodeExeArguments.Text = value;
+            }
+        }
+
+        public string ScriptFile  {
+            get {
+                return this._scriptFile.Text;
+            }
+            set {
+                this._scriptFile.Text = value;
             }
         }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -302,7 +302,9 @@ namespace Microsoft.NodejsTools.Project {
         public override bool IsCodeFile(string fileName) {
             var ext = Path.GetExtension(fileName);
             return ext.Equals(NodejsConstants.JavaScriptExtension, StringComparison.OrdinalIgnoreCase) ||
-                   ext.Equals(NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase);
+                   ext.Equals(NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase) ||
+                   // for some reason, the default express 4 template's startup file lacks an extension.
+                   string.IsNullOrEmpty(ext);
         }
 
         public override int InitializeForOuter(string filename, string location, string name, uint flags, ref Guid iid, out IntPtr projectPointer, out int canceled) {
@@ -434,6 +436,9 @@ namespace Microsoft.NodejsTools.Project {
                         break;
                     case NodejsConstants.NodeExeArguments:
                         propPage.NodeExeArguments = newValue;
+                        break;
+                    case CommonConstants.StartupFile:
+                        propPage.ScriptFile = newValue;
                         break;
                     case NodejsConstants.ScriptArguments:
                         propPage.ScriptArguments = newValue;

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -164,6 +164,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string ReplInitializationMessage = "ReplInitializationMessage";
         internal const string RequestedVersionRangeNone = "RequestedVersionRangeNone";
         internal const string ScriptArgumentsToolTip = "ScriptArgumentsToolTip";
+        internal const string ScriptFileToolTip = "ScriptFileTooltip";
         internal const string Seconds = "Seconds";
         internal const string StartBrowserToolTip = "StartBrowserToolTip";
         internal const string StatusAnalysisLoaded = "StatusAnalysisLoaded";

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -327,6 +327,9 @@
   <data name="ScriptArgumentsToolTip" xml:space="preserve">
     <value>Specifies the arguments passed to the script on launch.</value>
   </data>
+  <data name="ScriptFileTooltip" xml:space="preserve">
+    <value>Specifies the script run on launch.</value>
+  </data>
   <data name="StartBrowserToolTip" xml:space="preserve">
     <value>When checked a web browser is opened on launch</value>
   </data>


### PR DESCRIPTION
Fix #66 startup file setting breaks debugger
- rename "Node.exe arguments" -> "Node.exe options" to be consistent with
  node --help
- rearrange arguments so that they are in the order they are supposed to
  be appended to one another
- create a new "script (startup file)" property so that it is visible
  what arguments are getting passed to node from the General properties
  page, and doesn't block right clicking the file and setting as startup
  file or modifying it from file properties.

Fix #65 Enable "Set as Node.js Startup File" context menu item for all
filetypes
- add a special case for when there is no exension specified, as is the
  case in the default express 4 template.