### PR TITLE
Allow LiveLogger to be initialized without the need of NodejsPackage.Instance.

### DIFF
--- a/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
+++ b/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
@@ -32,11 +32,19 @@ namespace Microsoft.NodejsTools.Logging {
         private static volatile LiveLogger _instance;
         private static object _loggerLock = new object();
 
-        private NodejsDiagnosticsOptionsPage _diagnosticsOptions = null;
+        private NodejsDiagnosticsOptionsPage _diagnosticsOptions;
 
         private LiveLogger() {
-            if (NodejsPackage.Instance != null) {
-                _diagnosticsOptions = NodejsPackage.Instance.DiagnosticsOptionsPage;
+        }
+
+        private NodejsDiagnosticsOptionsPage DiagnosticsOptions {
+            get {
+                if (_diagnosticsOptions == null) {
+                    if (NodejsPackage.Instance != null) {
+                        _diagnosticsOptions = NodejsPackage.Instance.DiagnosticsOptionsPage;
+                    }
+                }
+                return _diagnosticsOptions;
             }
         }
 
@@ -70,7 +78,7 @@ namespace Microsoft.NodejsTools.Logging {
         private void LogMessage(string message) {
             Debug.WriteLine(message);
 
-            if (_diagnosticsOptions != null && _diagnosticsOptions.IsLiveDiagnosticsEnabled) {
+            if (DiagnosticsOptions != null && DiagnosticsOptions.IsLiveDiagnosticsEnabled) {
                 var pane = OutputWindowRedirector.Get(VisualStudio.Shell.ServiceProvider.GlobalProvider, LiveDiagnosticLogPaneGuid, LiveDiagnosticLogPaneName);
                 if (pane != null) {
                     pane.WriteLine(message);

--- a/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
+++ b/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
@@ -39,10 +39,8 @@ namespace Microsoft.NodejsTools.Logging {
 
         private NodejsDiagnosticsOptionsPage DiagnosticsOptions {
             get {
-                if (_diagnosticsOptions == null) {
-                    if (NodejsPackage.Instance != null) {
-                        _diagnosticsOptions = NodejsPackage.Instance.DiagnosticsOptionsPage;
-                    }
+                if (_diagnosticsOptions == null && NodejsPackage.Instance != null) {
+                    _diagnosticsOptions = NodejsPackage.Instance.DiagnosticsOptionsPage;
                 }
                 return _diagnosticsOptions;
             }


### PR DESCRIPTION
This is done by moving _diagnosticsOptions initialization away from LiveLogger constructor.

Fixes https://github.com/Microsoft/nodejstools/issues/481.