### PR TITLE
Add $ to IsIdentifierFirstChar list.

### DIFF
--- a/Nodejs/Product/Nodejs/Intellisense/IntellisenseController.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/IntellisenseController.cs
@@ -734,7 +734,7 @@ namespace Microsoft.NodejsTools.Intellisense {
         }
 
         private static bool IsIdentifierFirstChar(char ch) {
-            return ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+            return ch == '_' || ch == '$'|| (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
         }
 
         private static bool IsIdentifierChar(char ch) {


### PR DESCRIPTION
Quick fix for https://github.com/Microsoft/nodejstools/issues/514. Technically JavaScript identifier names can contain many other Unicode characters such as π, Σ, λ. We may want to support these in the future.