### PR TITLE
Simplify regex and test on Turkish locale

### DIFF
--- a/Nodejs/Product/Npm/Resources.Designer.cs
+++ b/Nodejs/Product/Npm/Resources.Designer.cs
@@ -223,6 +223,15 @@ namespace Microsoft.NodejsTools.Npm {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Semversion {0} for package {1} is invalid.
+        /// </summary>
+        internal static string InvalidPackageSemVersion {
+            get {
+                return ResourceManager.GetString("InvalidPackageSemVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to npm command cancelled.
         /// </summary>
         internal static string NpmCommandCancelled {

--- a/Nodejs/Product/Npm/Resources.resx
+++ b/Nodejs/Product/Npm/Resources.resx
@@ -200,4 +200,8 @@
   <data name="InfoRegistryUrl" xml:space="preserve">
     <value>Registry url: {0}</value>
   </data>
+  <data name="InvalidPackageSemVersion" xml:space="preserve">
+    <value>Semversion {0} for package {1} is invalid</value>
+    <comment>args: semantic version, package name</comment>
+  </data>
 </root>

--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -122,7 +122,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                                         if (!string.IsNullOrEmpty(latestVersion)) {
                                             try {
                                                 builder.LatestVersion = SemverVersion.Parse(latestVersion);
-                                            } catch (SemverVersionFormatException) { 
+                                            } catch (SemverVersionFormatException) {
+                                                OnOutputLogged(String.Format(Resources.InvalidPackageSemVersion, latestVersion, builder.Name));
                                             }
                                         }
                                     }

--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -120,7 +120,10 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                                             .FirstOrDefault();
 
                                         if (!string.IsNullOrEmpty(latestVersion)) {
-                                            builder.LatestVersion = SemverVersion.Parse(latestVersion);
+                                            try {
+                                                builder.LatestVersion = SemverVersion.Parse(latestVersion);
+                                            } catch (SemverVersionFormatException) { 
+                                            }
                                         }
                                     }
 

--- a/Nodejs/Product/Npm/SemverVersion.cs
+++ b/Nodejs/Product/Npm/SemverVersion.cs
@@ -33,11 +33,11 @@ namespace Microsoft.NodejsTools.Npm {
             + "\\.(?<patch>[…0-9]+)" // The '…' is there to handle the 'classy' library, which has a very long version number - see slightly snarky comment about that unadulterated bag of hilarity below.
             + "(?:-(?<prerelease>[…0-9A-Za-z-]+(\\.[…0-9A-Za-z-]+)*))?"
             + "(?:\\+(?<buildmetadata>[…0-9A-Za-z-]+(\\.[…0-9A-Za-z-]+)*))?$",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexOptions.Singleline);
 
         private static readonly Regex RegexOptionalFragment = new Regex(
             "^[…0-9A-Za-z-]+(\\.[…0-9A-Za-z-]+)*$",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexOptions.Singleline);
 
         public static SemverVersion Parse(string versionString) {
             var matches = RegexSemver.Matches(versionString);

--- a/Nodejs/Tests/NpmTests/SemverVersionTests.cs
+++ b/Nodejs/Tests/NpmTests/SemverVersionTests.cs
@@ -94,6 +94,20 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
+        public void TestPreReleaseHyphenatedIdentifierWithoutVersion()
+        {
+            // This version code is crazy, and for that reason it fail when
+            // regional settings is set to Turkish.
+            SemverVersionTestHelper.AssertVersionsEqual(
+                0,
+                1,
+                4,
+                "DEPRECATED-USE-cfenv-INSTEAD",
+                null,
+                SemverVersion.Parse("0.1.4-DEPRECATED-USE-cfenv-INSTEAD"));
+        }
+
+        [TestMethod, Priority(0)]
         public void TestPreReleaseAndBuildMetadata() {
             // 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85
             SemverVersionTestHelper.AssertVersionsEqual(1, 0, 0, "alpha", "001", SemverVersion.Parse("1.0.0-alpha+001"));


### PR DESCRIPTION
I remove RegexOptions.IgnoreCase since somehow this break the whole recognition on Turkish locale and I don't see any point have it. We already define both uppercase and lower case letters in the regex. Alternative for A-Za-z is to use \w and for 0-9 use \d, so maybe this will lead to more reliable version recognizer. If strict fragment rules needed they should be placed to RegexOptionalFragment, but I was unable to make this work reliable so far.

See #253 