### PR TITLE
 Make the various Guids used in the debug engine unique from PTVS  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ TestResults
 *.suo
 *.user
 *.sln.docstates
+.vs
 
 # Build results
 [Dd]ebug/

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
     // process only contains one program, it is implemented on the engine.
 
     [ComVisible(true)]
-    [Guid("135F3602-FE1D-4D8A-8D7C-C8CF803B1DFC")]
+    [Guid(Guids.DebugEngine)]
     public sealed class AD7Engine : IDebugEngine2, IDebugEngineLaunch2, IDebugProgram3, IDebugSymbolSettings100 {
         // used to send events to the debugger. Some examples of these events are thread create, exception thrown, module load.
         private IDebugEventCallback2 _events;

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7ProgramProvider.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7ProgramProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
     // This registered interface allows the session debug manager (SDM) to obtain information about programs 
     // that have been "published" through the IDebugProgramPublisher2 interface.
     [ComVisible(true)]
-    [Guid("FF3E23A2-DA7E-4fa7-AF47-6EDEDE4E922E")]
+    [Guid(Guids.DebugProgramProvider)]
     public class AD7ProgramProvider : IDebugProgramProvider2 {
         public AD7ProgramProvider() {
         }

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteDebugPortSupplier.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteDebugPortSupplier.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace Microsoft.NodejsTools.Debugger.Remote {
     [ComVisible(true)]
-    [Guid("A241707C-7DB3-464F-8D3E-F3D33E86AE99")]
+    [Guid(Guids.RemoteDebugPortSupplier)]
     public class NodeRemoteDebugPortSupplier : IDebugPortSupplier2, IDebugPortSupplierDescription2 {
         public const string PortSupplierId = "{9E16F805-5EFC-4CE5-8B67-9AE9B643EF80}";
         public static readonly Guid PortSupplierGuid = new Guid(PortSupplierId);

--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -46,6 +46,11 @@ namespace Microsoft.NodejsTools
         public const string NodejsProfilingCmdSetString = "3F2BC93C-CA2D-450B-9BFC-0C96288F1ED6";
         public const string ProfilingEditorFactoryString = "3585dc22-81a0-409e-85ae-cae5d02d99cd";
 
+        // Debug guids
+        public const string DebugEngine = "FC5B45BA-5B9C-46EA-887A-82073AE065FE";
+        public const string DebugProgramProvider = "472CD331-218C-451E-929E-98C9408F11DD";
+        public const string RemoteDebugPortSupplier = "A241707C-7DB3-464F-8D3E-F3D33E86AE99";
+
         public static readonly Guid NodejsBaseProjectFactory = new Guid(NodejsBaseProjectFactoryString);
         public static readonly Guid NodejsCmdSet = new Guid(NodejsCmdSetString);
         public static readonly Guid NodejsEditorFactory = new Guid(NodejsEditorFactoryString);


### PR DESCRIPTION
Adds the debug guids to the central guid file, and ensures they're unique from the PTVS guids. 

Fixes #147 