### PR TITLE
Fix return value of GetTargetPath target

### DIFF
--- a/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
+++ b/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
@@ -137,14 +137,23 @@
   <Target
     Name="GetTargetPath"
     DependsOnTargets="CoreCompile"
-    Returns="@(ScriptAndWebDeployFiles)"
+    Returns="@(ScriptAndWebDeployFilesWithoutMetadata)"
     >
     <ItemGroup>
       <NodejsBinFiles Include="bin\**\*"  Exclude="bin\Microsoft.NodejsTools.WebRole.dll"/>
       <ScriptAndWebDeployFiles Include="@(NodejsBinFiles->'%(RootDir)%(Directory)%(Filename)%(Extension)')"/>
       <ScriptAndWebDeployFiles Include="@(FilesCopiedToIntermediate->'%(RootDir)%(Directory)%(Filename)%(Extension)')" />
     </ItemGroup>
-    <Message Text="ScriptAndWebDeployFiles=@(ScriptAndWebDeployFiles)"  Importance="low"/>
+
+    <PropertyGroup>
+      <ScriptAndWebDeployFileList>@(ScriptAndWebDeployFiles)</ScriptAndWebDeployFileList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ScriptAndWebDeployFilesWithoutMetadata Include="$(ScriptAndWebDeployFileList)" />
+    </ItemGroup>
+    
+    <Message Text="ScriptAndWebDeployFilesWithoutMetadata=@(ScriptAndWebDeployFilesWithoutMetadata)"  Importance="low"/>
   </Target>
   <Target Name="WatGetTargetFrameworkDirectories" Returns="" />
   <Target Name="BuiltProjectOutputGroupDependencies" Returns="" />


### PR DESCRIPTION
The implementation of Microsoft.NodejsTools.targets has a bug in it that prevents the Node.js project type from being referenced properly by CPS-based projects (Common Project System in VS).  Symptoms include the following:
* An additional project reference shows up programmatically when enumerating the project references of the CPS-based project.  This "project reference" doesn't actually have a source project and just references the Microsoft.NodejsTools.WebRole.dll file in the Node.js project's bin folder.
* The project reference shows up as unresolved in Solution Explorer.

The root of the issue is in the implementation of the GetTargetPath target.  The items returned by that target end up having metadata for OriginalItemSpec.  Having that item metadata set is what causes all the issues.  The fix is to return the same set of files but without the OriginalItemSpec metadata.