### PR TITLE
#666 Disable failing tests to make it easier to detect regressions

### DIFF
--- a/Common/Tests/SharedProjectTests/BasicProjectTests.cs
+++ b/Common/Tests/SharedProjectTests/BasicProjectTests.cs
@@ -1186,6 +1186,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 #endif
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void OpenCommandHere() {
@@ -1546,6 +1547,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DeleteFolderWithReadOnlyFile() {

--- a/Common/Tests/SharedProjectTests/DragDropCopyCutPaste.cs
+++ b/Common/Tests/SharedProjectTests/DragDropCopyCutPaste.cs
@@ -34,12 +34,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             AssertListener.Initialize();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultiPasteKeyboard() {
             MultiPaste(CopyByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultiPasteMouse() {
@@ -99,6 +101,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Cut item, paste into folder, paste into top-level, 2nd paste shouldn’t do anything
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void CutPastePasteItem() {
@@ -136,6 +139,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Cut item, rename it, paste into top-level, check error message
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void CutRenamePaste() {
@@ -172,6 +176,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Cut item, rename it, paste into top-level, check error message
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void CutDeletePaste() {
@@ -354,6 +359,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Copy a file node, drag and drop a different file, paste the node, should succeed
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopiedBeforeDragPastedAfterDrop() {
@@ -397,12 +403,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragToAnotherProjectKeyboard() {
             DragToAnotherProject(CopyByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragToAnotherProjectMouse() {
@@ -478,6 +486,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Drag and drop a folder onto itself, nothing should happen
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void DragFolderOntoSelf() {
@@ -543,6 +552,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// Move a file to a location where A file with the same name now already exists.  We should get an overwrite
         /// dialog, and after answering yes to overwrite the file should be moved.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CutFileReplace() {
@@ -574,6 +584,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void CutFolderAndFile() {
@@ -639,6 +650,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// Drag and drop a folder onto itself, nothing should happen
         ///     Cannot move 'DragFolderAndFileToSameFolder'. The destination folder is the same as the source folder.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragFolderAndFileOntoSelf() {
@@ -708,6 +720,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyDeletePaste() {
@@ -830,12 +843,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyDuplicateFolderNameKeyboard() {
             CopyDuplicateFolderName(CopyByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyDuplicateFolderNameMouse() {
@@ -922,6 +937,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveReverseCrossHierarchyKeyboard() {
@@ -1332,6 +1348,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// Drag item from our project to other project, copy
         /// Drag item from other project to our project, still copy back
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveDoubleCrossHierarchy() {
@@ -1421,6 +1438,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Drag item from another project, drag same item again, prompt to overwrite, say yes, only one item should be in the hierarchy
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void CopyFolderMissingItem() {
@@ -1515,6 +1533,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// 
         /// http://pytools.codeplex.com/workitem/2609
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Mock")]
         [HostType("VSTestHost")]
         public void MoveFolderWithContents() {
@@ -1635,12 +1654,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(2), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyFileFromFolderToLinkedFolderKeyboard() {
             CopyFileFromFolderToLinkedFolder(CopyByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(2), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyFileFromFolderToLinkedFolderMouse() {

--- a/Common/Tests/SharedProjectTests/LinkedFileTests.cs
+++ b/Common/Tests/SharedProjectTests/LinkedFileTests.cs
@@ -333,6 +333,7 @@ namespace VisualStudioToolsUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveLinkedNodeFileExistsButNotInProject() {
@@ -434,6 +435,7 @@ namespace VisualStudioToolsUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SaveAsCreateFileNewDirectory() {
@@ -460,6 +462,7 @@ namespace VisualStudioToolsUITests {
         /// <summary>
         /// Adding a duplicate link to the same item
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddExistingItem() {
@@ -533,6 +536,7 @@ namespace VisualStudioToolsUITests {
         /// <summary>
         /// Adding new linked item when file of same name exists (when the file only exists on disk)
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddExistingItemAndFileByNameExistsOnDiskButNotInProject() {
@@ -557,6 +561,7 @@ namespace VisualStudioToolsUITests {
         /// <summary>
         /// Adding new linked item when file of same name exists (both in the project and on disk)
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddExistingItemAndFileByNameExistsOnDiskAndInProject() {
@@ -581,6 +586,7 @@ namespace VisualStudioToolsUITests {
         /// <summary>
         /// Adding new linked item when file of same name exists (in the project, but not on disk)
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddExistingItemAndFileByNameExistsInProjectButNotOnDisk() {
@@ -605,6 +611,7 @@ namespace VisualStudioToolsUITests {
         /// Adding new linked item when the file lives in the project dir but not in the directory we selected
         /// Add Existing Item from.  We should add the file to the directory where it lives.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddExistingItemAsLinkButFileExistsInProjectDirectory() {
@@ -628,6 +635,7 @@ namespace VisualStudioToolsUITests {
         /// <summary>
         /// Reaming the file name in the Link attribute is ignored.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenamedLinkedFile() {
@@ -691,6 +699,7 @@ namespace VisualStudioToolsUITests {
         /// Test linked files with a project home set (done by save as in this test)
         /// https://nodejstools.codeplex.com/workitem/1511
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestLinkedWithProjectHome() {

--- a/Common/Tests/SharedProjectTests/NewDragDropCopyCutPaste.cs
+++ b/Common/Tests/SharedProjectTests/NewDragDropCopyCutPaste.cs
@@ -27,12 +27,14 @@ using Mouse = TestUtilities.UI.Mouse;
 namespace Microsoft.VisualStudioTools.SharedProjectTests {
     [TestClass]
     public class NewDragDropCopyCutPaste : SharedProjectTest {
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveToMissingFolderKeyboard() {
             MoveToMissingFolder(MoveByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveToMissingFolderMouse() {
@@ -248,12 +250,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VsTestHost")]
         public void MoveDuplicateFileNamesFoldersSkipOneKeyboard() {
             MoveDuplicateFileNamesFoldersSkipOne(MoveByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VsTestHost")]
         public void MoveDuplicateFileNamesFoldersSkipOneMouse() {
@@ -483,12 +487,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(2), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveFileFromFolderToLinkedFolderKeyboard() {
             MoveFileFromFolderToLinkedFolder(MoveByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(2), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveFileFromFolderToLinkedFolderMouse() {

--- a/Common/Tests/SharedProjectTests/ScriptProjectTests.cs
+++ b/Common/Tests/SharedProjectTests/ScriptProjectTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// Renaming the folder containing the startup script should update the startup script
         /// https://nodejstools.codeplex.com/workitem/476
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenameStartupFileFolder() {
@@ -70,6 +71,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenameStartupFile() {

--- a/Common/Tests/SharedProjectTests/ShowAllFiles.cs
+++ b/Common/Tests/SharedProjectTests/ShowAllFiles.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             AssertListener.Initialize();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesToggle() {
@@ -173,6 +174,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesIncludeExclude() {
@@ -779,6 +781,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// https://pytools.codeplex.com/workitem/1996
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllExcludeSelected() {
@@ -842,6 +845,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// 
         /// https://nodejstools.codeplex.com/workitem/380
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesRapidChanges() {
@@ -875,6 +879,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// Creating & deleting and then re-creating files rapidly should have the files be 
         /// present in solution explorer.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesRapidChanges2() {
@@ -908,12 +913,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesCopyExcludedFolderWithItemByKeyboard() {
             ShowAllFilesCopyExcludedFolderWithItem(DragDropCopyCutPaste.CopyByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesCopyExcludedFolderWithItemByMouse() {
@@ -956,12 +963,14 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesMoveExcludedItemToExcludedFolderByKeyboard() {
             ShowAllFilesMoveExcludedItemToExcludedFolder(DragDropCopyCutPaste.MoveByKeyboard);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ShowAllFilesMoveExcludedItemToExcludedFolderByMouse() {

--- a/Common/Tests/SharedProjectTests/SourceControl.cs
+++ b/Common/Tests/SharedProjectTests/SourceControl.cs
@@ -107,6 +107,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewItem() {
@@ -175,6 +176,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void IncludeInProject() {
@@ -214,6 +216,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RemoveItem() {
@@ -257,6 +260,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Verify we get called w/ a project which does have source control enabled.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void BasicSourceControl() {
@@ -305,6 +309,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Verify the glyph change APIs update the glyphs appropriately
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SourceControlGlyphChanged() {
@@ -357,6 +362,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Verify we don't get called for a project which doesn't have source control enabled.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SourceControlNoControl() {
@@ -393,6 +399,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// 
         /// https://pytools.codeplex.com/workitem/1417
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SourceControlExcludedFilesNotPresent() {
@@ -422,6 +429,7 @@ namespace Microsoft.VisualStudioTools.SharedProjectTests {
         /// <summary>
         /// Verify we get called w/ a project which does have source control enabled.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SourceControlRenameFolder() {

--- a/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
@@ -482,6 +482,7 @@ z = y.abc;
         /// <summary>
         /// Currently failing because object literal {value: copied[propName]} gets merged resulting in shared types
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0)]
         public void FailingTestDefinePropertyLoop() {
             string code = @"
@@ -572,6 +573,7 @@ xyz = new Y();";
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(2)]
         public void Failing_TestThis() {
             var code = @"function SimpleTest(x, y) {
@@ -744,6 +746,7 @@ abc(abc);
             return sigs.ToArray();
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestJSDoc() {
             string code = @"
@@ -1031,6 +1034,7 @@ x = f.abc;
         /// object it's reading from, and when a new property is created
         /// we need to enqueue the callers.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestDefinePropertiesDependencies() {
             string code = @"
@@ -1450,6 +1454,7 @@ var z = y.abc";
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(2)]
         public void FailingTestForInLoop2() {
             var analysis = ProcessText("for(x in ['a','b','c']) { }");

--- a/Nodejs/Tests/AnalysisTests/ParserTests.cs
+++ b/Nodejs/Tests/AnalysisTests/ParserTests.cs
@@ -60,6 +60,7 @@ namespace AnalysisTests {
             Assert.IsTrue(span.Equals(span2));
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestFunctionRecovery() {
             const string code = @"
@@ -441,6 +442,7 @@ with abc {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void ErrorArrayLiteralBad() {
             const string code = @"
@@ -4080,6 +4082,7 @@ false
         /// HexDigit :: one of
         ///     0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestNumericLiterals() {
             const string numbers = @"

--- a/Nodejs/Tests/AnalysisTests/ScannerTests.cs
+++ b/Nodejs/Tests/AnalysisTests/ScannerTests.cs
@@ -50,6 +50,7 @@ namespace AnalysisTests {
             Assert.AreEqual(scanner.CurrentState.GetHashCode(), 2);
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestOperators() {
             var code = @"x %= 1
@@ -318,6 +319,7 @@ x /= 1
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestUnterminatedString() {
             var code = @"'abc
@@ -467,6 +469,7 @@ x /= 1
 
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestMultilineComment() {
             var code = @"/*
@@ -480,6 +483,7 @@ hello world
 
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestMultilineCommentUnterminated() {
             var code = @"/*

--- a/Nodejs/Tests/Core.UI/AzureProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/AzureProjectTests.cs
@@ -104,24 +104,28 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UpdateWebRoleServiceDefinitionInVS() {
             CloudProjectTest("Web", false);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UpdateWorkerRoleServiceDefinitionInVS() {
             CloudProjectTest("Worker", false);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UpdateWebRoleServiceDefinitionInVSDocumentOpen() {
             CloudProjectTest("Web", true);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UpdateWorkerRoleServiceDefinitionInVSDocumentOpen() {

--- a/Nodejs/Tests/Core.UI/BasicIntellisense.cs
+++ b/Nodejs/Tests/Core.UI/BasicIntellisense.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// 
         /// Make sure Ctrl-Space works
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CtrlSpace() {
@@ -55,6 +56,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// 
         /// Make sure we get intellisense for process.stdin
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ProcessStdinIntellisense() {
@@ -79,6 +81,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// 
         /// Make sure reference path intellisense works
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ReferenceIntellisense() {

--- a/Nodejs/Tests/Core.UI/BasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/BasicProjectTests.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ProjectAddFolder() {
@@ -227,6 +228,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAddExistingFolder() {
@@ -263,6 +265,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAddExistingFolderProject() {
@@ -287,6 +290,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAddExistingFolderDebugging() {
@@ -435,6 +439,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ProjectRenameAndDeleteItem() {
@@ -510,6 +515,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAutomationProperties() {
@@ -579,6 +585,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAutomationProject() {
@@ -688,6 +695,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// Opens a project w/ a reference to a .NET assembly (not a project).  Makes sure we get completion against the assembly, changes the assembly, rebuilds, makes
         /// sure the completion info changes.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddFolderExists() {
@@ -791,6 +799,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyAndPasteFolder() {
@@ -834,6 +843,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyAndPasteEmptyFolder() {
@@ -887,6 +897,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Verify we can copy a folder with multiple items in it.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyFolderWithMultipleItems() {
@@ -915,6 +926,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LoadProjectWithDuplicateItems() {
@@ -935,6 +947,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyFullPath() {

--- a/Nodejs/Tests/Core.UI/DebuggerUITests.cs
+++ b/Nodejs/Tests/Core.UI/DebuggerUITests.cs
@@ -106,6 +106,7 @@ process.exit(" + exitCode + ");"),
         /// Verifies that we can launch node.exe in a way where debugging doesn't
         /// start (in this case -v is passed to display the version).  VS shouldn't crash.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Debugging UI")]
         [HostType("VSTestHost")]
         public void TestNoDebugging() {

--- a/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             NodejsTestData.Deploy();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewTypeScriptItem() {
@@ -195,6 +196,7 @@ require('fs').writeFileSync('{0}', process.env.fob + process.env.bar + process.e
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestProjectProperties() {

--- a/Nodejs/Tests/Core.UI/OutliningTests.cs
+++ b/Nodejs/Tests/Core.UI/OutliningTests.cs
@@ -47,6 +47,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         [HostType("VSTestHost")]
         public void OutliningToplevelFunctionDefinitions() {
@@ -61,6 +62,7 @@ namespace NodejsTests {
 }"));
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         [HostType("VSTestHost")]
         public void OutliningNestedFunctionDefinitions() {

--- a/Nodejs/Tests/Core.UI/ProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/ProjectTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/270
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSnippetsDisabled() {
@@ -78,6 +79,7 @@ http.createServer(function (req, res) {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNoAutoFormattingEnter() {
@@ -103,6 +105,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNoAutoFormattingCloseFunction() {
@@ -129,6 +132,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNoAutoFormattingPaste() {
@@ -155,6 +159,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNoReferences() {
@@ -168,6 +173,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void GlobalIntellisense() {
@@ -187,6 +193,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireIntellisenseExpanded() {
@@ -264,6 +271,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void GlobalIntellisenseProjectReload() {
@@ -319,6 +327,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UserModule() {
@@ -337,6 +346,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewItem() {
@@ -357,6 +367,7 @@ http.createServer(function (req, res) {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void EnterCompletion() {
@@ -386,6 +397,7 @@ http.createServer(function (req, res) {
         /// <summary>
         /// Tests completions against builtin node modules.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void ModuleCompletions() {
@@ -422,6 +434,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNewProject() {
@@ -454,6 +467,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNewAzureProject() {
@@ -485,6 +499,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestAutomationProject() {
@@ -528,6 +543,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SetAsStartupFile() {
@@ -597,6 +613,7 @@ sd.StringDecoder
             return app.GetDocument(item.Document.FullName);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestProjectProperties() {
@@ -626,6 +643,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestBrowserLaunch() {
@@ -776,6 +794,7 @@ sd.StringDecoder
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestLongPathCheck() {

--- a/Nodejs/Tests/Core.UI/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core.UI/ReplWindowTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             AssertListener.Initialize();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestErrorNewLine() {
@@ -47,6 +48,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestColorOutput() {
@@ -79,6 +81,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestStdErrIsRed() {
@@ -106,6 +109,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestCompletion() {
@@ -117,6 +121,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestNoSpecialCommandCompletion() {

--- a/Nodejs/Tests/Core.UI/RequireIntellisense.cs
+++ b/Nodejs/Tests/Core.UI/RequireIntellisense.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             AssertListener.Initialize();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void InSubFolder() {
@@ -85,6 +86,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void BasicRequireCompletions() {
@@ -164,6 +166,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void BasicRequireCompletionsQuotes() {
@@ -256,6 +259,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void BasicRequireCompletionsDoubleQuotes() {
@@ -348,6 +352,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireKeyboardCompletionBraceCompletionOff() {
@@ -408,6 +413,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireKeyboardCompletionBraceCompletionOn() {
@@ -464,6 +470,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireBuiltinModules() {
@@ -500,6 +507,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CloseParenCommits() {
@@ -517,6 +525,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UserModule() {
@@ -536,6 +545,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void UserModuleInFolder() {
@@ -555,6 +565,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CloseQuoteDoesntCommit() {
@@ -574,6 +585,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterOperator() {
@@ -593,6 +605,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterOpenParen() {
@@ -612,6 +625,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterComma() {
@@ -631,6 +645,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterAssignment() {
@@ -648,6 +663,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterReturn() {
@@ -665,6 +681,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterSemiColon() {
@@ -682,6 +699,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterKeywordNoCompletions() {
@@ -697,6 +715,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterDotNoCompletions() {
@@ -711,6 +730,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RequireAfterContinuedMultiLineStringNoCompletions() {
@@ -728,6 +748,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// 
         /// Make sure adding a module externally gets picked up
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddModuleExternally() {
@@ -759,6 +780,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// We should include submodules (like quox) and not just the top-level
         /// module when index.js is present.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SubmodulesFiles() {
@@ -780,6 +802,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SubmodulesFiles2() {

--- a/Nodejs/Tests/Core.UI/SmartIndent.cs
+++ b/Nodejs/Tests/Core.UI/SmartIndent.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SmartIndentBug3() {
@@ -133,6 +134,7 @@ b = c;
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SmartIndentBasic() {

--- a/Nodejs/Tests/Core.UI/SnippetsTests.cs
+++ b/Nodejs/Tests/Core.UI/SnippetsTests.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             )
         };
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestInsertSnippet() {
@@ -91,6 +92,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSelectedIndented() {
@@ -110,6 +112,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSurroundWithSnippet() {
@@ -122,6 +125,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSelected() {
@@ -167,6 +171,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             return VerifySnippet(snippet, body, server);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestBasicSnippetsTab() {
@@ -189,6 +194,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             return VerifySnippet(snippet, "", server);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSurroundWithMultiline() {

--- a/Nodejs/Tests/Core.UI/UITests.cs
+++ b/Nodejs/Tests/Core.UI/UITests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         }
 #endif
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AbsolutePaths() {
@@ -102,6 +103,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MoveStartupFile() {
@@ -128,6 +130,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyPasteFile() {
@@ -156,6 +159,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyPasteRenameFile() {
@@ -207,6 +211,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DeleteFile() {
@@ -233,6 +238,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewFolder() {
@@ -267,6 +273,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a new folder which fits exactly w/ no space left in the path name
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewFolderLongPathBoundary() {
@@ -300,6 +307,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a new folder with a path that's too long, typing a new path.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewFolderLongPathTooLong() {
@@ -328,6 +336,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a folder with a path that's too long using the default provided folder name.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewFolderLongPathTooLongCancelEdit() {
@@ -355,6 +364,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a folder with a path that's too long using the default provided folder name.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewItemLongPathBoundary() {
@@ -380,6 +390,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a folder with a path that's too long using the default provided folder name.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewItemLongPathTooLong() {
@@ -404,6 +415,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Adds a folder with a path that's too long using the default provided folder name.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DeleteLockedFolder() {
@@ -456,6 +468,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             return app.OpenProject(Path.Combine(testDir, "LongFileNames.sln"));
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void AddNewFolderNested() {
@@ -504,6 +517,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenameProjectToExisting() {
@@ -545,6 +559,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenameItemsTest() {
@@ -618,6 +633,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CrossProjectCopy() {
@@ -642,6 +658,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CrossProjectCutPaste() {
@@ -667,6 +684,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CutPaste() {
@@ -692,6 +710,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void CopyFolderOnToSelf() {
@@ -712,6 +731,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragDropTest() {
@@ -739,6 +759,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Drag a file onto another file in the same directory, nothing should happen
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragDropFileToFileTest() {
@@ -767,6 +788,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// <summary>
         /// Drag a file onto it's containing folder, nothing should happen
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragDropFileToContainingFolderTest() {
@@ -791,6 +813,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragLeaveTest() {
@@ -821,6 +844,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void DragLeaveFolderTest() {
@@ -851,6 +875,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultiSelectCopyAndPaste() {
@@ -882,6 +907,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TransferItem() {
@@ -916,6 +942,7 @@ namespace Microsoft.Nodejs.Tests.UI {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void SaveAs() {

--- a/Nodejs/Tests/Core/AzureTests.cs
+++ b/Nodejs/Tests/Core/AzureTests.cs
@@ -29,6 +29,7 @@ using TestUtilities;
 namespace NodejsTests {
     [TestClass]
     public class AzureTests {
+        [Ignore]
         [TestMethod, Priority(0)]
         public void UpdateWorkerRoleServiceDefinitionTest() {
             var doc = new XmlDocument();

--- a/Nodejs/Tests/Core/CommentBlockTests.cs
+++ b/Nodejs/Tests/Core/CommentBlockTests.cs
@@ -22,6 +22,7 @@ using TestUtilities.Mocks;
 namespace NodejsTests {
     [TestClass]
     public class CommentBlockTests {
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentCurrentLine() {
             var view = new MockTextView(
@@ -45,6 +46,7 @@ console.log('Goodbye');",
                  view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestUnCommentCurrentLine() {
             var view = new MockTextView(
@@ -68,6 +70,7 @@ console.log('Goodbye');",
                 view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestComment() {
             var view = new MockTextView(
@@ -86,6 +89,7 @@ console.log('Goodbye');"));
                  view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentEmptyLine() {
             var view = new MockTextView(
@@ -106,6 +110,7 @@ console.log('Goodbye');"));
                  view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentWhiteSpaceLine() {
             var view = new MockTextView(
@@ -126,6 +131,7 @@ console.log('Goodbye');"));
                  view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentIndented() {
             var view = new MockTextView(
@@ -153,6 +159,7 @@ console.log('Goodbye');"));
                     view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentIndentedBlankLine() {
             var view = new MockTextView(
@@ -182,6 +189,7 @@ console.log('Goodbye');"));
                     view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentBlankLine() {
             var view = new MockTextView(
@@ -199,6 +207,7 @@ console.log('bye');",
              view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentIndentedWhiteSpaceLine() {
             var view = new MockTextView(
@@ -228,6 +237,7 @@ console.log('bye');",
                     view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestUnCommentIndented() {
             var view = new MockTextView(
@@ -255,6 +265,7 @@ console.log('bye');",
                     view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestUnComment() {
             var view = new MockTextView(
@@ -273,6 +284,7 @@ console.log('Goodbye');",
                 view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentStartOfLastLine() {
             var view = new MockTextView(
@@ -291,6 +303,7 @@ console.log('Goodbye');",
                 view.TextBuffer.CurrentSnapshot.GetText());
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestCommentAfterCodeIsNotUncommented() {
             var view = new MockTextView(

--- a/Nodejs/Tests/Core/Debugger/DataTipTests.cs
+++ b/Nodejs/Tests/Core/Debugger/DataTipTests.cs
@@ -81,6 +81,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
                 new { actualSpan.iStartLine, actualSpan.iStartIndex, actualSpan.iEndLine, actualSpan.iEndIndex });
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipStandAloneVariable() {
             const string code = "start; middle; end";
@@ -92,6 +93,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?<=mid)(?=dle)", "middle");
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipSelection() {
             const string code = "abc";
@@ -104,6 +106,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?<=a)bc", "abc");
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipPropertyAccess() {
             const string code = "a.b[1-'2'].c";
@@ -114,6 +117,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?=c)", "a.b[1-'2'].c");
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipParens() {
             const string code = "((a-b)*(c-d))";
@@ -123,6 +127,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?<=d\))", code);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipNoSideEffects() {
             const string code = "(1 - f(x).y - 2).z";
@@ -136,6 +141,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?=z)", null);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipSingleLineComment() {
             const string code = "/*a*/b/*c*/.d";
@@ -146,6 +152,7 @@ namespace NodejsTests.Debugger.FileNameMapping {
             DataTipTest(code, @"(?=d)", "b/*c*/.d");
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DataTipMultiLineComment() {
             const string code = "//a\r\nb//c\r\n.d";

--- a/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
+++ b/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
@@ -162,6 +162,7 @@ namespace NodejsTests.Debugger {
 
         #region Eval Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void EvalTests() {
             TestDebuggerSteps(
@@ -195,6 +196,7 @@ namespace NodejsTests.Debugger {
 
         #region Locals Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void LocalsTest() {
             LocalsTest(
@@ -220,6 +222,7 @@ namespace NodejsTests.Debugger {
         /// <summary>
         /// http://nodejstools.codeplex.com/workitem/13
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void SpecialNumberLocalsTest() {
             LocalsTest(
@@ -231,6 +234,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void GlobalsTest() {
             LocalsTest(
@@ -244,6 +248,7 @@ namespace NodejsTests.Debugger {
 
         #region Stepping Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void StepTest() {
             // Bug 509: http://pytools.codeplex.com/workitem/509
@@ -437,6 +442,7 @@ namespace NodejsTests.Debugger {
         }
 
         // F10/F11 startup
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Startup_BreakOnEntryPoint() {
             TestDebuggerSteps(
@@ -449,6 +455,7 @@ namespace NodejsTests.Debugger {
         }
 
         // F5/F10/F11 startup
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Startup_BreakOnEntryPointBreakPoint() {
             TestDebuggerSteps(
@@ -476,6 +483,7 @@ namespace NodejsTests.Debugger {
         }
 
         // F10/F11 startup
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Startup_BreakOnEntryPointTracePoint() {
             TestDebuggerSteps(
@@ -503,6 +511,7 @@ namespace NodejsTests.Debugger {
         }
 
         // F5 startup
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Startup_BreakOnEntryPointBreakOn() {
             TestDebuggerSteps(
@@ -523,6 +532,7 @@ namespace NodejsTests.Debugger {
         //[TestMethod, Priority(0)]
         //public void Running_Simple() { }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Running_AccrossBreakPoint() {
             TestDebuggerSteps(
@@ -553,6 +563,7 @@ namespace NodejsTests.Debugger {
 
         #region Stepping Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_Basic() {
             TestDebuggerSteps(
@@ -585,6 +596,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AccrossBreakPoints() {
             TestDebuggerSteps(
@@ -633,6 +645,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AccrossTracePoints() {
             TestDebuggerSteps(
@@ -687,6 +700,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AcrossCaughtExceptions() {
             TestDebuggerSteps(
@@ -709,6 +723,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void DebuggingDownloaded() {
             TestDebuggerSteps(
@@ -747,6 +762,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Breaking_InFunctionPassedFewerThanTakenParms() {
             TestDebuggerSteps(
@@ -762,6 +778,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_IntoFunctionPassedFewerThanTakenParms() {
             TestDebuggerSteps(
@@ -854,6 +871,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpoints() {
             TestDebuggerSteps(
@@ -866,6 +884,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpoints2() {
             TestDebuggerSteps(
@@ -881,6 +900,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpoints3() {
             TestDebuggerSteps(
@@ -894,6 +914,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointsConditionals() {
             TestDebuggerSteps(
@@ -925,6 +946,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointEnable() {
             TestDebuggerSteps(
@@ -941,6 +963,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointRemove() {
             TestDebuggerSteps(
@@ -983,6 +1006,7 @@ namespace NodejsTests.Debugger {
         //    process.WaitForExit();
         //}
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointsBreakOn() {
             // BreakOnKind.Always
@@ -1162,6 +1186,7 @@ namespace NodejsTests.Debugger {
             Assert.IsTrue(exceptionHit);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointsHitCount() {
             TestDebuggerSteps(
@@ -1181,6 +1206,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointInvalidLineFixup() {
             TestDebuggerSteps(
@@ -1397,16 +1423,19 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointPredicatedEntrypointNoFixup() {
             TestBreakpointPredicatedEntrypoint("BreakpointTest.js", targetBreakpoint: 0, expectedHit: 0);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointPredicatedEntrypointBlankLineFixup() {
             TestBreakpointPredicatedEntrypoint("FixupBreakpointOnBlankLine.js", targetBreakpoint: 0, expectedHit: 2);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestBreakpointPredicatedEntrypointCommentFixup() {
             TestBreakpointPredicatedEntrypoint("FixupBreakpointOnComment.js", targetBreakpoint: 0, expectedHit: 1);
@@ -1436,6 +1465,7 @@ namespace NodejsTests.Debugger {
 
         #region Exception Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestExceptions() {
             // Well-known, handled
@@ -1547,6 +1577,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestExceptionsTypes() {
             TestExceptions(
@@ -1570,6 +1601,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestComplexExceptions() {
             TestExceptions(
@@ -1592,6 +1624,7 @@ namespace NodejsTests.Debugger {
         /// Exceptions shouldnt't be reported while calling Require, for alpha this means we don't break on ENOENT
         /// by default.
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestRequireExceptions() {
             TestExceptions(
@@ -1607,6 +1640,7 @@ namespace NodejsTests.Debugger {
         /// 
         /// Test handling of exceptions in evaluated code
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestExceptionInEvaluatedCode() {
             TestDebuggerSteps(
@@ -1626,6 +1660,7 @@ namespace NodejsTests.Debugger {
 
         #region Deep Callstack Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AccrossDeepThrow() {
             TestDebuggerSteps(
@@ -1640,6 +1675,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AccrossDeepTracePoint() {
             TestDebuggerSteps(
@@ -1655,6 +1691,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void Stepping_AccrossDeepFixedUpTracePoint() {
             TestDebuggerSteps(
@@ -1674,6 +1711,7 @@ namespace NodejsTests.Debugger {
 
         #region Module Load Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestModuleLoad() {
             TestModuleLoad(
@@ -1721,6 +1759,7 @@ namespace NodejsTests.Debugger {
 
         #region Exit Code Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestExitNormal() {
             TestDebuggerSteps(
@@ -1732,6 +1771,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestExitException() {
             TestDebuggerSteps(
@@ -1761,6 +1801,7 @@ namespace NodejsTests.Debugger {
 
         #region Argument Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TestScriptArguments() {
             TestDebuggerSteps(
@@ -1816,6 +1857,7 @@ namespace NodejsTests.Debugger {
 
         #region TypeScript Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TypeScript_Stepping_Basic() {
             TestDebuggerSteps(
@@ -1919,6 +1961,7 @@ namespace NodejsTests.Debugger {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/1515
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TypeScript_Stepping_Basic_RedirectDir() {
             TestDebuggerSteps(
@@ -2002,6 +2045,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TypeScript_Break_On_First_Line() {
             TestDebuggerSteps(
@@ -2022,6 +2066,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void TypeScript_Inheiritance_BreakInClass() {
             TestDebuggerSteps(

--- a/Nodejs/Tests/Core/JadeTests.cs
+++ b/Nodejs/Tests/Core/JadeTests.cs
@@ -35,106 +35,127 @@ namespace NodejsTests {
             NodejsTestData.Deploy();
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File01() {
             Tokenize("001.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File02() {
             Tokenize("002.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File03() {
             Tokenize("003.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File04() {
             Tokenize("004.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File05() {
             Tokenize("005.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File06() {
             Tokenize("006.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File07() {
             Tokenize("007.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File08() {
             Tokenize("008.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File09() {
             Tokenize("009.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File10() {
             Tokenize("010.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File11() {
             Tokenize("011.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File12() {
             Tokenize("012.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File13() {
             Tokenize("013.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File14() {
             Tokenize("014.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File15() {
             Tokenize("015.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File16() {
             Tokenize("016.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File17() {
             Tokenize("017.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File18() {
             Tokenize("018.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File19() {
             Tokenize("019.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File20() {
             Tokenize("020.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File21() {
             Tokenize("021.jade");
@@ -145,6 +166,7 @@ namespace NodejsTests {
             Tokenize("022.jade");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void JadeTokenizerTest_File23() {
             Tokenize("023.jade");

--- a/Nodejs/Tests/Core/ProjectUpgradeTests.cs
+++ b/Nodejs/Tests/Core/ProjectUpgradeTests.cs
@@ -37,6 +37,7 @@ namespace NodejsTests {
             NodejsTestData.Deploy();
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Core"), Priority(0)]
         public void UpgradeEnvironmentVariables() {
             var factory = new BaseNodeProjectFactory(null);

--- a/Nodejs/Tests/Core/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core/ReplWindowTests.cs
@@ -122,6 +122,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestConsoleDir() {
             using (var eval = ProjectlessEvaluator()) {
@@ -426,6 +427,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestVarI() {
             using (var eval = ProjectlessEvaluator()) {
@@ -514,6 +516,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestNpmReplRedirector() {
             using (var eval = ProjectlessEvaluator()) {

--- a/Nodejs/Tests/Core/TemplateTests.cs
+++ b/Nodejs/Tests/Core/TemplateTests.cs
@@ -25,6 +25,7 @@ using TestUtilities;
 namespace NodejsTests {
     [TestClass]
     public class TemplateTests {
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestPackageJsonTemplateEncoding() {
             var projectTemplates = Path.Combine(TestData.BinarySourceLocation, "ProjectTemplates", "JavaScript", "Node.js", "1033");

--- a/Nodejs/Tests/Core/TestFrameworkStringConverterTest.cs
+++ b/Nodejs/Tests/Core/TestFrameworkStringConverterTest.cs
@@ -25,6 +25,7 @@ namespace NodejsTests {
 
     [TestClass]
     public class TestFrameworkStringConverterTest {
+        [Ignore]
         [TestMethod, Priority(0)]
         public void GetStandardValues_CheckValueSequence() {
             //Arrange

--- a/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
+++ b/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace NpmTests {
     [TestClass]
     public class InstallUninstallPackageTests : AbstractFilesystemPackageJsonTests {
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestAddPackageToSimplePackageJsonThenUninstall() {
             var rootDir = CreateRootPackage(PkgSimple);

--- a/Nodejs/Tests/NpmTests/NpmSearchTests.cs
+++ b/Nodejs/Tests/NpmTests/NpmSearchTests.cs
@@ -511,6 +511,7 @@ namespace NpmTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestFilterStringWithHyphens() {
             const string

--- a/Nodejs/Tests/NpmTests/ProblematicPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/ProblematicPackageJsonTests.cs
@@ -63,6 +63,7 @@ namespace NpmTests {
             TestFreshPackage("doublecomma");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
         public void TestParseDuplicateProperty() {
@@ -128,11 +129,13 @@ namespace NpmTests {
             TestFreshPackage("missingpropnamequotes");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestParseMissingTrailingBrace() {
             TestFreshPackage("missingtrailingbrace");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestParseMissingTrailingListBrace() {
             TestFreshPackage("missingtrailinglistbrace");

--- a/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
+++ b/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
@@ -155,6 +155,7 @@ namespace ProfilingUITests {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void NewProfilingSession() {
@@ -216,6 +217,7 @@ namespace ProfilingUITests {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/26
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestStartAnalysisDebugMenu() {
@@ -251,6 +253,7 @@ namespace ProfilingUITests {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/26
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestStartAnalysisDebugMenuNoProject() {
@@ -269,6 +272,7 @@ namespace ProfilingUITests {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/149
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchNewProfilingSession() {
@@ -341,6 +345,7 @@ namespace ProfilingUITests {
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/145
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestMultipleSessions() {
@@ -414,6 +419,7 @@ namespace ProfilingUITests {
         /// 
         /// Same as TestMultipleSessions, but reversing the order of which one we launch from
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestMultipleSessions2() {
@@ -482,6 +488,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void NewProfilingSessionOpenSolution() {
@@ -542,6 +549,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchNodejsProfilingWizard() {
@@ -589,6 +597,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchProject() {
@@ -617,6 +626,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchMappedProject() {
@@ -645,6 +655,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchMappedProjectNeedsBuild() {
@@ -678,6 +689,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchMappedProjectNeedsBuildWithErrors() {
@@ -696,6 +708,7 @@ namespace ProfilingUITests {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestSaveDirtySession() {
@@ -736,6 +749,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestDeleteReport() {
@@ -759,6 +773,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestCompareReports() {
@@ -831,6 +846,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestRemoveReport() {
@@ -854,6 +870,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestOpenReport() {
@@ -902,6 +919,7 @@ namespace ProfilingUITests {
             AutomationWrapper.EnsureExpanded(child);
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestOpenReportCtxMenu() {
@@ -927,6 +945,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestTargetPropertiesForProject() {
@@ -960,6 +979,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestTargetPropertiesForExecutable() {
@@ -1004,6 +1024,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestStopProfiling() {
@@ -1039,6 +1060,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestTwoProfilesAtTheSameTime() {
@@ -1103,6 +1125,7 @@ namespace ProfilingUITests {
             return app;
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultipleTargets() {
@@ -1162,6 +1185,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultipleTargetsWithProjectHome() {
@@ -1222,6 +1246,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void MultipleReports() {
@@ -1261,6 +1286,7 @@ namespace ProfilingUITests {
         }
 
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void LaunchExecutable() {
@@ -1296,6 +1322,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestJustMyCode() {
@@ -1328,6 +1355,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestJustMyCodeOff() {
@@ -1360,6 +1388,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestProjectProperties() {
@@ -1396,6 +1425,7 @@ namespace ProfilingUITests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void TestBrowserLaunch() {

--- a/Nodejs/Tests/Profiling/LogParserTests.cs
+++ b/Nodejs/Tests/Profiling/LogParserTests.cs
@@ -77,6 +77,7 @@ namespace ProfilerTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestFilenameParsing() {
             AssertExpectedFileInfo(

--- a/Nodejs/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Nodejs/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -36,6 +36,7 @@ namespace TestAdapterTests {
             NodejsTestData.Deploy();
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestRun() {
             
@@ -56,6 +57,7 @@ namespace TestAdapterTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestRunAll() {
             


### PR DESCRIPTION
Used the following (imperfect, but good enough) script to disable tests based on test run results: https://github.com/mousetraps/disable-failing-mstests

I suspect there may still be some lingering issues, so I plan to iterate after the test run completes. Additionally I plan to update #646 with priorities re: re-enabling tests. For instance, many of our debugger tests are failing due to an external issue in Node.js that is preventing us from detecting the end of program execution.

close #666