### PR TITLE
#423 Error retrieving websocket debug proxy information from web.config

### DIFF
--- a/Nodejs/Product/Nodejs/Azure/WebSiteServiceShims.cs
+++ b/Nodejs/Product/Nodejs/Azure/WebSiteServiceShims.cs
@@ -56,10 +56,13 @@ namespace Microsoft.VisualStudio.Web.WindowsAzure.Contracts.Shims {
         }
 
         private object InvokeByName(string name, object[] args) {
+            Type[] types = args != null ?
+                args.Select(arg => { return arg.GetType(); }).ToArray() :
+                new Type[] { };
             var method =
                 new[] { _interface }
                 .Concat(_interface.GetInterfaces())
-                .Select(t => t.GetMethod(name))
+                .Select(t => t.GetMethod(name, types))
                 .Where(m => m != null)
                 .FirstOrDefault();
             if (method == null) {


### PR DESCRIPTION
The issue was that there were two GetSubscription methods by the same name,
which was causing an AmbiguousMatchException. Specify type parameters to
work around this issue.

Fix #423 