### PR TITLE
Fix installer build issues

### DIFF
--- a/Build/Common.Build.CSharp.targets
+++ b/Build/Common.Build.CSharp.targets
@@ -71,7 +71,7 @@
        To avoid spawning a new msbuild.exe process again and again unnecessarily, do a quick up-to-date check (effectively
        duplicating the one done by .csproj) on the target. -->
   <Target Name="BuildBuildTasks" Inputs="@(BuildTasksSourceFiles)" Outputs="$(BuildTasksAssembly)">
-    <Exec Command='"$(MSBuildBinPath)\msbuild.exe" "$(BuildRoot)\Common\Tools\BuildTasks\BuildTasks.csproj"'/>
+    <Exec Command='"$(MSBuildBinPath)\msbuild.exe" "$(BuildRoot)\Common\Tools\BuildTasks\BuildTasks.csproj" /p:Configuration=$(Configuration) /p:VSTarget=$(VSTarget)'/>
   </Target>
 
   <UsingTask AssemblyFile="$(BuildTasksAssembly)" TaskName="Microsoft.VisualStudioTools.BuildTasks.ExtractLambdasFromXaml"/>

--- a/Nodejs/dirs.proj
+++ b/Nodejs/dirs.proj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectFile Include="$(BuildRoot)\Common\dirs.proj"/>
     <ProjectFile Include="Product\dirs.proj"/>
     <ProjectFile Include="Tests\dirs.proj" Condition="$(IncludeTests)" />
     <ProjectFile Include="Setup\dirs.proj" Condition="$(IncludeSetup)" />


### PR DESCRIPTION
- removes reference to Common/dirs.proj
- Fixes building with new BuildTasks project
- Fixes BuildTasks failing to build for correct VS version