### PR TITLE
Fix #337 NRE on loading project

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NodejsTools.Project {
 
             var includeInProject = base.IncludeInProject(includeChildren);
             
-            if (isContent && FileName.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
+            if (isContent && Url.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
                 this.ItemNode.ItemTypeName = ProjectFileConstants.Content;
             }
             

--- a/Nodejs/Product/Nodejs/Project/NodejsFolderNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFolderNode.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NodejsTools.Project {
             var fileNodesEnumerator = this.EnumNodesOfType<NodejsFileNode>().GetEnumerator();
             FolderContentType contentType = FolderContentType.None;
             while (fileNodesEnumerator.MoveNext()) {
-                if (!fileNodesEnumerator.Current.FileName.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
+                if (!fileNodesEnumerator.Current.Url.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
                     continue;
                 }
                 var properties = fileNodesEnumerator.Current.NodeProperties as IncludedFileNodeProperties;
@@ -119,7 +119,7 @@ namespace Microsoft.NodejsTools.Project {
             // If we are adding an immediate child to a directory, then set the content type
             // acording to the content type of the folder it is being moved to.
             var nodejsFileNode = node as NodejsFileNode;
-            if (nodejsFileNode != null && nodejsFileNode.FileName.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && nodejsFileNode.Parent == this) {
+            if (nodejsFileNode != null && nodejsFileNode.Url.EndsWith(".js", StringComparison.OrdinalIgnoreCase) && nodejsFileNode.Parent == this) {
                 var properties = nodejsFileNode.NodeProperties as IncludedFileNodeProperties;
                 if (properties != null) {
                     switch (ContentType) {
@@ -206,7 +206,7 @@ namespace Microsoft.NodejsTools.Project {
             var fileNodesEnumerator = this.EnumNodesOfType<NodejsFileNode>().GetEnumerator();
             while (fileNodesEnumerator.MoveNext()) {
                 var includedFileNodeProperties = fileNodesEnumerator.Current.NodeProperties as IncludedFileNodeProperties;
-                if (includedFileNodeProperties != null && includedFileNodeProperties.FileName.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
+                if (includedFileNodeProperties != null && includedFileNodeProperties.URL.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
                     includedFileNodeProperties.BuildAction = buildAction;
                 }
             }


### PR DESCRIPTION
- projects with missing linked files were not loading. Use Url instead of
  FileName because FileName can be null in these cases.