### PR TITLE
IntelliSense options page save settings fix

### DIFF
--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
@@ -84,7 +84,6 @@ namespace Microsoft.NodejsTools.Options {
                 // Fallback to full intellisense (High) if the ES6 intellisense preview isn't enabled
                 if (_level == AnalysisLevel.Preview && !_enableES6Preview) {
                     _level = AnalysisLevel.High;
-                    SaveSettingsToStorage();
                 }
 
                 if (oldLevel != _level) {
@@ -159,6 +158,11 @@ namespace Microsoft.NodejsTools.Options {
             if (_window != null) {
                 _window.SyncControlWithPageSettings(this);
             }
+
+            // Settings values can change after loading them from storage as there
+            // are conditions which could make them fallback to default values.
+            // Save the final settings back to storage.
+            SaveSettingsToStorage();
         }
 
         public override void SaveSettingsToStorage() {


### PR DESCRIPTION
Issue: the intellisense options page AnalysisLevel fallback saves the new setting back to storage. There are cases where the call to SaveSettingsStorage() can throw an exception if it is called before some of the other settings have been retrieved. 

Ex: An attempt to SaveSettingsStorage() when the CompletionsComittedBy string is null
SaveString(CompletionCommittedBySetting, CompletionCommittedBy);

Fix:  Move the call to SaveSettingsStorage to the end of LoadSettingsFromStorage() to guarantee that all settings have been retrieved and the final settings with default fallbacks are stored.