### PR TITLE
Fix #218 VS2015 redirect output to Bower/npm output window instead of …

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -190,9 +190,18 @@ namespace Microsoft.NodejsTools.Project {
 
         private static readonly Guid NpmOutputPaneGuid = new Guid("25764421-33B8-4163-BD02-A94E299D52D8");
 
+#if DEV14_OR_LATER
+        // This is the package manager pane that ships with VS2015, and we should print there if available.
+        private static readonly Guid VSPackageManagerPaneGuid = new Guid("C7E31C31-1451-4E05-B6BE-D11B6829E8BB");
+#endif
+
         private OutputWindowRedirector GetNpmOutputPane() {
             try {
+#if DEV14_OR_LATER
+                return OutputWindowRedirector.Get(_projectNode.Site, VSPackageManagerPaneGuid, "Bower/npm");
+#else
                 return OutputWindowRedirector.Get(_projectNode.Site, NpmOutputPaneGuid, SR.GetString(SR.NpmOutputPaneTitle));
+#endif
             } catch (InvalidOperationException) {
                 return null;
             }
@@ -356,9 +365,9 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        #endregion
+#endregion
 
-        #region Updating module hierarchy
+#region Updating module hierarchy
 
         internal void ReloadHierarchySafe() {
             NodejsPackage.Instance.GetUIThread().InvokeAsync(ReloadHierarchy)
@@ -402,9 +411,9 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        #endregion
+#endregion
 
-        #region HierarchyNode implementation
+#region HierarchyNode implementation
 
         public override int SortPriority {
             get { return DefaultSortOrderNode.ReferenceContainerNode + 1; }
@@ -418,9 +427,9 @@ namespace Microsoft.NodejsTools.Project {
             get { return _cCaption; }
         }
 
-        #endregion
+#endregion
 
-        #region Command handling
+#region Command handling
 
         internal bool IsCurrentStateASuppressCommandsMode() {
             return _suppressCommands || ProjectMgr.IsCurrentStateASuppressCommandsMode();
@@ -674,7 +683,7 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        #endregion
+#endregion
 
         public override void ManageNpmModules() {
             ManageModules();

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -188,11 +188,11 @@ namespace Microsoft.NodejsTools.Project {
 
         #region Logging and status bar updates
 
-        private static readonly Guid NpmOutputPaneGuid = new Guid("25764421-33B8-4163-BD02-A94E299D52D8");
-
 #if DEV14_OR_LATER
         // This is the package manager pane that ships with VS2015, and we should print there if available.
         private static readonly Guid VSPackageManagerPaneGuid = new Guid("C7E31C31-1451-4E05-B6BE-D11B6829E8BB");
+#else
+        private static readonly Guid NpmOutputPaneGuid = new Guid("25764421-33B8-4163-BD02-A94E299D52D8");
 #endif
 
         private OutputWindowRedirector GetNpmOutputPane() {


### PR DESCRIPTION
…our Npm window