### PR TITLE
Fix #8 - test explorer doesn't run mocha tests with fs.readFileSync and

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -1,9 +1,11 @@
 var fs = require('fs');
+var path = require('path');
 
 var find_tests = function (testFileList, discoverResultFile) {
     var testList = [];
     testFileList.split(';').forEach(function (testFile) {
         var testCases;
+        process.chdir(path.dirname(testFile));
         try {
             testCases = require(testFile);
         } catch (ex) {

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -1,4 +1,5 @@
 ﻿var fs = require('fs');
+var path = require('path');
 
 var find_tests = function (testFileList, discoverResultFile, projectFolder) {
     var Mocha = detectMocha(projectFolder);
@@ -30,6 +31,7 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
     var testList = [];
     testFileList.split(';').forEach(function (testFile) {
         var mocha = new Mocha();
+        process.chdir(path.dirname(testFile));
         try {
             mocha.ui('tdd');
             mocha.addFile(testFile);


### PR DESCRIPTION
possibly more
- the issue was that test discovery is running node from a different
  filepath than expected. This change sets the path from which the process
  is run to the path to the file itself in ExportRunner and Mocha. This
  location is consistent with the paths from which the process is run in the
  individual unit tests.