### PR TITLE
#427 Visual Studio locks up when I create project from Existing Node.js

### DIFF
--- a/Nodejs/Product/Nodejs/Commands/ImportWizardCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/ImportWizardCommand.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
 using System.Windows;
 using Microsoft.NodejsTools.Project;
 using Microsoft.VisualStudio;
@@ -89,7 +91,10 @@ namespace Microsoft.NodejsTools.Commands {
                         } else {
                             statusBar.SetText("An error occurred and your project was not created.");
                         }
-                    }, System.Threading.Tasks.TaskScheduler.FromCurrentSynchronizationContext());
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.HideScheduler,
+                    System.Threading.Tasks.TaskScheduler.FromCurrentSynchronizationContext());
             } else {
                 statusBar.SetText("");
             }

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -207,7 +207,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
             string filters = Filters;
             string startupFile = StartupFile;
             bool excludeNodeModules = ExcludeNodeModules;
-            return Task.Factory.StartNew<string>(() => {
+            return Task.Run<string>(() => {
                 bool success = false;
                 Guid projectGuid;
                 try {


### PR DESCRIPTION
source
- VS was locking up during a call into AppInsights, which has a bug in that
  it is possible to run on the UI Thread. Use HideScheduler to work around
  this issue.

fix #427 