### PR TITLE
Fix #334 Test explorer view is messed up in VS 2015

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -17,7 +17,7 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
             if (suite.tests && suite.tests.length !== 0) {
                 suite.tests.forEach(function (t, i, testArray) {
                     testList.push({
-                        test: t.title,
+                        test: t.fullTitle(),
                         suite: suite.fullTitle(),
                         file: testFile,
                         line: 0,


### PR DESCRIPTION
- nested tests were not appearing in Test Explorer discovery because we
  were returning title rather than fullTitle()