### PR TITLE
#714 update signing certificates

### DIFF
--- a/Build/BuildReleaseHelpers.psm1
+++ b/Build/BuildReleaseHelpers.psm1
@@ -69,13 +69,16 @@ function begin_sign_files {
             $job.Keywords = $jobKeywords
             
             if ($certificates -match "authenticode") {
-                $job.SelectCertificate("10006")  # Authenticode
+                $job.SelectCertificate("401")  # Authenticode
+            }
+            if ($certificates -match "msi") {
+                $job.SelectCertificate("400")  # Authenticode
             }
             if ($certificates -match "strongname") {
                 $job.SelectCertificate("67")     # StrongName key
             }
-            if ($certificates -match "opc") {
-                $job.SelectCertificate("160")     # Microsoft OPC Publisher (VSIX)
+            if ($certificates -match "vsix") {
+                $job.SelectCertificate("10040160")     # Microsoft OPC Publisher (VSIX)
             }
             
             foreach ($approver in $approvers) {

--- a/Build/BuildReleaseMockHelpers.psm1
+++ b/Build/BuildReleaseMockHelpers.psm1
@@ -77,16 +77,23 @@ job.Keywords:     $jobKeywords"
     
     if ($certificates -match "authenticode") {
         $msg = "$msg
-job.SelectCertificate(10006)"
-        $job.SelectCertificate("10006")  # Authenticode
+job.SelectCertificate(401)"
+        $job.SelectCertificate("401")  # Authenticode
+    }
+    if ($certificates -match "msi") {
+        $msg = "$msg
+job.SelectCertificate(400)"
+        $job.SelectCertificate("400")   # Authenticode for MSI
     }
     if ($certificates -match "strongname") {
         $msg = "$msg
 job.SelectCertificate(67)"
         $job.SelectCertificate("67")     # StrongName key
     }
-    if ($certificates -match "opc") {
-        $job.SelectCertificate("160")     # Microsoft OPC Publisher (VSIX)
+    if ($certificates -match "vsix") {
+        $msg = "$msg
+job.SelectCertificate(100040160)"
+        $job.SelectCertificate("100040160")   # Microsoft OPC Publisher (VSIX)
     }
     
     foreach ($approver in $approvers) {

--- a/Nodejs/Setup/BuildRelease.ps1
+++ b/Nodejs/Setup/BuildRelease.ps1
@@ -561,7 +561,7 @@ try {
 
                     $jobs += begin_sign_files $msi_files $i.signed_msidir $approvers `
                         $project_name $project_url "$project_name $($i.VSName) - installer" $project_keywords `
-                        "authenticode"
+                        "msi"
                 }
 
 
@@ -575,7 +575,7 @@ try {
 
                     $jobs += begin_sign_files $vsix_files $i.signed_msidir $approvers `
                         $project_name $project_url "$project_name $($i.VSName) - VSIX" $project_keywords `
-                        "authenticode;opc"
+                        "vsix"
                 }
             }
 


### PR DESCRIPTION
Use SHA2 certificates

Completed a private build with these changes as well
https://github.com/mousetraps/nodejstools/releases/tag/v1.1.PrivateDev-3.1.2015

fix #714