### PR TITLE
Fix #162 Copying files in sln explorer does not work after latest updates when PTVS is installed

### DIFF
--- a/Common/Product/SharedProject/ClipboardService.cs
+++ b/Common/Product/SharedProject/ClipboardService.cs
@@ -19,32 +19,32 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.VisualStudioTools {
 
-    class ClipboardService : IClipboardService {
-        public void SetClipboard(IDataObject dataObject) {
+    class ClipboardService : ClipboardServiceBase {
+        public override void SetClipboard(IDataObject dataObject) {
             ErrorHandler.ThrowOnFailure(UnsafeNativeMethods.OleSetClipboard(dataObject));
         }
 
-        public IDataObject GetClipboard() {
+        public override IDataObject GetClipboard() {
             IDataObject res;
             ErrorHandler.ThrowOnFailure(UnsafeNativeMethods.OleGetClipboard(out res));
             return res;
         }
 
-        public void FlushClipboard() {
+        public override void FlushClipboard() {
             ErrorHandler.ThrowOnFailure(UnsafeNativeMethods.OleFlushClipboard());
         }
 
-        public bool OpenClipboard() {
+        public override bool OpenClipboard() {
             int res = UnsafeNativeMethods.OpenClipboard(IntPtr.Zero);
             ErrorHandler.ThrowOnFailure(res);
             return res == 1;
         }
 
-        public void EmptyClipboard() {
+        public override void EmptyClipboard() {
             ErrorHandler.ThrowOnFailure(UnsafeNativeMethods.EmptyClipboard());
         }
 
-        public void CloseClipboard() {
+        public override void CloseClipboard() {
             ErrorHandler.ThrowOnFailure(UnsafeNativeMethods.CloseClipboard());
         }
     }

--- a/Common/Product/SharedProject/ClipboardServiceBase.cs
+++ b/Common/Product/SharedProject/ClipboardServiceBase.cs
@@ -16,17 +16,17 @@ using System;
 using Microsoft.VisualStudio.OLE.Interop;
 
 namespace Microsoft.VisualStudioTools {
-    interface IClipboardService {
-        void SetClipboard(IDataObject dataObject);
+    public abstract class ClipboardServiceBase {
+        public abstract void SetClipboard(IDataObject dataObject);
 
-        IDataObject GetClipboard();
+        public abstract IDataObject GetClipboard();
 
-        void FlushClipboard();
+        public abstract void FlushClipboard();
 
-        bool OpenClipboard();
+        public abstract bool OpenClipboard();
 
-        void EmptyClipboard();
+        public abstract void EmptyClipboard();
 
-        void CloseClipboard();
+        public abstract void CloseClipboard();
     }
 }

--- a/Common/Product/SharedProject/SharedProject.proj
+++ b/Common/Product/SharedProject/SharedProject.proj
@@ -334,8 +334,8 @@
       <Link>SharedProject\IdleManager.cs</Link>
       <Visible>true</Visible>
     </Compile>
-    <Compile Include="$(_ProjectSystemFilesLocation)\IClipboardService.cs">
-      <Link>SharedProject\IClipboardService.cs</Link>
+    <Compile Include="$(_ProjectSystemFilesLocation)\ClipboardServiceBase.cs">
+      <Link>SharedProject\ClipboardServiceBase.cs</Link>
       <Visible>true</Visible>
     </Compile>
     <Compile Include="$(_ProjectSystemFilesLocation)\ClipboardService.cs">

--- a/Common/Product/SharedProject/VsExtensions.cs
+++ b/Common/Product/SharedProject/VsExtensions.cs
@@ -92,8 +92,8 @@ namespace Microsoft.VisualStudioTools {
             }
         }
 
-        internal static IClipboardService GetClipboardService(this IServiceProvider serviceProvider) {
-            return (IClipboardService)serviceProvider.GetService(typeof(IClipboardService));
+        internal static ClipboardServiceBase GetClipboardService(this IServiceProvider serviceProvider) {
+            return (ClipboardServiceBase)serviceProvider.GetService(typeof(ClipboardServiceBase));
         }
 
         internal static UIThreadBase GetUIThread(this IServiceProvider serviceProvider) {

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -183,7 +183,7 @@ namespace Microsoft.NodejsTools {
             var langService = new NodejsLanguageInfo(this);
             ((IServiceContainer)this).AddService(langService.GetType(), langService, true);
 
-            ((IServiceContainer)this).AddService(typeof(IClipboardService), new ClipboardService(), true);
+            ((IServiceContainer)this).AddService(typeof(ClipboardServiceBase), new ClipboardService(), true);
 
             RegisterProjectFactory(new NodejsProjectFactory(this));
             RegisterEditorFactory(new NodejsEditorFactory(this));


### PR DESCRIPTION
Fix #162 
IClipboardService should be an abstract class rather than an interface because the CLR doesn't take into account assembly names when generating and interfaces GUID.