### PR TITLE
#690 - fix async debug issues

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NodejsTools.Debugger {
 
             // Node usage: node [options] [ -e script | script.js ] [arguments]
             string allArgs = String.Format(
-                "--debug-brk={0} {1} {2}",
+                "--debug-brk={0} --nolazy {1} {2}",
                 debuggerPortOrDefault,
                 interpreterOptions,
                 script


### PR DESCRIPTION
- V8's lazy compilation sometimes reports the incorrect breakpoint
  location, so work around the issue using the --nolazy flag

close #690