### PR TITLE
Refresh modules list when module is not found

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -1228,7 +1228,12 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
         private void OnDocumentSaved(Document document) {
             var module = Process.GetModuleForFilePath(document.FullName);
             if (module == null) {
-                return;
+				Process.RefreshModules();
+				module = Process.GetModuleForFilePath(document.FullName);
+
+				if (module == null) {
+					return;
+				}
             }
 
             // For .ts files, we need to build the project to regenerate .js code.
@@ -1236,8 +1241,11 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                 if (document.ProjectItem.ContainingProject.GetNodeProject().Build(null, null) != MSBuildResult.Successful) {
                     var statusBar = (IVsStatusbar)ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar));
                     statusBar.SetText(SR.GetString(SR.DebuggerModuleUpdateFailed));
-                    return;
-                }
+				
+					// From some reason Build() sometimes returns false even when the compilation succeeded...
+					// Let's not return here so that if the module compiled properly - it would be reloaded.
+					//return; 
+				}
             }
 
             DebuggerClient.RunWithRequestExceptionsHandled(async () => {

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -1228,12 +1228,12 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
         private void OnDocumentSaved(Document document) {
             var module = Process.GetModuleForFilePath(document.FullName);
             if (module == null) {
-				Process.RefreshModules();
-				module = Process.GetModuleForFilePath(document.FullName);
+                Process.RefreshModules();
+                module = Process.GetModuleForFilePath(document.FullName);
 
-				if (module == null) {
-					return;
-				}
+                if (module == null) {
+                    return;
+                }
             }
 
             // For .ts files, we need to build the project to regenerate .js code.
@@ -1241,11 +1241,11 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                 if (document.ProjectItem.ContainingProject.GetNodeProject().Build(null, null) != MSBuildResult.Successful) {
                     var statusBar = (IVsStatusbar)ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar));
                     statusBar.SetText(SR.GetString(SR.DebuggerModuleUpdateFailed));
-				
-					// From some reason Build() sometimes returns false even when the compilation succeeded...
-					// Let's not return here so that if the module compiled properly - it would be reloaded.
-					//return; 
-				}
+
+                    // From some reason Build() sometimes returns false even when the compilation succeeded...
+                    // Let's not return here so that if the module compiled properly - it would be reloaded.
+                    //return; 
+                }
             }
 
             DebuggerClient.RunWithRequestExceptionsHandled(async () => {

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -475,6 +475,10 @@ namespace Microsoft.NodejsTools.Debugger {
             return true;
         }
 
+		public void RefreshModules() {
+			GetScriptsAsync().Wait((int)_timeout.TotalMilliseconds);
+		}
+
         /// <summary>
         /// Starts listening for debugger communication.  Can be called after Start
         /// to give time to attach to debugger events.

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -475,9 +475,9 @@ namespace Microsoft.NodejsTools.Debugger {
             return true;
         }
 
-		public void RefreshModules() {
-			GetScriptsAsync().Wait((int)_timeout.TotalMilliseconds);
-		}
+        public void RefreshModules() {
+            GetScriptsAsync().Wait((int)_timeout.TotalMilliseconds);
+        }
 
         /// <summary>
         /// Starts listening for debugger communication.  Can be called after Start


### PR DESCRIPTION

At the moment, in most cases, Change Live only works after breaking into the debugger in the file that needs to be changed and reloaded.

The modules list is retrieved from Node once, in NodeDebugger::StartListening() and then cached. Any modules that have not been loaded by Node yet will not enter the cache.

Consequently, when saving a file in VS, NTVS tries to look the module up in the cached list. The module is likely missing from the list, so it is not reloaded (in AD7Engine::OnDocumentSaved()).

This patch causes NTVS to re-retrieve all modules from Node whenever AD7Engine::OnDocumentSaved() fails to find the saved document in the cached modules list. The cached modules list is also updated with the new modules.

There may be a more efficient way to do this (maybe query Node only for the specific module that is not found?) - but I didn't have the time to dive more deeply into the Node Debugger API and the NTVS code...

Another small change: Change Live was not being invoked if the saved document was TypeScript and NodejsProjectNode::Build() returned Failure. In my experience that function often returns Failure, even though the file compiled properly. I'm not sure why (maybe because no build targets are supplied?), but it was preventing Change Live from working - so I changed the code to continue even if the build has supposedly failed.
