### PR TITLE
Check for null before dereference on RootPackage.HomePages

### DIFF
--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -167,11 +167,13 @@ namespace Microsoft.NodejsTools.Project {
             if (cmdGroup == Guids.NodejsNpmCmdSet) {
                 switch (cmd) {
                     case PkgCmdId.cmdidNpmOpenModuleHomepage:
-                        using (var enumerator = this.Package.Homepages.GetEnumerator()) {
-                            if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
-                                result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
-                            } else {
-                                result = QueryStatusResult.SUPPORTED;
+                        if (this.Package.Homepages != null) {
+                            using (var enumerator = this.Package.Homepages.GetEnumerator()) {
+                                if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
+                                    result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
+                                } else {
+                                    result = QueryStatusResult.SUPPORTED;
+                                }
                             }
                         }
                         return VSConstants.S_OK;
@@ -225,9 +227,11 @@ namespace Microsoft.NodejsTools.Project {
             if (cmdGroup == Guids.NodejsNpmCmdSet) {
                 switch (cmd) {
                     case PkgCmdId.cmdidNpmOpenModuleHomepage:
-                        using (var enumerator = this.Package.Homepages.GetEnumerator()) {
-                            if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
-                                Process.Start(enumerator.Current);
+                        if (this.Package.Homepages != null) {
+                            using (var enumerator = this.Package.Homepages.GetEnumerator()) {
+                                if (enumerator.MoveNext() && !string.IsNullOrEmpty(enumerator.Current)) {
+                                    Process.Start(enumerator.Current);
+                                }
                             }
                         }
                         return VSConstants.S_OK;


### PR DESCRIPTION
**Defect**
`RootPackage.Homepage` can return null to indicate that no root package
exists. This causes two potential null dereferences in `DependencyNode.cs`

**Fix**
This fix just adds a null check before accessing the enumerator on the
`HomePages` property.