### PR TITLE
Files without extensions should not be considered codefiles, since th…

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -365,9 +365,7 @@ namespace Microsoft.NodejsTools.Project {
         public override bool IsCodeFile(string fileName) {
             var ext = Path.GetExtension(fileName);
             return ext.Equals(NodejsConstants.JavaScriptExtension, StringComparison.OrdinalIgnoreCase) ||
-                   ext.Equals(NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase) ||
-                   // for some reason, the default express 4 template's startup file lacks an extension.
-                   string.IsNullOrEmpty(ext);
+                   ext.Equals(NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int InitializeForOuter(string filename, string location, string name, uint flags, ref Guid iid, out IntPtr projectPointer, out int canceled) {

--- a/Nodejs/Product/Nodejs/Templates/Files/DockerfileTemplate/Dockerfile.vstemplate
+++ b/Nodejs/Product/Nodejs/Templates/Files/DockerfileTemplate/Dockerfile.vstemplate
@@ -9,7 +9,7 @@
     <SortOrder>500</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem TargetFileName="Dockerfile" SubType="Code" ReplaceParameters="true">Dockerfile</ProjectItem>
+    <ProjectItem TargetFileName="Dockerfile" SubType="Content" ReplaceParameters="true">Dockerfile</ProjectItem>
   </TemplateContent>
   <WizardExtension>
     <Assembly>Microsoft.NodejsTools.ProjectWizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>


### PR DESCRIPTION
…is is almost always wrong.

And set the content type for the Docker template to 'Content', since it's not 'Code'.