### PR TITLE
First Stage of Auto Typing Download Work - Detecting new packages(auto-dts branch)

### DIFF
--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -42,39 +42,7 @@ namespace Microsoft.NodejsTools.Project {
             _parent = parent;
             Package = package;
 
-            var buff = new StringBuilder(package.Name);
-            if (package.IsMissing) {
-                buff.Append(" (missing)");
-            } else {
-                buff.Append('@');
-                buff.Append(package.Version);
-
-                if (!package.IsListedInParentPackageJson) {
-                    buff.AppendFormat(" (not listed in {0})", NodejsConstants.PackageJsonFile);
-                } else {
-                    List<string> dependencyTypes = new List<string>(3);
-                    if (package.IsDependency) {
-                        dependencyTypes.Add("standard");
-                    }
-                    if (package.IsDevDependency) {
-                        dependencyTypes.Add("dev");
-                    }
-                    if (package.IsOptionalDependency) {
-                        dependencyTypes.Add("optional");
-                    }
-
-                    if (package.IsDevDependency || package.IsOptionalDependency) {
-                        buff.Append(" (");
-                        buff.Append(string.Join(", ", dependencyTypes.ToArray()));
-                        buff.Append(")");
-                    }
-                }
-            }
-
-            if (package.IsBundledDependency) {
-                buff.Append("[bundled]");
-            }
-
+            var buff = GetInitialPackageDisplayString(package);
             _displayString = buff.ToString();
             ExcludeNodeFromScc = true;
         }
@@ -281,6 +249,46 @@ namespace Microsoft.NodejsTools.Project {
             return base.ExecCommandOnNode(cmdGroup, cmd, nCmdexecopt, pvaIn, pvaOut);
         }
 
-#endregion
+        #endregion
+
+        private static StringBuilder GetInitialPackageDisplayString(IPackage package) {
+            var buff = new StringBuilder(package.Name);
+            if (package.IsMissing) {
+                buff.Append(" (missing)");
+            } else {
+                buff.Append('@');
+                buff.Append(package.Version);
+
+                if (!package.IsListedInParentPackageJson) {
+                    buff.AppendFormat(" (not listed in {0})", NodejsConstants.PackageJsonFile);
+                } else {
+                    var dependencyTypes = GetDependencyTypeNames(package);
+                    if (package.IsDevDependency || package.IsOptionalDependency) {
+                        buff.Append(" (");
+                        buff.Append(string.Join(", ", dependencyTypes.ToArray()));
+                        buff.Append(")");
+                    }
+                }
+            }
+
+            if (package.IsBundledDependency) {
+                buff.Append("[bundled]");
+            }
+            return buff;
+        }
+
+        private static List<string> GetDependencyTypeNames(IPackage package) {
+            var dependencyTypes = new List<string>(3);
+            if (package.IsDependency) {
+                dependencyTypes.Add("standard");
+            }
+            if (package.IsDevDependency) {
+                dependencyTypes.Add("dev");
+            }
+            if (package.IsOptionalDependency) {
+                dependencyTypes.Add("optional");
+            }
+            return dependencyTypes;
+        }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -28,22 +28,25 @@ using Microsoft.VisualStudioTools.Project;
 using VsCommands2K = Microsoft.VisualStudio.VSConstants.VSStd2KCmdID;
 
 namespace Microsoft.NodejsTools.Project {
-    internal class DependencyNode : HierarchyNode {
+    internal interface IDependencyNodeBasePath {
+        string GetRelativeUrlFragment();
+    }
+
+    internal class DependencyNode : HierarchyNode, IDependencyNodeBasePath {
         private readonly NodejsProjectNode _projectNode;
-        private readonly DependencyNode _parent;
+        private readonly IDependencyNodeBasePath _parent;
         private readonly string _displayString;
 
         public DependencyNode(
             NodejsProjectNode root,
-            DependencyNode parent,
+            IDependencyNodeBasePath parent,
             IPackage package)
             : base(root) {
             _projectNode = root;
             _parent = parent;
             Package = package;
 
-            var buff = GetInitialPackageDisplayString(package);
-            _displayString = buff.ToString();
+            _displayString = GetInitialPackageDisplayString(package);
             ExcludeNodeFromScc = true;
         }
 
@@ -63,7 +66,7 @@ namespace Microsoft.NodejsTools.Project {
 
         #region HierarchyNode implementation
 
-        private string GetRelativeUrlFragment() {
+        public string GetRelativeUrlFragment() {
             var buff = new StringBuilder();
             if (null != _parent) {
                 buff.Append(_parent.GetRelativeUrlFragment());
@@ -251,7 +254,7 @@ namespace Microsoft.NodejsTools.Project {
 
         #endregion
 
-        private static StringBuilder GetInitialPackageDisplayString(IPackage package) {
+        private static string GetInitialPackageDisplayString(IPackage package) {
             var buff = new StringBuilder(package.Name);
             if (package.IsMissing) {
                 buff.Append(" (missing)");
@@ -274,7 +277,7 @@ namespace Microsoft.NodejsTools.Project {
             if (package.IsBundledDependency) {
                 buff.Append("[bundled]");
             }
-            return buff;
+            return buff.ToString();
         }
 
         private static List<string> GetDependencyTypeNames(IPackage package) {

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -382,33 +382,31 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             var controller = _npmController;
-            if (null != controller) {
-                if (null != RootPackage) {
-                    var dev = controller.RootPackage.Modules.Where(package => package.IsDevDependency);
-                    _devModulesNode.Packages = dev;
-                    ReloadHierarchy(_devModulesNode, dev);
+            if (null == controller)
+                return;
 
-                    var optional = controller.RootPackage.Modules.Where(package => package.IsOptionalDependency);
-                    _optionalModulesNode.Packages = optional;
-                    ReloadHierarchy(_optionalModulesNode, optional);
+            if (null != RootPackage) {
+                var dev = GetDevPackages(controller);
+                _devModulesNode.Packages = dev;
+                ReloadHierarchy(_devModulesNode, dev);
 
-                    var root = controller.RootPackage.Modules.Where(package => 
-                        package.IsDependency || 
-                        !package.IsListedInParentPackageJson);
-                    
-                    ReloadHierarchy(this, root);
-                }
+                var optional = GetOptionalPackages(controller);
+                _optionalModulesNode.Packages = optional;
+                ReloadHierarchy(_optionalModulesNode, optional);
 
-                var global = controller.GlobalPackages;
-                if (null != global) {
-                    _globalModulesNode.GlobalPackages = global;
-                    ReloadHierarchy(_globalModulesNode, global.Modules);
-                }
+                var root = GetRootPackages(controller);
+                ReloadHierarchy(this, root);
+            }
 
-                if (_firstHierarchyLoad) {
-                    controller.FinishedRefresh += NpmController_FinishedRefresh;
-                    _firstHierarchyLoad = false;
-                }
+            var global = controller.GlobalPackages;
+            if (null != global) {
+                _globalModulesNode.GlobalPackages = global;
+                ReloadHierarchy(_globalModulesNode, global.Modules);
+            }
+
+            if (_firstHierarchyLoad) {
+                controller.FinishedRefresh += NpmController_FinishedRefresh;
+                _firstHierarchyLoad = false;
             }
         }
 
@@ -688,6 +686,20 @@ namespace Microsoft.NodejsTools.Project {
 
         public override void ManageNpmModules() {
             ManageModules();
+        }
+
+        private static IEnumerable<IPackage> GetDevPackages(INpmController controller) {
+            return controller.RootPackage.Modules.Where(package => package.IsDevDependency);
+        }
+
+        private static IEnumerable<IPackage> GetOptionalPackages(INpmController controller) {
+            return controller.RootPackage.Modules.Where(package => package.IsOptionalDependency);
+        }
+
+        private static IEnumerable<IPackage> GetRootPackages(INpmController controller) {
+            return controller.RootPackage.Modules.Where(package =>
+                package.IsDependency ||
+                !package.IsListedInParentPackageJson);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -66,7 +66,8 @@ namespace Microsoft.NodejsTools.Project {
 
         public NodeModulesNode(NodejsProjectNode root)
             : base(root) {
-            CreateNpmController();
+            _npmController = DefaultNpmController(_projectNode.ProjectHome, new NpmPathProvider(this));
+            RegistryWithNpmController(_npmController);
 
             _globalModulesNode = new GlobalModulesNode(root, this);
             AddChild(_globalModulesNode);
@@ -130,20 +131,20 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        private INpmController CreateNpmController() {
-            if (null == _npmController) {
-                _npmController = NpmControllerFactory.Create(
-                    _projectNode.ProjectHome,
-                    NodejsPackage.Instance.NpmOptionsPage.NpmCachePath,
-                    false,
-                    new NpmPathProvider(this));
-                _npmController.CommandStarted += NpmController_CommandStarted;
-                _npmController.OutputLogged += NpmController_OutputLogged;
-                _npmController.ErrorLogged += NpmController_ErrorLogged;
-                _npmController.ExceptionLogged += NpmController_ExceptionLogged;
-                _npmController.CommandCompleted += NpmController_CommandCompleted;
-            }
-            return _npmController;
+        private static INpmController DefaultNpmController(string projectHome, NpmPathProvider pathProvider) {
+            return NpmControllerFactory.Create(
+                   projectHome,
+                   NodejsPackage.Instance.NpmOptionsPage.NpmCachePath,
+                   false,
+                   pathProvider);
+        }
+
+        private void RegistryWithNpmController(INpmController controller) {
+            controller.CommandStarted += NpmController_CommandStarted;
+            controller.OutputLogged += NpmController_OutputLogged;
+            controller.ErrorLogged += NpmController_ErrorLogged;
+            controller.ExceptionLogged += NpmController_ExceptionLogged;
+            controller.CommandCompleted += NpmController_CommandCompleted;
         }
 
         void NpmController_FinishedRefresh(object sender, EventArgs e) {

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -62,12 +62,18 @@ namespace Microsoft.NodejsTools.Project {
 
         #endregion
 
+        #region
+
+        public event EventHandler<IEnumerable<IPackage>> PackagesAdded;
+
+        #endregion
+
         #region Initialization
 
         public NodeModulesNode(NodejsProjectNode root)
             : base(root) {
             _npmController = DefaultNpmController(_projectNode.ProjectHome, new NpmPathProvider(this));
-            RegistryWithNpmController(_npmController);
+            RegisterWithNpmController(_npmController);
 
             _globalModulesNode = new GlobalModulesNode(root, this);
             AddChild(_globalModulesNode);
@@ -139,7 +145,7 @@ namespace Microsoft.NodejsTools.Project {
                 pathProvider);
         }
 
-        private void RegistryWithNpmController(INpmController controller) {
+        private void RegisterWithNpmController(INpmController controller) {
             controller.CommandStarted += NpmController_CommandStarted;
             controller.OutputLogged += NpmController_OutputLogged;
             controller.ErrorLogged += NpmController_ErrorLogged;
@@ -390,6 +396,12 @@ namespace Microsoft.NodejsTools.Project {
             if (_firstHierarchyLoad) {
                 controller.FinishedRefresh += NpmController_FinishedRefresh;
                 _firstHierarchyLoad = false;
+            }
+
+            if (newPackages.Any()) {
+                var handler = PackagesAdded;
+                if (handler != null)
+                    handler(this, newPackages);
             }
         }
 

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -23,7 +23,7 @@ using System.Linq;
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NodeModules : AbstractNodeModules {
         private Dictionary<string, ModuleInfo> _allModules;
-        private readonly string[] _ignoredDirectories = { @"\.bin", @"\.staging" };
+        private static readonly string[] _ignoredDirectories = { @"\.bin", @"\.staging" };
 
         public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0) {
             var modulesBase = Path.Combine(parent.Path, NodejsConstants.NodeModulesFolder);
@@ -35,41 +35,22 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             if (depth == 0) {
                 Debug.Assert(_allModules.Count == 0, "Depth is 0, but top-level modules have already been added.");
 
-                IEnumerable<string> topLevelDirectories = Enumerable.Empty<string>();
-                try {
-                    topLevelDirectories = Directory.EnumerateDirectories(modulesBase);
-                } catch (IOException) {
-                    // We want to handle DirectoryNotFound, DriveNotFound, PathTooLong
-                } catch (UnauthorizedAccessException) {
-                }
-
                 // Go through every directory in node_modules, and see if it's required as a top-level dependency
-                foreach (var moduleDir in topLevelDirectories) {
-                    if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !_ignoredDirectories.Any(toIgnore => moduleDir.EndsWith(toIgnore))) {
-                        IPackageJson packageJson;
-                        try {
-                            packageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(moduleDir));
-                        } catch (PackageJsonException) {
-                            // Fail gracefully if there was an error parsing the package.json
-                            Debug.Fail("Failed to parse package.json in {0}", moduleDir);
-                            continue;
-                        }
-
-                        if (packageJson != null) {
-                            if (packageJson.RequiredBy.Count() > 0) {
-                                // All dependencies in npm v3 will have at least one element present in _requiredBy.
-                                // _requiredBy dependencies that begin with hash characters represent top-level dependencies
-                                foreach (var requiredBy in packageJson.RequiredBy) {
-                                    if (requiredBy.StartsWith("#") || requiredBy == "/") {
-                                        AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth);
-                                        break;
-                                    }
-                                }
-                            } else {
-                                // This dependency is a top-level dependency not added by npm v3
+                foreach (var topLevelDependency in GetTopLevelDependencies(modulesBase)) {
+                    var moduleDir = topLevelDependency.Key;
+                    var packageJson = topLevelDependency.Value;
+                    if (packageJson.RequiredBy.Any()) {
+                        // All dependencies in npm v3 will have at least one element present in _requiredBy.
+                        // _requiredBy dependencies that begin with hash characters represent top-level dependencies
+                        foreach (var requiredBy in packageJson.RequiredBy) {
+                            if (requiredBy.StartsWith("#") || requiredBy == "/") {
                                 AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth);
+                                break;
                             }
                         }
+                    } else {
+                        // This dependency is a top-level dependency not added by npm v3
+                        AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth);
                     }
                 }
             }
@@ -166,6 +147,31 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             Debug.WriteLine("Module Depth: {0} [{1}]", filepath, depth);
 
             return depth;
+        }
+
+        private static IEnumerable<KeyValuePair<string, IPackageJson>> GetTopLevelDependencies(string modulesBase) {
+            var topLevelDirectories = Enumerable.Empty<string>();
+            try {
+                topLevelDirectories = Directory.EnumerateDirectories(modulesBase);
+            } catch (IOException) {
+                // We want to handle DirectoryNotFound, DriveNotFound, PathTooLong
+            } catch (UnauthorizedAccessException) {
+            }
+
+            // Go through every directory in node_modules, and see if it's required as a top-level dependency
+            foreach (var moduleDir in topLevelDirectories) {
+                if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !_ignoredDirectories.Any(toIgnore => moduleDir.EndsWith(toIgnore))) {
+                    IPackageJson json = null;
+                    try {
+                        json = PackageJsonFactory.Create(new DirectoryPackageJsonSource(moduleDir));
+                    } catch (PackageJsonException) {
+                        // Fail gracefully if there was an error parsing the package.json
+                        Debug.Fail("Failed to parse package.json in {0}", moduleDir);
+                    }
+                    if (json != null)
+                        yield return new KeyValuePair<string, IPackageJson>(moduleDir, json);
+                }
+            }
         }
     }
 

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             Dictionary<string, ModuleInfo> allModules = null,
             int depth = 0)
         :
-            this(LoadRootPackageJson(fullPathToRootDirectory), fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth
+            this(LoadRootPackageJson(fullPathToRootDirectory), fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth)
         { }
     
         public RootPackage(

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -25,13 +25,34 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             string fullPathToRootDirectory,
             bool showMissingDevOptionalSubPackages,
             Dictionary<string, ModuleInfo> allModules = null,
-            int depth = 0) {
+            int depth = 0)
+        :
+            this(LoadRootPackageJson(fullPathToRootDirectory), fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth
+        { }
+    
+        public RootPackage(
+            IPackageJson packageJson,
+            string fullPathToRootDirectory,
+            bool showMissingDevOptionalSubPackages,
+            Dictionary<string, ModuleInfo> allModules = null,
+            int depth = 0)
+        {
+            PackageJson = packageJson;
             Path = fullPathToRootDirectory;
+            try {
+                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth);
+            } catch (PathTooLongException) {
+                // otherwise we fail to create it completely...
+            }
+        }
+
+        private static IPackageJson LoadRootPackageJson(string fullPathToRootDirectory) {
             var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
             try {
                 if (packageJsonFile.Length < 260) {
-                    PackageJson = PackageJsonFactory.Create(new DirectoryPackageJsonSource(fullPathToRootDirectory));
+                    return  PackageJsonFactory.Create(new DirectoryPackageJsonSource(fullPathToRootDirectory));
                 }
+                return null;
             } catch (RuntimeBinderException rbe) {
                 throw new PackageJsonException(
                     string.Format(@"Error processing package.json at '{0}'. The file was successfully read, and may be valid JSON, but the objects may not match the expected form for a package.json file.
@@ -39,15 +60,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 The following error was reported:
 
 {1}",
-                    packageJsonFile,
-                    rbe.Message),
+                        packageJsonFile,
+                        rbe.Message),
                     rbe);
-            }
-
-            try {
-                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth);
-            }  catch (PathTooLongException) {
-                // otherwise we fail to create it completely...
             }
         }
 


### PR DESCRIPTION
Reopening #719 against the `auto-dts` branch. Original message is below.

-----

First step of implementing automatic type downloading -  #694 . This pull request just adds an internal interface for detecting when a new npm package is installed. We will hook into this interface to automatically download the typings for new packages.

**New Interface**
The new interface is the `PackagesAdded` event on `NodeModulesNode`. This event is invoked whenever `NodeModulesNode` detects that a new package has been added. 

Adding this logic at this level is a little strange since `NodeModulesNode` is conceptually a user interface component, but it was the best place I found that had all the module data available and would also know which modules have already been loaded.

**Other Changes**
The majority of the other changes are simple method extractions from reshaper. I'm still trying to find the best way to hook this work up for testing, and I explored a few different options up and down the object hierarchy. These extractions were made to make testing easier or clarify the existing implementations of various methods.

I still don't have a good story for testing at the level of `NodeModulesNode` yet though. It's too reliant on UI concepts and too tightly coupled to everything else at the moment. 