### PR TITLE
Fix import wizard tests.

### DIFF
--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -214,8 +214,9 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
                     using (var writer = GetDefaultWriter(projectPath)) {
                         WriteProjectXml(writer, projectPath, sourcePath, filters, startupFile, excludeNodeModules, out projectGuid);
                     }
-                    // Log telemetry
-                    NodejsPackage.Instance.TelemetryLogger.ReportEvent(TelemetryEvents.ProjectImported, TelemetryProperties.ProjectGuid, projectGuid.ToString("B"));
+                    if (NodejsPackage.Instance != null) {
+                        NodejsPackage.Instance.TelemetryLogger.ReportEvent(TelemetryEvents.ProjectImported, TelemetryProperties.ProjectGuid, projectGuid.ToString("B"));
+                    }
                     success = true;
                     return projectPath;
                 } finally {

--- a/Nodejs/Tests/Core/ImportWizardTests.cs
+++ b/Nodejs/Tests/Core/ImportWizardTests.cs
@@ -303,7 +303,7 @@ namespace NodejsTests {
             AssertUtil.ContainsExactly(proj.Descendants(proj.GetName("TypeScriptCompile")).Select(x => x.Attribute("Include").Value),
                 "server.ts");
 
-            Assert.AreEqual("server.js", proj.Descendant("StartupFile").Value);
+            Assert.AreEqual("server.ts", proj.Descendant("StartupFile").Value);
         }
 
         /// <summary>


### PR DESCRIPTION
+ Add null check for NodejsPackage.Instance.
+ In TypeScript project, StartUpFile should be server.ts instead of server.js.

All ImportWizard* test cases should be passing after these changes (9/12 are failing right now).