### PR TITLE
#63 IntelliSense disappears after closing VS when there is an

### DIFF
--- a/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
@@ -682,7 +682,8 @@ namespace Microsoft.NodejsTools.Intellisense {
             }
 
             foreach (var item in _projectFiles) {
-                if (!File.Exists(item.Value.Entry.FilePath) || (!item.Value.Reloaded && !item.Value.Entry.IsBuiltin)) {
+                if ((!File.Exists(item.Value.Entry.FilePath) || !item.Value.Reloaded)
+                    && !item.Value.Entry.IsBuiltin) {
                     UnloadFile(item.Value.Entry);
                 }
             }


### PR DESCRIPTION
incomplete statement in the editor
- Fixes an issue where we were we were inadvertently unloading
  built-in modules from analysis in some scenarios.

Fix #63