### PR TITLE
Fix #124 - include error details in mocha unit test results

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -61,10 +61,12 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder) {
         mocha.grep(testName);
     }
     mocha.addFile(testFile);
-    // Choose 'tap' rather 'min'. The reason is when under piped/redirect,
-    // mocha produces undisplayable text to stdout and stderr. Using xunit works fine 
-    // And 'xunit' does not print the stack trace from the test.
+
+    // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
+    // 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
+    // and 'xunit' does not print the stack trace from the test.
     mocha.reporter('tap');
+
     mocha.run(function (code) {
         process.exit(code);
     });

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -61,9 +61,10 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder) {
         mocha.grep(testName);
     }
     mocha.addFile(testFile);
-    //Choose 'xunit' rather 'min'. The reason is when under piped/redirect,
-    //mocha produces undisplayable text to stdout and stderr. Using xunit works fine 
-    mocha.reporter('xunit');
+    // Choose 'tap' rather 'min'. The reason is when under piped/redirect,
+    // mocha produces undisplayable text to stdout and stderr. Using xunit works fine 
+    // And 'xunit' does not print the stack trace from the test.
+    mocha.reporter('tap');
     mocha.run(function (code) {
         process.exit(code);
     });


### PR DESCRIPTION
Fix #124 - include error details in mocha unit test results
- use the 'tap' error reporter instead of xunit because 'xunit' does not
  print the trace.