### PR TITLE
#604 Runtime syntax error kills Visual Studio

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
@@ -147,7 +147,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                             throw;
                         }
                         LiveLogger.WriteLine("Connection attempt {0} failed with: {1}", connection_attempts, ex);
-                        if (connection_attempts >= MAX_ATTEMPTS && !_isClosed) {
+                        if (_isClosed || connection_attempts >= MAX_ATTEMPTS) {
                             throw;
                         }
                         else {


### PR DESCRIPTION
- we should be exiting the debug-connect loop when the connection is closed.

fix #604 