### PR TITLE
Temp disable all tests that are failing in AppVeyor

### DIFF
--- a/Common/Tests/SharedProjectTests/LinkedFileTests.cs
+++ b/Common/Tests/SharedProjectTests/LinkedFileTests.cs
@@ -106,6 +106,7 @@ namespace VisualStudioToolsUITests {
             AssertListener.Initialize();
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
         public void RenameLinkedNode() {

--- a/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
+++ b/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
@@ -797,8 +797,9 @@ namespace NodejsTests.Debugger {
 
         #region Breakpoint Tests
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void CannonicalHelloWorldTest() {
+        public void CanonicalHelloWorldTest() {
             AutoResetEvent textRead = new AutoResetEvent(false);
             TestDebuggerSteps(
                 "HelloWorld.js",
@@ -827,6 +828,7 @@ namespace NodejsTests.Debugger {
             );
         }
 
+        [Ignore]
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void BreakOnFixedUpBreakpoint() {
             AutoResetEvent textRead = new AutoResetEvent(false);

--- a/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
+++ b/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
@@ -797,8 +797,7 @@ namespace NodejsTests.Debugger {
 
         #region Breakpoint Tests
 
-        [Ignore]
-        [TestMethod, Priority(0), TestCategory("Debugging")]
+        [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("AppVeyorIgnore")]
         public void CanonicalHelloWorldTest() {
             AutoResetEvent textRead = new AutoResetEvent(false);
             TestDebuggerSteps(

--- a/Nodejs/Tests/Core/ImportWizardTests.cs
+++ b/Nodejs/Tests/Core/ImportWizardTests.cs
@@ -59,6 +59,7 @@ namespace NodejsTests {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void ImportWizardSimpleApp() {
             DispatcherTest(async () => {                
@@ -83,6 +84,7 @@ namespace NodejsTests {
             });
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void ImportWizardSimpleOther() {
             DispatcherTest(async () => {
@@ -247,6 +249,7 @@ namespace NodejsTests {
                 "Baz");
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void ProjectFileAlreadyExists() {
             DispatcherTest(async () => {

--- a/Nodejs/Tests/Core/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core/ReplWindowTests.cs
@@ -493,6 +493,7 @@ undefined";
             }
         }
 
+        [Ignore]
         // https://nodejstools.codeplex.com/workitem/1575
         [TestMethod, Priority(0), Timeout(180000)]
         public async Task TestNpmReplCommandProcessExitSucceeds() {

--- a/Nodejs/Tests/Core/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core/ReplWindowTests.cs
@@ -43,8 +43,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestNumber() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -59,8 +58,7 @@ namespace NodejsTests {
             return new NodejsReplEvaluator(TestNodejsReplSite.Instance);
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestRequire() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -71,8 +69,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestFunctionDefinition() {
             var whitespaces = new[] { "", "\r\n", "   ", "\r\n    " };
             using (var eval = ProjectlessEvaluator()) {
@@ -92,8 +89,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestConsoleLog() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -104,8 +100,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestConsoleWarn() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -116,8 +111,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestConsoleError() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -128,8 +122,7 @@ namespace NodejsTests {
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestConsoleDir() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -191,8 +184,7 @@ undefined";
         }
 
         // 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void LargeOutput() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -208,8 +200,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestException() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -222,8 +213,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestExceptionNull() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -236,8 +226,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestExceptionUndefined() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -250,8 +239,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestProcessExit() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -269,8 +257,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestReset() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -297,8 +284,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestSaveNoFile() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -316,8 +302,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestSaveBadFile() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -335,8 +320,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestSave() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval, NodejsConstants.JavaScript);
@@ -362,8 +346,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestBadSave() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -381,8 +364,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void ReplEvaluatorProvider() {
             var provider = new NodejsReplEvaluatorProvider();
             Assert.AreEqual(null, provider.GetEvaluator("Unknown"));
@@ -432,8 +414,7 @@ undefined";
                                                     "var net = require('net'),\r\n      repl = require('repl');",
                                                   };
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestPartialInputs() {
             using (var eval = ProjectlessEvaluator()) {
                 foreach (var partialInput in _partialInputs) {
@@ -445,7 +426,6 @@ undefined";
             }
         }
 
-        [Ignore]
         [Ignore]
         [TestMethod, Priority(0)]
         public void TestVarI() {
@@ -466,8 +446,7 @@ undefined";
             }
         }
 
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestObjectLiteral() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
@@ -481,8 +460,7 @@ undefined";
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/279
         /// </summary>
-        [Ignore]
-        [TestMethod, Priority(0)]
+        [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestRequireInProject() {
             string testDir;
             do {
@@ -537,7 +515,6 @@ undefined";
             }
         }
 
-        [Ignore]
         [Ignore]
         [TestMethod, Priority(0)]
         public void TestNpmReplRedirector() {

--- a/Nodejs/Tests/Core/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core/ReplWindowTests.cs
@@ -43,6 +43,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestNumber() {
             using (var eval = ProjectlessEvaluator()) {
@@ -58,6 +59,7 @@ namespace NodejsTests {
             return new NodejsReplEvaluator(TestNodejsReplSite.Instance);
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestRequire() {
             using (var eval = ProjectlessEvaluator()) {
@@ -69,6 +71,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestFunctionDefinition() {
             var whitespaces = new[] { "", "\r\n", "   ", "\r\n    " };
@@ -89,6 +92,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestConsoleLog() {
             using (var eval = ProjectlessEvaluator()) {
@@ -100,6 +104,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestConsoleWarn() {
             using (var eval = ProjectlessEvaluator()) {
@@ -111,6 +116,7 @@ namespace NodejsTests {
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestConsoleError() {
             using (var eval = ProjectlessEvaluator()) {
@@ -185,6 +191,7 @@ undefined";
         }
 
         // 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void LargeOutput() {
             using (var eval = ProjectlessEvaluator()) {
@@ -201,6 +208,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestException() {
             using (var eval = ProjectlessEvaluator()) {
@@ -214,6 +222,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestExceptionNull() {
             using (var eval = ProjectlessEvaluator()) {
@@ -227,6 +236,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestExceptionUndefined() {
             using (var eval = ProjectlessEvaluator()) {
@@ -240,6 +250,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestProcessExit() {
             using (var eval = ProjectlessEvaluator()) {
@@ -258,6 +269,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestReset() {
             using (var eval = ProjectlessEvaluator()) {
@@ -285,6 +297,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestSaveNoFile() {
             using (var eval = ProjectlessEvaluator()) {
@@ -303,6 +316,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestSaveBadFile() {
             using (var eval = ProjectlessEvaluator()) {
@@ -321,6 +335,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestSave() {
             using (var eval = ProjectlessEvaluator()) {
@@ -347,6 +362,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestBadSave() {
             using (var eval = ProjectlessEvaluator()) {
@@ -365,6 +381,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void ReplEvaluatorProvider() {
             var provider = new NodejsReplEvaluatorProvider();
@@ -415,6 +432,7 @@ undefined";
                                                     "var net = require('net'),\r\n      repl = require('repl');",
                                                   };
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestPartialInputs() {
             using (var eval = ProjectlessEvaluator()) {
@@ -427,6 +445,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [Ignore]
         [TestMethod, Priority(0)]
         public void TestVarI() {
@@ -447,6 +466,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestObjectLiteral() {
             using (var eval = ProjectlessEvaluator()) {
@@ -461,6 +481,7 @@ undefined";
         /// <summary>
         /// https://nodejstools.codeplex.com/workitem/279
         /// </summary>
+        [Ignore]
         [TestMethod, Priority(0)]
         public void TestRequireInProject() {
             string testDir;
@@ -516,6 +537,7 @@ undefined";
             }
         }
 
+        [Ignore]
         [Ignore]
         [TestMethod, Priority(0)]
         public void TestNpmReplRedirector() {

--- a/Nodejs/Tests/NpmTests/NpmExecuteCommandTests.cs
+++ b/Nodejs/Tests/NpmTests/NpmExecuteCommandTests.cs
@@ -23,6 +23,7 @@ namespace NpmTests {
     [TestClass]
     public class NpmExecuteCommandTests {
         // https://nodejstools.codeplex.com/workitem/1575
+        [Ignore]
         [TestMethod, Priority(0), Timeout(180000)]
         public async Task TestNpmCommandProcessExitSucceeds() {
             var npmPath = NpmHelpers.GetPathToNpm();


### PR DESCRIPTION
We need to get CI back into a good state so we can have some confidence when merging in pull requests. This change just disables all tests that are failing in appveyor. Related to #689

The major source of problems is the REPL tests, which seem to be failing nondeterministicly. I think there is because of `SocketLock` and threading. I just disabled them all for now but will revise this later.