### PR TITLE
Fix #216 and add additional mocha configuration options

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -120,7 +120,7 @@ function getMochaOptions(projectFolder) {
             mochaOptions[opt] = options[opt];
         }
     } catch (ex) {
-        console.log("NTVS: mocha.json options file not found. Using default values.");
+        logError("mocha.json options file not found. Using default values.");
     }
 
     return mochaOptions;

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -42,7 +42,7 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
             getTestList(mocha.suite, testFile);
         } catch (e) {
             //we would like continue discover other files, so swallow, log and continue;
-            logError('NTVS_ERROR: An error occurred during mocha test discovery in file: ' + testFile, e);
+            logError('An error occurred during mocha test discovery in file: ' + testFile, e);
         }
     });
 
@@ -70,12 +70,10 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder) {
     });
 };
 
-function logError(errorMessage, error) {
-    if (typeof error === 'undefined') {
-        console.error("NTVS_ERROR: " + errorMessage);
-    } else {
-        console.error("NTVS_ERROR: " + errorMessage, error);
-    }
+function logError() {
+    var errorArgs = Array.prototype.slice.call(arguments);
+    errorArgs.unshift("NTVS_ERROR:");
+    console.error.apply(console, errorArgs);
 }
 
 function detectMocha(projectFolder) {
@@ -105,7 +103,7 @@ function applyMochaOptions(mocha, options) {
                 try {
                     mochaOpt.call(mocha, optValue);
                 } catch (e) {
-                    logError("Could not set mocha option '" + opt + "' with value '" + optValue + "' due to error: ", e);
+                    logError("Could not set mocha option '" + opt + "' with value '" + optValue + "' due to error:", e);
                 }
             }
         }

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -99,7 +99,7 @@ function applyMochaOptions(mocha, options) {
                 try {
                     mochaOpt.call(mocha, optValue);
                 } catch (e) {
-                    error("Could not set mocha option '" + opt + "' with value '" + optValue + "' due to error: " + e);
+                    logError("Could not set mocha option '" + opt + "' with value '" + optValue + "' due to error: " + e);
                 }
             }
         }


### PR DESCRIPTION
#216

This change adds the ability to configure mocha by adding a config file to the project located at $(ProjectDirectory)\test\mocha.json.  The relative path under the test directory was chosen because this is where mocha looks for a configuration by default when run from the command line (looks for mocha.opts).  Adding the mocha.json file will result in the mocha tests running with the options specified.  

An example of a valid mocha.json file is: 

{
	"ui": "tdd",
	"timeout": 300000,
	"reporter": "xunit"
}

Also, note that if the config file does not specify a ui, timeout or reporter the default will be chosen automatically.