### PR TITLE
Fix #319 Failing to parse some PackageJson Person fields

### DIFF
--- a/Nodejs/Product/Npm/SPI/Person.cs
+++ b/Nodejs/Product/Npm/SPI/Person.cs
@@ -83,7 +83,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             // Verify we are parsing correctly
             try {
                 var jObject = JObject.Parse(source);
-                Debug.Assert((string)jObject["name"] == Name, string.Format("Failed to parse name from {0}", source));
+                var name = (string)jObject["name"];
+                Debug.Assert(name != null ? name == Name : Name == source, string.Format("Failed to parse name from {0}", source));
                 Debug.Assert((string)jObject["email"] == Email, string.Format("Failed to parse email from {0}", source));
                 Debug.Assert((string)jObject["url"] == Url, string.Format("Failed to parse url from {0}", source));
             } catch (Exception) {

--- a/Nodejs/Product/Npm/SPI/Person.cs
+++ b/Nodejs/Product/Npm/SPI/Person.cs
@@ -32,9 +32,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         private static readonly Regex RegexPerson = new Regex(
         "\"name\":\\s*\"(?<name>[^<]+?)\"" +
         "|" +
-        "(\"email\":\\s*\"(?<email>[^<]+?)\")" +
+        "\"email\":\\s*\"(?<email>[^<]+?)\"" +
         "|" +
-        "(\"url\":\\s*\"(?<url>[^<]+?)\")",
+        "\"url\":\\s*\"(?<url>[^<]+?)\"",
         RegexOptions.Singleline);
     
         [JsonConstructor]

--- a/Nodejs/Product/Npm/SPI/Person.cs
+++ b/Nodejs/Product/Npm/SPI/Person.cs
@@ -83,9 +83,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             // Verify we are parsing correctly
             try {
                 var jObject = JObject.Parse(source);
-                Debug.Assert(((string)jObject["name"] ?? string.Empty) == (Name ?? string.Empty), string.Format("Failed to parse name from {0}", source));
-                Debug.Assert(((string)jObject["email"] ?? string.Empty) == (Email ?? string.Empty), string.Format("Failed to parse email from {0}", source));
-                Debug.Assert(((string)jObject["url"] ?? string.Empty) == (Url ?? string.Empty), string.Format("Failed to parse url from {0}", source));
+                Debug.Assert((string)jObject["name"] == Name, string.Format("Failed to parse name from {0}", source));
+                Debug.Assert((string)jObject["email"] == Email, string.Format("Failed to parse email from {0}", source));
+                Debug.Assert((string)jObject["url"] == Url, string.Format("Failed to parse url from {0}", source));
             } catch (Exception) {
                 Debug.Assert(source == Name);
             }

--- a/Nodejs/Product/Npm/SPI/Person.cs
+++ b/Nodejs/Product/Npm/SPI/Person.cs
@@ -27,13 +27,15 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class Person : IPerson {
 
-    private static readonly Regex RegexPerson = new Regex(
+        // We cannot rely on the ordering of any of these fields,
+        // so we should match them separately.
+        private static readonly Regex RegexPerson = new Regex(
         "\"name\":\\s*\"(?<name>[^<]+?)\"" +
-        "[\\s,]*" +
-        "(\"email\":\\s*\"(?<email>[^<]+?)\")?" +
-        "[\\s,]*" +
-        "(\"url\":\\s*\"(?<url>[^<]+?)\")?",
-        RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        "|" +
+        "(\"email\":\\s*\"(?<email>[^<]+?)\")" +
+        "|" +
+        "(\"url\":\\s*\"(?<url>[^<]+?)\")",
+        RegexOptions.Singleline);
     
         [JsonConstructor]
         private Person() {
@@ -53,16 +55,26 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             // We parse using a regex because JObject.Parse throws exceptions for malformatted json,
             // and simply handling them causes performance issues.
             var matches = RegexPerson.Matches(source);
-            if (matches.Count == 1) {
-                var match = matches[0];
-                var group = match.Groups["name"];
-                Name = group.Value;
+            if (matches.Count >= 1) {
+                foreach (Match match in matches) {
+                    var group = match.Groups["name"];
+                    if (group.Success) {
+                        Name = group.Value;
+                        continue;
+                    }
 
-                group = match.Groups["email"];
-                Email = group.Value;
+                    group = match.Groups["email"];
+                    if (group.Success) {
+                        Email = group.Value;
+                        continue;
+                    }
 
-                group = match.Groups["url"];
-                Url = group.Value;
+                    group = match.Groups["url"];
+                    if (group.Success) {
+                        Url = group.Value;
+                        continue;
+                    }
+                }
             } else {
                 Name = source;
             }
@@ -71,9 +83,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             // Verify we are parsing correctly
             try {
                 var jObject = JObject.Parse(source);
-                Debug.Assert(((string)jObject["name"] ?? string.Empty) == Name, string.Format("Failed to parse name from {0}", source));
-                Debug.Assert(((string)jObject["email"] ?? string.Empty) == Email, string.Format("Failed to parse email from {0}", source));
-                Debug.Assert(((string)jObject["url"] ?? string.Empty) == Url, string.Format("Failed to parse url from {0}", source));
+                Debug.Assert(((string)jObject["name"] ?? string.Empty) == (Name ?? string.Empty), string.Format("Failed to parse name from {0}", source));
+                Debug.Assert(((string)jObject["email"] ?? string.Empty) == (Email ?? string.Empty), string.Format("Failed to parse email from {0}", source));
+                Debug.Assert(((string)jObject["url"] ?? string.Empty) == (Url ?? string.Empty), string.Format("Failed to parse url from {0}", source));
             } catch (Exception) {
                 Debug.Assert(source == Name);
             }

--- a/Nodejs/Tests/NpmTests/PackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonTests.cs
@@ -43,6 +43,11 @@ namespace NpmTests {
    ""name"": ""mypackage"",
    ""version"": ""0.7.0"",
    ""description"": ""Sample package for CommonJS. This package demonstrates the required elements of a CommonJS package."",
+   ""author"": {
+       ""name"": ""Firstname Lastname"",
+       ""email"": ""firstname@lastname.com"",
+       ""url"": ""http://firstnamelastname.com""
+   },
    ""keywords"": [
        ""package"",
        ""example"" 
@@ -108,6 +113,10 @@ namespace NpmTests {
    ""name"": ""mypackage"",
    ""version"": ""0.7.0"",
    ""description"": ""Sample package for CommonJS. This package demonstrates the required elements of a CommonJS package."",
+   ""author"": {
+       ""url"": ""http://firstnamelastname.com"",
+       ""name"": ""Firstname Lastname""
+   },
    ""keywords"": [
        ""package"",
        ""example"" 
@@ -375,6 +384,22 @@ namespace NpmTests {
                 LoadFrom(PkgLargeCompliant).Man,
                 2,
                 new[] { "./man/foo.1", "./man/bar.1" });
+        }
+
+        [TestMethod, Priority(0)]
+        public void TestReadAuthorCompliant() {
+            var compliantAuthor = LoadFrom(PkgLargeCompliant).Author;
+            Assert.AreEqual("Firstname Lastname", compliantAuthor.Name);
+            Assert.AreEqual("firstname@lastname.com", compliantAuthor.Email);
+            Assert.AreEqual("http://firstnamelastname.com", compliantAuthor.Url);
+        }
+
+        [TestMethod, Priority(0)]
+        public void TestReadAuthorNonCompliant() {
+            var nonCompliantAuthor = LoadFrom(PkgLargeNonCompliant).Author;
+            Assert.AreEqual("Firstname Lastname", nonCompliantAuthor.Name);
+            Assert.AreEqual("http://firstnamelastname.com", nonCompliantAuthor.Url);
+            Assert.IsNull(nonCompliantAuthor.Email);
         }
 
         //  TODO: authors, contributors, private, main, bin, directories (hash), repository, config, 

--- a/Nodejs/Tests/NpmTests/PackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonTests.cs
@@ -27,6 +27,22 @@ namespace NpmTests {
     ""bugs"": ""http://www.mybugtracker.com/""
 }";
 
+        private const string PkgMisSpelledAuthor = @"{
+    ""name"": ""TestPkg"",
+    ""version"": ""0.1.0"",
+    ""author"": {
+        ""misspelledname"": ""Firstname Lastname""
+    }
+}";
+
+        private const string PkgSingleAuthorField = @"{
+    ""name"": ""TestPkg"",
+    ""version"": ""0.1.0"",
+    ""author"": {
+        ""name"": ""Firstname Lastname""
+    }
+}";
+
         private const string PkgSingleLicenseType = @"{
     ""name"": ""TestPkg"",
     ""version"": ""0.1.0"",
@@ -384,6 +400,29 @@ namespace NpmTests {
                 LoadFrom(PkgLargeCompliant).Man,
                 2,
                 new[] { "./man/foo.1", "./man/bar.1" });
+        }
+
+        [TestMethod, Priority(0)]
+        public void TestReadEmptyAuthor() {
+            Assert.IsNull(LoadFrom(PkgSimple).Author);
+        }
+
+        [TestMethod, Priority(0)]
+        public void TestReadMisspelledAuthor() {
+            Assert.AreEqual(
+                @"{
+  ""misspelledname"": ""Firstname Lastname""
+}",
+                LoadFrom(PkgMisSpelledAuthor).Author.Name
+            );
+        }
+
+        [TestMethod, Priority(0)]
+        public void TestReadSingleAuthorField() {
+            Assert.AreEqual(
+                "Firstname Lastname",
+                LoadFrom(PkgSingleAuthorField).Author.Name
+            );
         }
 
         [TestMethod, Priority(0)]


### PR DESCRIPTION
Fix issues while parsing Person package.json fields
* we were not properly handling cases when the name, email, and url fields
      were out of order.
* fix assertion check when result is empty
* add relevant test cases