### PR TITLE
#670 Many Npm CI tests failing with Unable to load DLL 'sqlite3'

### DIFF
--- a/Nodejs/Tests/NpmTests/NpmSearchTests.cs
+++ b/Nodejs/Tests/NpmTests/NpmSearchTests.cs
@@ -28,8 +28,7 @@ namespace NpmTests {
 
     [TestClass]
     [DeploymentItem(@"TestData\NpmSearchData\", "NpmSearchData")]
-    // TODO: The below was causing failures when included. Figure out if/how this should be set. (Seems to work fine without it).
-    //[DeploymentItem(@"sqlite3.dll")]
+    [DeploymentItem(@"sqlite3.dll")]
     public class NpmSearchTests {
 
         private const string PackageCacheAllJsonFilename = "packagecache.min.json";


### PR DESCRIPTION
Ensure that sqlite.dll is deployed along with the assemblies before running tests.

close #670