### PR TITLE
Implement constructor MockTextBuffer(string)

### DIFF
--- a/Nodejs/Tests/Core/CommentBlockTests.cs
+++ b/Nodejs/Tests/Core/CommentBlockTests.cs
@@ -17,7 +17,8 @@
 using Microsoft.NodejsTools.Editor.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
-using TestUtilities.Mocks;
+using MockTextView = TestUtilities.Mocks.MockTextView;
+using MockTextBuffer = NodejsTests.Mocks.MockTextBuffer;
 
 namespace NodejsTests {
     [TestClass]

--- a/Nodejs/Tests/Core/Mocks/MockTextBuffer.cs
+++ b/Nodejs/Tests/Core/Mocks/MockTextBuffer.cs
@@ -1,8 +1,20 @@
-﻿using Microsoft.NodejsTools;
+﻿using System.IO;
+using Microsoft.NodejsTools;
 
 namespace NodejsTests.Mocks {
     class MockTextBuffer : TestUtilities.Mocks.MockTextBuffer {
-		public MockTextBuffer(string content) : base(content: content, contentType: NodejsConstants.Nodejs, filename: "file.js") {
+		public MockTextBuffer(string content) : base(content: content, contentType: NodejsConstants.Nodejs) {
+        }
+
+        private static string GetRandomFileNameIfNull(string filename) {
+            if (filename == null) {
+                filename = Path.Combine(TestUtilities.TestData.GetTempPath(), Path.GetRandomFileName(), "file.js");
+            }
+            return filename;
+        }
+
+        public MockTextBuffer(string content, string contentType, string filename = null) : base(content: content,
+            contentType: contentType, filename: MockTextBuffer.GetRandomFileNameIfNull(filename)) {
         }
     }
 }

--- a/Nodejs/Tests/Core/Mocks/MockTextBuffer.cs
+++ b/Nodejs/Tests/Core/Mocks/MockTextBuffer.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.NodejsTools;
+
+namespace NodejsTests.Mocks {
+    class MockTextBuffer : TestUtilities.Mocks.MockTextBuffer {
+		public MockTextBuffer(string content) : base(content: content, contentType: NodejsConstants.Nodejs, filename: "file.js") {
+        }
+    }
+}

--- a/Nodejs/Tests/Core/NodejsTests.csproj
+++ b/Nodejs/Tests/Core/NodejsTests.csproj
@@ -205,6 +205,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Mocks\MockTextBuffer.cs" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes https://github.com/Microsoft/nodejstools/issues/413.

Most TestComment* test cases use the following constructor of MockTextBuffer which by some reason is not implemented :neutral_face:
```C#
MockTextBuffer.cs
31  public MockTextBuffer(string content) {
32  }
```

All TestComment* pass after this change.