### PR TITLE
#530 Fix MEF errors on Jade files

### DIFF
--- a/Nodejs/Product/Nodejs/ClassifierProviderMetadata.cs
+++ b/Nodejs/Product/Nodejs/ClassifierProviderMetadata.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NodejsTools {
     /// Just used for our MEF import to get the metadata in a strongly
     /// typed way.
     /// </summary>
-    public interface IContentTypeMetadata {
+    public interface IClassifierProviderMetadata {
         IEnumerable<string> ContentTypes { get; }
     }
 }

--- a/Nodejs/Product/Nodejs/ClassifierProviderMetadata.cs
+++ b/Nodejs/Product/Nodejs/ClassifierProviderMetadata.cs
@@ -22,11 +22,7 @@ namespace Microsoft.NodejsTools {
     /// Just used for our MEF import to get the metadata in a strongly
     /// typed way.
     /// </summary>
-    sealed class ClassifierProviderMetadata {
-        public readonly IEnumerable<string> ContentTypes;
-
-        public ClassifierProviderMetadata(IDictionary<string, object> values) {
-            ContentTypes = (IEnumerable<string>)values["ContentTypes"];
-        }
+    public interface IContentTypeMetadata {
+        IEnumerable<string> ContentTypes { get; }
     }
 }

--- a/Nodejs/Product/Nodejs/Jade/Classifier/JadeClassifierProvider.cs
+++ b/Nodejs/Product/Nodejs/Jade/Classifier/JadeClassifierProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NodejsTools.Jade {
             ITextBufferFactoryService bufferFact,
             IContentTypeRegistryService contentTypeService,
             [ImportMany(typeof(ITaggerProvider))]Lazy<ITaggerProvider, TaggerProviderMetadata>[] taggerProviders,
-            [ImportMany(typeof(IClassifierProvider))]Lazy<IClassifierProvider, ClassifierProviderMetadata>[] classifierProviders) {
+            [ImportMany(typeof(IClassifierProvider))]Lazy<IClassifierProvider, IContentTypeMetadata>[] classifierProviders) {
             ClassificationRegistryService = registryService;
             BufferFactoryService = bufferFact;
             JsContentType = contentTypeService.GetContentType(NodejsConstants.JavaScript);

--- a/Nodejs/Product/Nodejs/Jade/Classifier/JadeClassifierProvider.cs
+++ b/Nodejs/Product/Nodejs/Jade/Classifier/JadeClassifierProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NodejsTools.Jade {
             ITextBufferFactoryService bufferFact,
             IContentTypeRegistryService contentTypeService,
             [ImportMany(typeof(ITaggerProvider))]Lazy<ITaggerProvider, TaggerProviderMetadata>[] taggerProviders,
-            [ImportMany(typeof(IClassifierProvider))]Lazy<IClassifierProvider, IContentTypeMetadata>[] classifierProviders) {
+            [ImportMany(typeof(IClassifierProvider))]Lazy<IClassifierProvider, IClassifierProviderMetadata>[] classifierProviders) {
             ClassificationRegistryService = registryService;
             BufferFactoryService = bufferFact;
             JsContentType = contentTypeService.GetContentType(NodejsConstants.JavaScript);


### PR DESCRIPTION
Fixes #530. Not sure what changed in Update1, but apparently this is the MEF pattern to follow, and most importantly - it works. (At least in VS2015 Update1. Still to validate on earlier builds, but this is a common pattern for a while).