### PR TITLE
Fix test case: TestInsertSnippet 

### DIFF
--- a/Nodejs/Tests/Core.UI/SnippetsTests.cs
+++ b/Nodejs/Tests/Core.UI/SnippetsTests.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Nodejs.Tests.UI {
         [HostType("VSTestHost")]
         public void TestInsertSnippet() {
             using (var solution = BasicProject.Generate().ToVs()) {
-                    
                 foreach (var snippet in BasicSnippets) {
                     TestOneInsertSnippet(solution, snippet, "Nodejs");
 
@@ -215,14 +214,12 @@ namespace Microsoft.Nodejs.Tests.UI {
             foreach (var decl in snippet.Declarations) {
                 Console.WriteLine("Declaration: {0}", decl.Replacement);
                 Keyboard.Type(decl.Replacement);
-                Keyboard.Type("\t");
+                Keyboard.Type("→");
                 server.WaitForText(decl.Expected.Replace("$body$", body));
                 Keyboard.Type("\t");
             }
             Keyboard.Type("\r");
             return server;
         }
-
     }
-
 }


### PR DESCRIPTION
Regarding the following snippet test:
```C#
new Snippet(
   "iife",
    "(function (undefined) {\r\n    $body$\r\n})();\r\n",
    new Declaration("name","(function (name) {\r\n    $body$\r\n})();\r\n")
),
```

Typing the declaration "name" then hit "\t" will trigger auto completion which replaces "name" with "__dirname":

![abc](https://cloud.githubusercontent.com/assets/1707813/10324744/dc867e80-6c40-11e5-93fd-8cb8b711b259.gif)

As we still want "name" in the expected result, change to use right arrow instead of tab "\t" to avoid auto completion.