### PR TITLE
Fix exception in classifier

### DIFF
--- a/Nodejs/Product/Nodejs/Classifier/NodejsClassifier.cs
+++ b/Nodejs/Product/Nodejs/Classifier/NodejsClassifier.cs
@@ -331,7 +331,7 @@ namespace Microsoft.NodejsTools.Classifier {
                 int currentLineTemp = _tokenCache.IndexOfPreviousTokenization(firstLine, 0, out lineTokenizationTemp) + 1;
                 object stateTemp = lineTokenizationTemp.State;
 
-                while (currentLineTemp <= snapshot.LineCount) {
+                while (currentLineTemp < snapshot.LineCount) {
                     if (!_tokenCache.TryGetTokenization(currentLineTemp, out lineTokenizationTemp)) {
                         lineTokenizationTemp = TokenizeLine(JSScanner, snapshot, stateTemp, currentLineTemp);
                         _tokenCache[currentLineTemp] = lineTokenizationTemp;


### PR DESCRIPTION
This appears to be the root cause of issue #130.  The use of `<=` allows
for `currentLineTemp` to be equal to the number of lines in the
snapshot.  When that occurs and the value is passed to `TokenizeLine` it
will result in an exception because it will be passed to
`GetLineFromLineNumber` which throws when the line requested is `>=` to
the line count.

closes #130