### PR TITLE
Terminate existing node process when project is being disposed.

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
@@ -43,6 +43,10 @@ namespace Microsoft.NodejsTools.Debugger {
             return res;
         }
 
+        public void ResponseToTerminateEvent(object sender, EventArgs e) {
+            this.Kill();
+        }
+
         public void Start() {
             string waitMode;
             if (_waitOnNormal && _waitOnAbnormal) {

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -102,6 +102,7 @@ namespace Microsoft.NodejsTools.Project {
                     NodejsPackage.Instance.GeneralOptionsPage.WaitOnAbnormalExit,
                     NodejsPackage.Instance.GeneralOptionsPage.WaitOnNormalExit
                 );
+                _project.OnDispose += process.ResponseToTerminateEvent;
 
                 if (startBrowser && uri != null) {
                     OnPortOpenedHandler.CreateHandler(

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -956,6 +956,8 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
+        internal event EventHandler OnDispose;
+
         protected override void Dispose(bool disposing) {
             if (disposing) {
                 if (_analyzer != null) {
@@ -979,6 +981,11 @@ namespace Microsoft.NodejsTools.Project {
                 NodejsPackage.Instance.IntellisenseOptionsPage.SaveToDiskChanged -= IntellisenseOptionsPageSaveToDiskChanged;
                 NodejsPackage.Instance.IntellisenseOptionsPage.AnalysisLevelChanged -= IntellisenseOptionsPageAnalysisLevelChanged;
                 NodejsPackage.Instance.IntellisenseOptionsPage.AnalysisLogMaximumChanged -= AnalysisLogMaximumChanged;
+
+                EventHandler handler = OnDispose;
+                if (handler != null) {
+                    handler(this, EventArgs.Empty);
+                }
             }
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Add OnDispose event to NodejsProcessNode and let NodeProcess subscribe to it.

Fixes https://github.com/Microsoft/nodejstools/issues/285.