### PR TITLE
#508 Unhandled System.ArgumentException and

### DIFF
--- a/Nodejs/Product/Analysis/Analysis/AnalysisLog.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLog.cs
@@ -87,19 +87,17 @@ namespace Microsoft.NodejsTools.Analysis {
             int max = MaxItems;
 
             if (max != 0) {
-                lock (LogItems) {
-                    if (LogItems.Count >= max) {
-                        while (LogItems.Count > max) {
-                            // if the queue was set to shrink remove any old items.
-                            LogItems.PopLeft();
-                        }
-                        if (LogIndex >= max) {
-                            LogIndex = 0;
-                        }
-                        LogItems[LogIndex++] = new LogItem { Time = Time, Event = Event, Args = Args };
-                    } else {
-                        LogItems.Append(new LogItem { Time = Time, Event = Event, Args = Args });
+                if (LogItems.Count >= max) {
+                    while (LogItems.Count > max) {
+                        // if the queue was set to shrink remove any old items.
+                        LogItems.PopLeft();
                     }
+                    if (LogIndex >= max) {
+                        LogIndex = 0;
+                    }
+                    LogItems[LogIndex++] = new LogItem { Time = Time, Event = Event, Args = Args };
+                } else {
+                    LogItems.Append(new LogItem { Time = Time, Event = Event, Args = Args });
                 }
             }
         }

--- a/Nodejs/Product/Analysis/Analysis/AnalysisLog.cs
+++ b/Nodejs/Product/Analysis/Analysis/AnalysisLog.cs
@@ -87,17 +87,19 @@ namespace Microsoft.NodejsTools.Analysis {
             int max = MaxItems;
 
             if (max != 0) {
-                if (LogItems.Count >= max) {
-                    while (LogItems.Count > max) {
-                        // if the queue was set to shrink remove any old items.
-                        LogItems.PopLeft();
+                lock (LogItems) {
+                    if (LogItems.Count >= max) {
+                        while (LogItems.Count > max) {
+                            // if the queue was set to shrink remove any old items.
+                            LogItems.PopLeft();
+                        }
+                        if (LogIndex >= max) {
+                            LogIndex = 0;
+                        }
+                        LogItems[LogIndex++] = new LogItem { Time = Time, Event = Event, Args = Args };
+                    } else {
+                        LogItems.Append(new LogItem { Time = Time, Event = Event, Args = Args });
                     }
-                    if (LogIndex >= max) {
-                        LogIndex = 0;
-                    }
-                    LogItems[LogIndex++] = new LogItem { Time = Time, Event = Event, Args = Args };
-                } else {
-                    LogItems.Append(new LogItem { Time = Time, Event = Event, Args = Args });
                 }
             }
         }

--- a/Nodejs/Product/Analysis/Analysis/Analyzer/AnalysisUnit.cs
+++ b/Nodejs/Product/Analysis/Analysis/Analyzer/AnalysisUnit.cs
@@ -32,6 +32,9 @@ namespace Microsoft.NodejsTools.Analysis {
     /// Our dependency tracking scheme works by tracking analysis units - when we add a dependency it is the current
     /// AnalysisUnit which is dependent upon the variable.  If the value of a variable changes then all of the dependent
     /// AnalysisUnit's will be re-enqueued.  This proceeds until we reach a fixed point.
+    /// 
+    /// Note that AnalysisUnit contructors / methods are not threadsafe because we expect there to be many AnalysisUnits,
+    /// and we want to keep things as performant as possible (which means minimizing locking behavior and whatnot.)
     /// </summary>
     [Serializable]
     internal class AnalysisUnit : ISet<AnalysisUnit> {


### PR DESCRIPTION
System.IndexOutOfRangeException during LoadCachedAnalysis
- We were simultaneously mutating the AnalysisLog from two threads. This
  caused various Deque properties like _data, _tail, etc. to get out of
  sync with one another. The fix is to lock LogItems whenever adding new
  events to the log.

fix #508