### PR TITLE
Fix #165 - Add "open documentation" command to npm context menu

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsTools.vsct
+++ b/Nodejs/Product/Nodejs/NodejsTools.vsct
@@ -39,12 +39,16 @@
       <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJWIN_SCOPE" priority="0x0500">
         <Parent guid="guidNodeToolsNpmCmdSet" id="NpmMenu"/>
       </Group>
-
+      
       <Group guid="guidNodeToolsNpmCmdSet" id="NpmGroup" priority="0x0600">
         <Parent guid="guidNodeToolsNpmCmdSet" id="NpmMenu"/>
       </Group>
-
-      <Group guid="guidSHLMainMenu" id="IDG_VS_MNUDES_PROPERTIES" priority="0x0700">
+      
+      <Group guid="guidNodeToolsNpmCmdSet" id="NpmExploreGroup" priority="0x0700">
+        <Parent guid="guidNodeToolsNpmCmdSet" id="NpmMenu"/>
+      </Group>
+      
+      <Group guid="guidSHLMainMenu" id="IDG_VS_MNUDES_PROPERTIES" priority="0x0800">
         <Parent guid="guidNodeToolsNpmCmdSet" id="NpmMenu"/>
       </Group>
     </Groups>
@@ -230,6 +234,16 @@
         </Strings>
       </Button>
 
+      <Button guid="guidNodeToolsNpmCmdSet" id="cmdidNpmOpenModuleHomepage" priority="0x8370" type="Button">
+        <Parent guid="guidNodeToolsNpmCmdSet" id="NpmExploreGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <CommandName>cmdidNpmOpenModuleHomepage</CommandName>
+          <ButtonText>Open &amp;Documentation</ButtonText>
+        </Strings>
+      </Button>
+
       <Button guid="guidNodeToolsCmdSet" id="cmdidImportWizard" priority="0x010" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="ToolsMenuItemsGroup"/>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -289,7 +303,7 @@
       <Parent guid="guidNodeToolsCmdSet" id="CodeFileGroup"/>
     </CommandPlacement>
     <CommandPlacement guid="guidVSStd2K" id="cmdidExploreFolderInWindows" priority="0x0700">
-      <Parent guid="guidNodeToolsNpmCmdSet" id="NpmGroup"/>
+      <Parent guid="guidNodeToolsNpmCmdSet" id="NpmExploreGroup"/>
     </CommandPlacement>
     <CommandPlacement guid="guidNodeToolsCmdSet" id="cmdidOpenCommandPromptHere" priority="0x600">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EXPLORE"/>
@@ -346,8 +360,11 @@
       <IDSymbol name="cmdidNpmUninstallModule" value="0x0303" />
       <IDSymbol name="cmdidNpmInstallSingleMissingModule" value="0x0304" />
       <IDSymbol name="cmdidNpmUpdateSingleModule" value="0x0305" />
-      
+      <IDSymbol name="cmdidNpmOpenModuleHomepage" value="0x0306" />
+
       <IDSymbol name="NpmGroup" value="0x2010"/>
+      <IDSymbol name="NpmExploreGroup" value="0x2011"/>
+
 
       <IDSymbol name="NpmMenu" value="0x3000"/>
     </GuidSymbol>

--- a/Nodejs/Product/Nodejs/PkgCmdId.cs
+++ b/Nodejs/Product/Nodejs/PkgCmdId.cs
@@ -41,6 +41,7 @@ namespace Microsoft.NodejsTools {
         public const int cmdidNpmUninstallModule            = 0x303;
         public const int cmdidNpmInstallSingleMissingModule = 0x304;
         public const int cmdidNpmUpdateSingleModule         = 0x305;
+        public const int cmdidNpmOpenModuleHomepage         = 0x306;
         public const int menuIdNpm                          = 0x3000;
     }
 }

--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -161,37 +161,51 @@ namespace Microsoft.NodejsTools.Project {
             //  Latter condition is because it's only valid to carry out npm operations
             //  on top level dependencies of the user's project, not sub-dependencies.
             //  Performing operations on sub-dependencies would just break things.
-            if (cmdGroup == Guids.NodejsNpmCmdSet && null == _parent) {
+            if (cmdGroup == Guids.NodejsNpmCmdSet) {
                 switch (cmd) {
-                    case PkgCmdId.cmdidNpmInstallSingleMissingModule:
-                        if (GetPropertiesObject().IsGlobalInstall) {
-                            result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
-                        } else if (null == _projectNode.ModulesNode
-                            || _projectNode.ModulesNode.IsCurrentStateASuppressCommandsMode()) {
-                            result = QueryStatusResult.SUPPORTED;
-                        } else {
-                            if (null != Package && Package.IsMissing) {
+                    case PkgCmdId.cmdidNpmOpenModuleHomepage:
+                        using (var enumerator = this.Package.Homepages.GetEnumerator()) {
+                            if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
                                 result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
                             } else {
                                 result = QueryStatusResult.SUPPORTED;
                             }
                         }
                         return VSConstants.S_OK;
+                }
 
-                    case PkgCmdId.cmdidNpmUpdateSingleModule:
-                    case PkgCmdId.cmdidNpmUninstallModule:
-                        if (null != _projectNode.ModulesNode &&
-                            !_projectNode.ModulesNode.IsCurrentStateASuppressCommandsMode()) {
-                            result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
-                        } else {
-                            result = QueryStatusResult.SUPPORTED;
-                        }
-                        return VSConstants.S_OK;
+                if (null == _parent) {
+                    switch (cmd) {
+                        case PkgCmdId.cmdidNpmInstallSingleMissingModule:
+                            if (GetPropertiesObject().IsGlobalInstall) {
+                                result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
+                            } else if (null == _projectNode.ModulesNode
+                                || _projectNode.ModulesNode.IsCurrentStateASuppressCommandsMode()) {
+                                result = QueryStatusResult.SUPPORTED;
+                            } else {
+                                if (null != Package && Package.IsMissing) {
+                                    result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
+                                } else {
+                                    result = QueryStatusResult.SUPPORTED;
+                                }
+                            }
+                            return VSConstants.S_OK;
 
-                    case PkgCmdId.cmdidNpmInstallModules:
-                    case PkgCmdId.cmdidNpmUpdateModules:
-                        result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
-                        return VSConstants.S_OK;
+                        case PkgCmdId.cmdidNpmUpdateSingleModule:
+                        case PkgCmdId.cmdidNpmUninstallModule:
+                            if (null != _projectNode.ModulesNode &&
+                                !_projectNode.ModulesNode.IsCurrentStateASuppressCommandsMode()) {
+                                result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
+                            } else {
+                                result = QueryStatusResult.SUPPORTED;
+                            }
+                            return VSConstants.S_OK;
+
+                        case PkgCmdId.cmdidNpmInstallModules:
+                        case PkgCmdId.cmdidNpmUpdateModules:
+                            result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
+                            return VSConstants.S_OK;
+                    }
                 }
             } else if (cmdGroup == Microsoft.VisualStudioTools.Project.VsMenus.guidStandardCommandSet2K) {
                 switch ((VsCommands2K)cmd) {
@@ -205,28 +219,39 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         internal override int ExecCommandOnNode(Guid cmdGroup, uint cmd, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
-            if (cmdGroup == Guids.NodejsNpmCmdSet && null == _parent) {
+            if (cmdGroup == Guids.NodejsNpmCmdSet) {
                 switch (cmd) {
-                    case PkgCmdId.cmdidNpmInstallSingleMissingModule:
-                        if (null != _projectNode.ModulesNode) {
-                            var t = _projectNode.ModulesNode.InstallMissingModule(this);
-                        }
-                        return VSConstants.S_OK;
-
-                    case PkgCmdId.cmdidNpmUninstallModule:
-                        if (null != _projectNode.ModulesNode) {
-                            var t = _projectNode.ModulesNode.UninstallModule(this);
-                        }
-                        return VSConstants.S_OK;
-
-                    case PkgCmdId.cmdidNpmUpdateSingleModule:
-                        if (null != _projectNode.ModulesNode) {
-                            var t = _projectNode.ModulesNode.UpdateModule(this);
+                    case PkgCmdId.cmdidNpmOpenModuleHomepage:
+                        using (var enumerator = this.Package.Homepages.GetEnumerator()) {
+                            if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
+                                Process.Start(enumerator.Current);
+                            }
                         }
                         return VSConstants.S_OK;
                 }
+                if (null == _parent) {
+                    switch (cmd) {
+                        case PkgCmdId.cmdidNpmInstallSingleMissingModule:
+                            if (null != _projectNode.ModulesNode) {
+                                var t = _projectNode.ModulesNode.InstallMissingModule(this);
+                            }
+                            return VSConstants.S_OK;
+
+                        case PkgCmdId.cmdidNpmUninstallModule:
+                            if (null != _projectNode.ModulesNode) {
+                                var t = _projectNode.ModulesNode.UninstallModule(this);
+                            }
+                            return VSConstants.S_OK;
+
+                        case PkgCmdId.cmdidNpmUpdateSingleModule:
+                            if (null != _projectNode.ModulesNode) {
+                                var t = _projectNode.ModulesNode.UpdateModule(this);
+                            }
+                            return VSConstants.S_OK;
+                    }
+                }
             } else if (cmdGroup == Microsoft.VisualStudioTools.Project.VsMenus.guidStandardCommandSet2K) {
-                switch((VsCommands2K)cmd) {
+                switch ((VsCommands2K)cmd) {
                     case CommonConstants.OpenFolderInExplorerCmdId:
                         string path = this.Package.Path;
                         try {

--- a/Nodejs/Product/Nodejs/Project/GlobalModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/GlobalModulesNode.cs
@@ -73,6 +73,7 @@ namespace Microsoft.NodejsTools.Project {
                     case PkgCmdId.cmdidNpmInstallSingleMissingModule:
                     case PkgCmdId.cmdidNpmUninstallModule:
                     case PkgCmdId.cmdidNpmUpdateSingleModule:
+                    case PkgCmdId.cmdidNpmOpenModuleHomepage:
                         result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
                         return VSConstants.S_OK;
                 }

--- a/Nodejs/Product/Nodejs/Project/LocalModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/LocalModulesNode.cs
@@ -94,6 +94,7 @@ namespace Microsoft.NodejsTools.Project {
                     case PkgCmdId.cmdidNpmInstallSingleMissingModule:
                     case PkgCmdId.cmdidNpmUninstallModule:
                     case PkgCmdId.cmdidNpmUpdateSingleModule:
+                    case PkgCmdId.cmdidNpmOpenModuleHomepage:
                         result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
                         return VSConstants.S_OK;
                 }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -464,6 +464,7 @@ namespace Microsoft.NodejsTools.Project {
                     case PkgCmdId.cmdidNpmInstallSingleMissingModule:
                     case PkgCmdId.cmdidNpmUninstallModule:
                     case PkgCmdId.cmdidNpmUpdateSingleModule:
+                    case PkgCmdId.cmdidNpmOpenModuleHomepage:
                         result = QueryStatusResult.SUPPORTED | QueryStatusResult.INVISIBLE;
                         return VSConstants.S_OK;
                 }


### PR DESCRIPTION
#165 - Add "open documentation" command to npm context menu
- Adds a new context menu command that opens the selected module's
  homepage from solution explorer.
- Creates a new menu group to hold commands related to exploring npm
  modules. This is because the previous npm group was getting too
  cluttered with the addition of this new command, and this separation
  logically makes sense too (executing npm commands related to managing
  dependencies vs. working with your currently installed dependencies)

Screenshot below shows what it looks like in the product. 
![image](https://cloud.githubusercontent.com/assets/762848/7955657/ef82b5c2-098e-11e5-95e3-49adfeb78191.png)
