### PR TITLE
Fix #96 when throwing strings

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -7,7 +7,7 @@ var find_tests = function (testFileList, discoverResultFile) {
         try {
             testCases = require(testFile);
         } catch (ex) {
-            console.error("NTVS_ERROR:" + ex.stack);
+            console.error("NTVS_ERROR:", ex, "in", testFile);
             return;
         }
         for (var test in testCases) {

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -37,7 +37,7 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
             getTestList(mocha.suite, testFile);
         } catch (e) {
             //we would like continue discover other files, so swallow, log and continue;
-            console.error('catch discover error:' + e.stack);
+            console.error('NTVS_ERROR:', e, "in", testFile);
         }
     });
 


### PR DESCRIPTION
Rather than printing the stack, which is not available, print the testFile path