### PR TITLE
#208 Error reading package.json. The file may be parseable JSON but may

### DIFF
--- a/Nodejs/Product/Npm/ReaderPackageJsonSource.cs
+++ b/Nodejs/Product/Npm/ReaderPackageJsonSource.cs
@@ -17,12 +17,21 @@
 using System;
 using System.IO;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NodejsTools.Npm {
     public class ReaderPackageJsonSource : IPackageJsonSource {
         public ReaderPackageJsonSource(TextReader reader) {
             try {
-                Package = JsonConvert.DeserializeObject(reader.ReadToEnd());
+                var text = reader.ReadToEnd();
+                try {
+                    // JsonConvert and JObject.Parse exhibit slightly different behavior,
+                    // so fall back to JObject.Parse if JsonConvert does not properly deserialize
+                    // the object.
+                    Package = JsonConvert.DeserializeObject(text);
+                } catch (ArgumentException) {
+                    Package = JObject.Parse(text);
+                }
             } catch (JsonReaderException jre) {
                 WrapExceptionAndRethrow(jre);
             } catch (JsonSerializationException jse) {

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -46,7 +46,14 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                 // Go through every directory in node_modules, and see if it's required as a top-level dependency
                 foreach (var moduleDir in topLevelDirectories) {
                     if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !_ignoredDirectories.Any(toIgnore => moduleDir.EndsWith(toIgnore))) {
-                        var packageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(moduleDir));
+                        IPackageJson packageJson;
+                        try {
+                            packageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(moduleDir));
+                        } catch (PackageJsonException) {
+                            // Fail gracefully if there was an error parsing the package.json
+                            Debug.Fail("Failed to parse package.json in {0}", moduleDir);
+                            continue;
+                        }
 
                         if (packageJson != null) {
                             if (packageJson.RequiredBy.Count() > 0) {


### PR DESCRIPTION
contain objects with duplicate properties
- fallback to a different parsing method if parsing fails
- handle failures gracefully (that package won't be displayed in sln explorer, but the rest of the packages will be.)

fix #208