### PR TITLE
Fix multiline comment tests

### DIFF
--- a/Nodejs/Product/Nodejs/Editor/EditorExtensions.cs
+++ b/Nodejs/Product/Nodejs/Editor/EditorExtensions.cs
@@ -172,7 +172,7 @@ namespace Microsoft.NodejsTools.Editor.Core {
             var classifier = buffer.GetNodejsClassifier();
 
             // Find if this is a comment and then find the starting position of the comment if so.
-            var classificationSpans = buffer.GetNodejsClassifier().GetClassificationSpans(
+            var classificationSpans = classifier.GetClassificationSpans(
                 new SnapshotSpan(insertionPoint.Snapshot, new Span(insertionPoint.Position - 1, 1)));
 
             foreach (var span in classificationSpans) {

--- a/Nodejs/Tests/Core/MultiLineCommentTests.cs
+++ b/Nodejs/Tests/Core/MultiLineCommentTests.cs
@@ -142,7 +142,7 @@ namespace NodejsTests {
 
             // create the view and request a multiline comment format
             var view = new MockTextView(
-                new MockTextBuffer(startingText, "C:\\app.js", NodejsConstants.Nodejs));
+                new MockTextBuffer(startingText, NodejsConstants.Nodejs, "C:\\app.js"));
             var insertionPoint = new SnapshotPoint(view.TextSnapshot, insertionPosition);
 
             // Setup mock registry service and classification provider for the IsMultilineComment method.

--- a/Nodejs/Tests/Core/MultiLineCommentTests.cs
+++ b/Nodejs/Tests/Core/MultiLineCommentTests.cs
@@ -142,7 +142,7 @@ namespace NodejsTests {
 
             // create the view and request a multiline comment format
             var view = new MockTextView(
-                new MockTextBuffer(startingText, NodejsConstants.Nodejs, "C:\\app.js"));
+                new MockTextBuffer(content: startingText, contentType: NodejsConstants.Nodejs, filename: "C:\\app.js"));
             var insertionPoint = new SnapshotPoint(view.TextSnapshot, insertionPosition);
 
             // Setup mock registry service and classification provider for the IsMultilineComment method.


### PR DESCRIPTION
` new MockTextBuffer(startingText, "C:\\app.js", NodejsConstants.Nodejs));` 
should be 
`new MockTextBuffer(startingText, NodejsConstants.Nodejs, "C:\\app.js"));` 
as the constructor of `MockTestBuffer` is:
`public MockTextBuffer(string content, string contentType, string filename = null)`

This fixes https://github.com/Microsoft/nodejstools/issues/411.