### PR TITLE
Avoid PathTooLongExceptions when possible

### DIFF
--- a/Common/Product/SharedProject/CommonProjectNode.cs
+++ b/Common/Product/SharedProject/CommonProjectNode.cs
@@ -819,8 +819,8 @@ namespace Microsoft.VisualStudioTools.Project {
                 return true;
             }
 
-            if ((path.Length >= 248 || !Directory.Exists(path) 
-                && (path.Length >= 260 || !File.Exists(path)))) {
+            if ((path.Length >= NativeMethods.MAX_FOLDER_PATH || !Directory.Exists(path) 
+                && (path.Length >= NativeMethods.MAX_PATH || !File.Exists(path)))) {
                 // if the file has disappeared avoid the exception...
                 // same if file is outside of path limits.
                 return true; // Files/directories that don't exist should be hidden. This also fix DiskMerger when adds files that were already deleted

--- a/Common/Product/SharedProject/CommonProjectNode.cs
+++ b/Common/Product/SharedProject/CommonProjectNode.cs
@@ -819,8 +819,10 @@ namespace Microsoft.VisualStudioTools.Project {
                 return true;
             }
 
-            if (!File.Exists(path) && !Directory.Exists(path)) {
+            if ((path.Length >= 248 || !Directory.Exists(path) 
+                && (path.Length >= 260 || !File.Exists(path)))) {
                 // if the file has disappeared avoid the exception...
+                // same if file is outside of path limits.
                 return true; // Files/directories that don't exist should be hidden. This also fix DiskMerger when adds files that were already deleted
             }
 

--- a/Common/Tests/Utilities/FileUtils.cs
+++ b/Common/Tests/Utilities/FileUtils.cs
@@ -23,16 +23,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestUtilities {
     public static class FileUtils {
-        /// <summary>
-        /// Maximum directory length in Windows.
-        /// </summary>
-        internal const int MaxDirectoryLength = 248;
-
-        /// <summary>
-        /// Maximum file name length in Windows.
-        /// </summary>
-        internal const int MaxFileNameLength = 260;
-
         public static void CopyDirectory(string sourceDir, string destDir) {
             sourceDir = sourceDir.TrimEnd('\\');
             destDir = destDir.TrimEnd('\\');
@@ -50,7 +40,7 @@ namespace TestUtilities {
 
             foreach (var newDir in newDirectories.OrderBy(i => i.Length).Select(i => Path.Combine(destDir, i))) {
                 try {
-                    if (newDir.Length < MaxDirectoryLength) {
+                    if (newDir.Length < NativeMethods.MAX_FOLDER_PATH) {
                         Directory.CreateDirectory(newDir);
                     }
                 } catch {
@@ -69,15 +59,19 @@ namespace TestUtilities {
                 var copyFrom = Path.Combine(sourceDir, newFile);
                 var copyTo = Path.Combine(destDir, newFile);
                 try {
-                    if (copyTo.Length < MaxFileNameLength && copyFrom.Length < MaxFileNameLength) {
+                    if (copyTo.Length < NativeMethods.MAX_PATH && copyFrom.Length < NativeMethods.MAX_PATH) {
                         var copyToDir = Path.GetDirectoryName(copyTo);
-                        if (copyToDir.Length < MaxDirectoryLength) {
+                        if (copyToDir.Length < NativeMethods.MAX_FOLDER_PATH) {
                             File.Copy(copyFrom, copyTo);
                             File.SetAttributes(copyTo, FileAttributes.Normal);
+                        } else {
+                            Debug.WriteLine("Failed to copy " + copyFrom + " to " + copyTo + " due to max path limit");
                         }
+                    } else {
+                        Debug.WriteLine("Failed to copy " + copyFrom + " to " + copyTo + " due to max path limit");
                     }
                 } catch {
-                    Debug.WriteLine("Failed to copy " + copyFrom + " to " + copyTo);
+                    Debug.WriteLine("Failed to copy " + copyFrom + " to " + copyTo + " for unknown reason");
                 }
             }
         }

--- a/Common/Tests/Utilities/FileUtils.cs
+++ b/Common/Tests/Utilities/FileUtils.cs
@@ -23,6 +23,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestUtilities {
     public static class FileUtils {
+        /// <summary>
+        /// Maximum directory length in Windows.
+        /// </summary>
+        internal const int MaxDirectoryLength = 248;
+
+        /// <summary>
+        /// Maximum file name length in Windows.
+        /// </summary>
+        internal const int MaxFileNameLength = 260;
+
         public static void CopyDirectory(string sourceDir, string destDir) {
             sourceDir = sourceDir.TrimEnd('\\');
             destDir = destDir.TrimEnd('\\');
@@ -40,7 +50,9 @@ namespace TestUtilities {
 
             foreach (var newDir in newDirectories.OrderBy(i => i.Length).Select(i => Path.Combine(destDir, i))) {
                 try {
-                    Directory.CreateDirectory(newDir);
+                    if (newDir.Length < MaxDirectoryLength) {
+                        Directory.CreateDirectory(newDir);
+                    }
                 } catch {
                     Debug.WriteLine("Failed to create directory " + newDir);
                 }
@@ -57,8 +69,13 @@ namespace TestUtilities {
                 var copyFrom = Path.Combine(sourceDir, newFile);
                 var copyTo = Path.Combine(destDir, newFile);
                 try {
-                    File.Copy(copyFrom, copyTo);
-                    File.SetAttributes(copyTo, FileAttributes.Normal);
+                    if (copyTo.Length < MaxFileNameLength && copyFrom.Length < MaxFileNameLength) {
+                        var copyToDir = Path.GetDirectoryName(copyTo);
+                        if (copyToDir.Length < MaxDirectoryLength) {
+                            File.Copy(copyFrom, copyTo);
+                            File.SetAttributes(copyTo, FileAttributes.Normal);
+                        }
+                    }
                 } catch {
                     Debug.WriteLine("Failed to copy " + copyFrom + " to " + copyTo);
                 }

--- a/Common/Tests/Utilities/NativeMethods.cs
+++ b/Common/Tests/Utilities/NativeMethods.cs
@@ -329,7 +329,15 @@ namespace TestUtilities {
             FO_RENAME = 0x0004,
         }
 
+        /// <summary>
+        /// Maximum file name length in Windows.
+        /// </summary>
         public const int MAX_PATH = 260;
+
+        /// <summary>
+        /// Maximum directory length in Windows.
+        /// </summary>
+        public const int MAX_FOLDER_PATH = 248;
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Nodejs/Product/Npm/NativeMethods.cs
+++ b/Nodejs/Product/Npm/NativeMethods.cs
@@ -1,0 +1,22 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+namespace Microsoft.NodejsTools.Npm {
+    internal static class NativeMethods {
+        public const int MAX_PATH = 260; // windef.h	
+        public const int MAX_FOLDER_PATH = MAX_PATH - 12;   // folders need to allow 8.3 filenames, so MAX_PATH - 12
+    }
+}

--- a/Nodejs/Product/Npm/Npm.csproj
+++ b/Nodejs/Product/Npm/Npm.csproj
@@ -89,6 +89,7 @@
     </Compile>
     <Compile Include="IHomepages.cs" />
     <Compile Include="IPackageCatalogFilter.cs" />
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="NpmArgumentBuilder.cs" />
     <Compile Include="NpmHelpers.cs" />
     <Compile Include="SemverVersionComparer.cs" />

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NodeModules : AbstractNodeModules {
         public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages) {
             var modulesBase = Path.Combine(parent.Path, "node_modules");
-            if (Directory.Exists(modulesBase)) {
+            if (modulesBase.Length <= 224 && Directory.Exists(modulesBase)) {
                 var bin = string.Format("{0}.bin", Path.DirectorySeparatorChar);
                 foreach (var moduleDir in Directory.EnumerateDirectories(modulesBase)) {
                     if (!moduleDir.EndsWith(bin)) {
@@ -34,12 +34,15 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                 foreach (var dependency in parentPackageJson.AllDependencies) {
                     Package module = null;
                     if (!Contains(dependency.Name)) {
-                        module = new Package(
-                            parent,
-                            Path.Combine(modulesBase, dependency.Name),
-                            showMissingDevOptionalSubPackages);
-                        if (parent as IPackage == null || !module.IsMissing || showMissingDevOptionalSubPackages) {
-                            AddModule(module);
+                        var dependencyPath = Path.Combine(modulesBase, dependency.Name);
+                        if (dependencyPath.Length <= 224) {
+                            module = new Package(
+                                parent,
+                                dependencyPath,
+                                showMissingDevOptionalSubPackages);
+                            if (parent as IPackage == null || !module.IsMissing || showMissingDevOptionalSubPackages) {
+                                AddModule(module);
+                            }
                         }
                     } else {
                         module = this[dependency.Name] as Package;

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -20,10 +20,10 @@ namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NodeModules : AbstractNodeModules {
         public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages) {
             var modulesBase = Path.Combine(parent.Path, "node_modules");
-            if (modulesBase.Length <= 224 && Directory.Exists(modulesBase)) {
+            if (modulesBase.Length < NativeMethods.MAX_FOLDER_PATH && Directory.Exists(modulesBase)) {
                 var bin = string.Format("{0}.bin", Path.DirectorySeparatorChar);
                 foreach (var moduleDir in Directory.EnumerateDirectories(modulesBase)) {
-                    if (!moduleDir.EndsWith(bin)) {
+                    if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !moduleDir.EndsWith(bin)) {
                         AddModule(new Package(parent, moduleDir, showMissingDevOptionalSubPackages));
                     }
                 }
@@ -35,7 +35,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                     Package module = null;
                     if (!Contains(dependency.Name)) {
                         var dependencyPath = Path.Combine(modulesBase, dependency.Name);
-                        if (dependencyPath.Length <= 224) {
+                        if (dependencyPath.Length < NativeMethods.MAX_FOLDER_PATH) {
                             module = new Package(
                                 parent,
                                 dependencyPath,

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -25,8 +25,11 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             string fullPathToRootDirectory,
             bool showMissingDevOptionalSubPackages) {
             Path = fullPathToRootDirectory;
+            var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
             try {
-                PackageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(fullPathToRootDirectory));
+                if (packageJsonFile.Length < 260) {
+                    PackageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(fullPathToRootDirectory));
+                }
             } catch (RuntimeBinderException rbe) {
                 throw new PackageJsonException(
                     string.Format(@"Error processing package.json at '{0}'. The file was successfully read, and may be valid JSON, but the objects may not match the expected form for a package.json file.
@@ -34,7 +37,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 The following error was reported:
 
 {1}",
-                    System.IO.Path.Combine(fullPathToRootDirectory, "package.json"),
+                    packageJsonFile,
                     rbe.Message),
                     rbe);
             }


### PR DESCRIPTION
When opening NPM modules with large depth tree, a lot of exceptions silently produced. This lead to CPU spikes as described in #234 