### PR TITLE
#552 Gruntfile.js failed to load

### DIFF
--- a/Common/Product/SharedProject/FileNode.cs
+++ b/Common/Product/SharedProject/FileNode.cs
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
             for (HierarchyNode n = this.Parent.FirstChild; n != null; n = n.NextSibling) {
                 // TODO: Distinguish between real Urls and fake ones (eg. "References")
-                if (n != this && String.Equals(n.GetEditLabel(), label, StringComparison.OrdinalIgnoreCase)) {
+                if (n != this && String.Equals(n.GetItemName(), label, StringComparison.OrdinalIgnoreCase)) {
                     //A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
                     //If this file or folder does not appear in the Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.
                     throw new InvalidOperationException(SR.GetString(SR.FileOrFolderAlreadyExists, label));
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudioTools.Project {
             // where we get called is when a folder above us gets renamed (in which case our path is invalid)
             HierarchyNode parent = this.Parent;
             while (parent != null && (parent is FolderNode)) {
-                strRelPath = Path.Combine(parent.GetEditLabel(), strRelPath);
+                strRelPath = Path.Combine(parent.GetItemName(), strRelPath);
                 parent = parent.Parent;
             }
 
@@ -614,7 +614,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
         public virtual string FileName {
             get {
-                return this.GetEditLabel();
+                return this.GetItemName();
             }
             set {
                 this.SetEditLabel(value);
@@ -630,7 +630,7 @@ namespace Microsoft.VisualStudioTools.Project {
             bool fileExist = IsFileOnDisk(this.Url);
 
             if (!fileExist && showMessage && !Utilities.IsInAutomationFunction(this.ProjectMgr.Site)) {
-                string message = SR.GetString(SR.ItemDoesNotExistInProjectDirectory, GetEditLabel());
+                string message = SR.GetString(SR.ItemDoesNotExistInProjectDirectory, GetItemName());
                 string title = string.Empty;
                 OLEMSGICON icon = OLEMSGICON.OLEMSGICON_CRITICAL;
                 OLEMSGBUTTON buttons = OLEMSGBUTTON.OLEMSGBUTTON_OK;
@@ -726,7 +726,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     newfilename = relationalName + extension;
                     newfilename = CommonUtils.GetAbsoluteFilePath(Path.GetDirectoryName(childNode.Parent.GetMkDocument()), newfilename);
                 } else {
-                    newfilename = CommonUtils.GetAbsoluteFilePath(Path.GetDirectoryName(childNode.Parent.GetMkDocument()), childNode.GetEditLabel());
+                    newfilename = CommonUtils.GetAbsoluteFilePath(Path.GetDirectoryName(childNode.Parent.GetMkDocument()), childNode.GetItemName());
                 }
 
                 childNode.RenameDocument(childNode.GetMkDocument(), newfilename);

--- a/Common/Product/SharedProject/FolderNode.cs
+++ b/Common/Product/SharedProject/FolderNode.cs
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 return VSConstants.E_FAIL;
             }
 
-            if (filename == GetEditLabel() || Parent.FindImmediateChildByName(filename) == null) {
+            if (filename == GetItemName() || Parent.FindImmediateChildByName(filename) == null) {
                 if (ProjectMgr.QueryFolderAdd(Parent, path)) {
                     Directory.CreateDirectory(path);
                     IsBeingCreated = false;
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     }
                 } catch (IOException ioEx) {
                     // re-throw with a friendly path
-                    throw new IOException(ioEx.Message.Replace(path, GetEditLabel()));
+                    throw new IOException(ioEx.Message.Replace(path, GetItemName()));
                 }
             }
         }
@@ -455,7 +455,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     if (node == null) {
                         child.SetEditLabel(child.GetEditLabel());
                     } else {
-                        node.RenameFolder(node.GetEditLabel());
+                        node.RenameFolder(node.GetItemName());
                     }
                 }
             } finally {
@@ -515,7 +515,7 @@ namespace Microsoft.VisualStudioTools.Project {
         protected override void OnCancelLabelEdit() {
             if (IsBeingCreated) {
                 // finish the creation
-                FinishFolderAdd(GetEditLabel(), true);
+                FinishFolderAdd(GetItemName(), true);
             }
         }
 

--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -590,7 +590,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     break;
 
                 case __VSHPROPID.VSHPROPID_Name:
-                    result = this.GetEditLabel();
+                    result = this.GetItemName();
                     break;
 
                 case __VSHPROPID.VSHPROPID_ExpandByDefault:
@@ -686,7 +686,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
                 case __VSHPROPID.VSHPROPID_SaveName:
                     //SaveName is the name shown in the Save and the Save Changes dialog boxes.
-                    result = this.GetEditLabel();
+                    result = this.GetItemName();
                     break;
 
                 case __VSHPROPID.VSHPROPID_ExtObject:
@@ -874,6 +874,14 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         /// <returns>the node cation</returns>
         public virtual string GetEditLabel() {
+            return GetItemName();
+        }
+
+        /// <summary>
+        /// Returns the underlying file or directory name based on the Url.
+        /// </summary>
+        /// <returns></returns>
+        public string GetItemName() {
             return CommonUtils.GetFileOrDirectoryName(Url);
         }
 
@@ -1000,7 +1008,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         public virtual string GetRelationalName() {
             //Get the first part of the caption
-            string[] partsOfParent = this.GetEditLabel().Split(new string[] { this.NameRelationSeparator }, StringSplitOptions.None);
+            string[] partsOfParent = this.GetItemName().Split(new string[] { this.NameRelationSeparator }, StringSplitOptions.None);
             return partsOfParent[0];
         }
 
@@ -1010,7 +1018,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         /// <returns>The extension</returns>
         public virtual string GetRelationNameExtension() {
-            return this.GetEditLabel().Substring(this.GetEditLabel().IndexOf(this.NameRelationSeparator, StringComparison.Ordinal));
+            return this.GetItemName().Substring(this.GetItemName().IndexOf(this.NameRelationSeparator, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/Common/Product/SharedProject/NodeProperties.cs
+++ b/Common/Product/SharedProject/NodeProperties.cs
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [AlwaysSerialized]
         public virtual string FileName {
             get {
-                return this.HierarchyNode.GetEditLabel();
+                return this.HierarchyNode.GetItemName();
             }
             set {
                 this.HierarchyNode.SetEditLabel(value);
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [Browsable(false)]
         public string Extension {
             get {
-                return Path.GetExtension(this.HierarchyNode.GetEditLabel());
+                return Path.GetExtension(this.HierarchyNode.GetItemName());
             }
         }
 
@@ -444,7 +444,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [ReadOnly(true)]
         public override string FileName {
             get {
-                return this.HierarchyNode.GetEditLabel();
+                return this.HierarchyNode.GetItemName();
             }
             set {
                 throw new InvalidOperationException();
@@ -461,7 +461,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [SRDescriptionAttribute(SR.FileNameDescription)]
         public virtual string FileName {
             get {
-                return this.HierarchyNode.GetEditLabel();
+                return this.HierarchyNode.GetItemName();
             }
         }
 
@@ -728,7 +728,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [SRDescriptionAttribute(SR.FolderNameDescription)]
         public string FolderName {
             get {
-                return this.HierarchyNode.GetEditLabel();
+                return this.HierarchyNode.GetItemName();
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
@@ -743,7 +743,7 @@ namespace Microsoft.VisualStudioTools.Project {
         [AutomationBrowsable(true)]
         public string FileName {
             get {
-                return this.HierarchyNode.GetEditLabel();
+                return this.HierarchyNode.GetItemName();
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -4306,7 +4306,7 @@ If the files in the existing folder have the same names as files in the folder y
                     continue;
                 }
 
-                if (parent.AllChildren.Any(n => candidate == n.GetEditLabel())) {
+                if (parent.AllChildren.Any(n => candidate == n.GetItemName())) {
                     // Cannot create a node if one exists with the same name.
                     continue;
                 }

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -188,12 +188,6 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        public override int SetEditLabel(string label) {
-            var res = base.SetEditLabel(label);
-
-            return res;
-        }
-
         public new NodejsProjectNode ProjectMgr {
             get {
                 return (NodejsProjectNode)base.ProjectMgr;


### PR DESCRIPTION
Previously we were relying on GetEditLabel() to produce the
non-display-name. This was problematic because sometimes GetEditLabel
returns null or produces a NotImplementedException when a node cannot be
renamed. Instead, expose GetItemName, which will always return the
underlying file or directory name based on the Url.

fix #552 