### PR TITLE
Readme: Add 1.1 RC link and remove migration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ NTVS supports **editing**, **Intellisense**, **profiling**, **npm**, **TypeScrip
 [NTVS documentation](https://github.com/Microsoft/nodejstools/wiki) is available in the NTVS wiki.
 
 ## Releases
-NTVS releases are currently hosted on CodePlex.
 * **[NTVS 1.1 RC](https://aka.ms/ntvslatest)** includes support for Visual Studio 2012, 2013, and 2015
 * **[NTVS 1.0](https://nodejstools.codeplex.com/releases/view/612573)** includes support for Visual Studio 2012 and 2013
 * **[Dev Builds](https://github.com/Microsoft/nodejstools/releases)** include the most recent changes and bugfixes (available for Visual Studio 2012, 2013, and 2015)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ NTVS supports **editing**, **Intellisense**, **profiling**, **npm**, **TypeScrip
 
 ## Releases
 NTVS releases are currently hosted on CodePlex.
-* **[NTVS 1.1 Beta](https://nodejstools.codeplex.com/releases/view/614706)** includes support for Visual Studio 2012, 2013, and 2015 RC
+* **[NTVS 1.1 RC](https://aka.ms/ntvslatest)** includes support for Visual Studio 2012, 2013, and 2015
 * **[NTVS 1.0](https://nodejstools.codeplex.com/releases/view/612573)** includes support for Visual Studio 2012 and 2013
 * **[Dev Builds](https://github.com/Microsoft/nodejstools/releases)** include the most recent changes and bugfixes (available for Visual Studio 2012, 2013, and 2015)
-* **[Older NTVS releases](https://nodejstools.codeplex.com/releases)** are also available.
 
 ## Contributions
 We would love to have you as a contributor!
@@ -24,10 +23,3 @@ We would love to have you as a contributor!
 
 ## License
 [Apache License 2.0 (Apache)](https://github.com/Microsoft/nodejstools/blob/master/LICENSE)
-
-## GitHub Migration Status
-* **Issue tracker:** Working on migrating [existing issues](https://nodejstools.codeplex.com/workitem/list/basic), but file new issues on GitHub.
-* **Discussions:** No plans to migrate [existing discussions](https://nodejstools.codeplex.com/discussions). Please use the "discuss" tag in the GitHub issue tracker for all new discussions.  
-* **Source code:** Done!
-* **Documentation:** Done!
-* **Releases:** Not yet migrated.


### PR DESCRIPTION
GitHub migration is complete enough that we no longer need to surface up the status. If anything else comes up, we can include it in the wiki.