### PR TITLE
#584 VS2015 crashes if change code while debugging w/ Node.js v5

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Commands/ChangeLiveCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/ChangeLiveCommand.cs
@@ -41,7 +41,6 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
 
         public bool Updated { get; private set; }
         public bool StackModified { get; private set; }
-        public bool NeedStepIn { get; private set; }
 
         public override void ProcessResponse(JObject response) {
             base.ProcessResponse(response);
@@ -49,7 +48,6 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
             JToken result = response["body"]["result"];
             Updated = (bool)result["updated"];
             StackModified = (bool)result["stack_modified"];
-            NeedStepIn = (bool)result["stack_update_needs_step_in"];
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -465,14 +465,10 @@ namespace Microsoft.NodejsTools.Debugger {
                 return false;
             }
 
-            // Make step into if required
-            if (changeLiveCommand.NeedStepIn) {
+            // Make step into and update stacktrace if required
+            if (changeLiveCommand.StackModified) {
                 var continueCommand = new ContinueCommand(CommandId, SteppingKind.Into);
                 await TrySendRequestAsync(continueCommand).ConfigureAwait(false);
-            }
-
-            // Update stacktrace if required
-            if (changeLiveCommand.StackModified || changeLiveCommand.NeedStepIn) {
                 await CompleteSteppingAsync(false).ConfigureAwait(false);
             }
 

--- a/Nodejs/Tests/Core/Debugger/Commands/ChangeLiveCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/ChangeLiveCommandTests.cs
@@ -58,7 +58,6 @@ namespace NodejsTests.Debugger.Commands {
             // Assert
             Assert.AreEqual(commandId, changeLiveCommand.Id);
             Assert.IsTrue(changeLiveCommand.Updated);
-            Assert.IsTrue(changeLiveCommand.NeedStepIn);
             Assert.IsTrue(changeLiveCommand.StackModified);
         }
     }


### PR DESCRIPTION
- v8 has recently removed the "stack_update_needs_step_in" property in
  responses. It looks like it always returned the same value as
  "stack_modified" anyways, so go ahead and ignore the property altogether.
  https://codereview.chromium.org/1247363002/diff/1/src/liveedit-debugger.js