### PR TITLE
#566 No IntelliSense after npm install with a new project

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NodejsTools.Project {
             CreateWatcher(Url);
 #endif
             if (Url.Contains(AnalysisConstants.NodeModulesFolder)) {
-                root.DelayedAnalysisQueue.Enqueue(this);
+                root.EnqueueForDelayedAnalysis(this);
             } else {
                 Analyze();
             }
@@ -50,7 +50,8 @@ namespace Microsoft.NodejsTools.Project {
             get {
                 // We analyze if we are a member item or the file is included
                 // Also, it should either be marked as compile or not have an item type name (value is null for node_modules
-                return !ProjectMgr.DelayedAnalysisQueue.Contains(this) &&
+                return !Url.Contains(NodejsConstants.NodeModulesStagingFolder) &&
+                    !ProjectMgr.DelayedAnalysisQueue.Contains(this) &&
                     (!IsNonMemberItem || ProjectMgr.IncludeNodejsFile(this)) &&
                     (ItemNode.ItemTypeName == ProjectFileConstants.Compile || string.IsNullOrEmpty(ItemNode.ItemTypeName));
 


### PR DESCRIPTION
This was due to a race condition with the delayed analysis queue. In
particular, there were some cases where the NodejsFileNode was created
(and therefore an analysis unit enqueued) after the delayed analysis queue
had already finished processing existing entries. This fix simplifies the
logic to make it more deterministic. In particular, get rid of the
separate filewatcher altogether, add entries to the delayed analysis queue
whenever new NodejsFileNodes are created, and restart the idle
node_modules timer after enqueuing the unit.

fix #566 