### PR TITLE
Debugger connection retry logic

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
@@ -103,18 +103,24 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                         break;
                     }
                 } catch (OperationCanceledException) {
-                    LiveLogger.WriteLine("NodeRemoteEnumDebugProcesses ping timed out.");
+                    LiveLogger.WriteLine("OperationCanceledException connecting to remote debugger");
                 } catch (DebuggerAlreadyAttachedException ex) {
+                    LiveLogger.WriteLine("DebuggerAlreadyAttachedException connecting to remote debugger");
                     exception = ex;
                 } catch (AggregateException ex) {
+                    LiveLogger.WriteLine("AggregateException connecting to remote debugger");
                     exception = ex;
                 } catch (IOException ex) {
+                    LiveLogger.WriteLine("IOException connecting to remote debugger");
                     exception = ex;
                 } catch (SocketException ex) {
+                    LiveLogger.WriteLine("SocketException connecting to remote debugger");
                     exception = ex;
                 } catch (WebSocketException ex) {
+                    LiveLogger.WriteLine("WebSocketException connecting to remote debugger");
                     exception = ex;
                 } catch (PlatformNotSupportedException) {
+                    LiveLogger.WriteLine("NodeRemoteEnumDebugProcesses ping timed out.");
                     MessageBox.Show(
                         "Remote debugging of node.js Microsoft Azure applications is only supported on Windows 8 and above.",
                         null, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
@@ -103,7 +103,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                         break;
                     }
                 } catch (OperationCanceledException) {
-                    LiveLogger.WriteLine("OperationCanceledException connecting to remote debugger");
+                    LiveLogger.WriteLine("NodeRemoteEnumDebugProcesses ping timed out.");
                 } catch (DebuggerAlreadyAttachedException ex) {
                     LiveLogger.WriteLine("DebuggerAlreadyAttachedException connecting to remote debugger");
                     exception = ex;
@@ -120,7 +120,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                     LiveLogger.WriteLine("WebSocketException connecting to remote debugger");
                     exception = ex;
                 } catch (PlatformNotSupportedException) {
-                    LiveLogger.WriteLine("NodeRemoteEnumDebugProcesses ping timed out.");
+                    LiveLogger.WriteLine("PlatformNotSupportedException connecting to remote debugger");
                     MessageBox.Show(
                         "Remote debugging of node.js Microsoft Azure applications is only supported on Windows 8 and above.",
                         null, MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
This adds retry logic when attempting to connect to the debug port on Node, in an attempt to resolve #245 and #246.

In some scenarios, especially when using Debug builds of Node/io.js, the Node process doesn't open the debug port (5858 by default) in time. At the network level, this results in the connection being refused. This change adds retry logic if the connection fails (and additional logging).

On my machine, using the 'Debug' build of the latest io.js branch (as using 'Release' shows no issue at all), I can now see the connection retry and succeed, e.g.

```
[17:20:09.0841895] AD7Engine Created (63760528)
[17:20:09.0907085] AD7Engine Called SetRegistryRoot
[17:20:09.0912082] AD7Engine Called SetLocale
[17:20:09.0947085] AD7Engine LaunchSuspended Called with flags 'LAUNCH_ENABLE_ENC' (63760528)
[17:20:09.1791871] Debugger connecting to URI: tcp://localhost:5858/
[17:20:11.2412522] Connection attempt 1 failed with: System.Net.Sockets.SocketException (0x80004005): No connection could be made because the target machine actively refused it 127.0.0.1:5858
   at System.Net.Sockets.TcpClient..ctor(String hostname, Int32 port)
   at Microsoft.NodejsTools.Debugger.Communication.NetworkClientFactory.CreateNetworkClient(Uri uri) in C:\src\nodejstools\Nodejs\Product\Nodejs\Debugger\Communication\NetworkClientFactory.cs:line 32
   at Microsoft.NodejsTools.Debugger.Communication.DebuggerConnection.Connect(Uri uri) in C:\src\nodejstools\Nodejs\Product\Nodejs\Debugger\Communication\DebuggerConnection.cs:line 130
[17:20:12.9912323] Debugger connected successfully
[17:20:12.9912323] DebuggerConnection: Request: {"command":"scripts","seq":1,"type":"request","arguments":{"includeSource":false}}
```

Note that on a retry connect, sometime the debugger enters a state where it doesn't appear to be connected, but using "Debug / Break all" will then break on the first line and debugging can then continue. This needs to be looked at separately.