### PR TITLE
#511 npm tree incomplete when there are duplicate entries

### DIFF
--- a/Nodejs/Product/Npm/SPI/AbstractNodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/AbstractNodeModules.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         private readonly IDictionary<string, IPackage> _packagesByName = new Dictionary<string, IPackage>();
 
         protected virtual void AddModule(IPackage package) {
-            if (!_packagesSorted.Contains(package) && package.Name != null) {
+            if (package.Name != null && !_packagesByName.ContainsKey(package.Name)) {
                 _packagesSorted.Add(package);
                 _packagesByName[package.Name] = package;
             }


### PR DESCRIPTION
- Always add top-level dependencies even if they've already been added
  before

fix #511 