### PR TITLE
Added *.temp_proj to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ x64/
 *.tli
 *.tlh
 *.tmp
+*.tmp_proj
 *.log
 *.vspscc
 *.vssscc
@@ -100,7 +101,6 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
-*.tmp_proj
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
+*.tmp_proj
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer


### PR DESCRIPTION
Saw this showing up a few times during development. It always is auto deleted before being commited, but this file should not even be picked up in the first place.