### PR TITLE
#455 IntelliSense commits too aggressively when completion is selected

### DIFF
--- a/Nodejs/Product/Nodejs/Intellisense/IntellisenseController.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/IntellisenseController.cs
@@ -647,7 +647,8 @@ namespace Microsoft.NodejsTools.Intellisense {
                         case VSConstants.VSStd2KCmdID.COMPLETEWORD:
                             ForceCompletions = true;
                             try {
-                                TriggerCompletionSession((VSConstants.VSStd2KCmdID)nCmdID == VSConstants.VSStd2KCmdID.COMPLETEWORD);
+                                TriggerCompletionSession((VSConstants.VSStd2KCmdID)nCmdID == VSConstants.VSStd2KCmdID.COMPLETEWORD
+                                    && !NodejsPackage.Instance.IntellisenseOptionsPage.OnlyTabOrEnterToCommit);
                             } finally {
                                 ForceCompletions = false;
                             }


### PR DESCRIPTION
- do not enable COMPLETEWORD when OnlyTabOrEnterToCommit option is
  enabled

fix #455