### PR TITLE
Fix warnings for having AbstractFilesystemPackageJsonTests use TestInitialize

### DIFF
--- a/Nodejs/Tests/NpmTests/AbstractFilesystemPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/AbstractFilesystemPackageJsonTests.cs
@@ -15,22 +15,9 @@
 //*********************************************************//
 
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NpmTests {
-    public abstract class AbstractFilesystemPackageJsonTests : AbstractPackageJsonTests {
-        protected TemporaryFileManager TempFileManager { get; private set; }
-
-        [TestInitialize]
-        public void Init() {
-            TempFileManager = new TemporaryFileManager();
-        }
-
-        [TestCleanup]
-        public void Cleanup() {
-            TempFileManager.Dispose();
-        }
-
+    public class AbstractFilesystemPackageJsonTests : AbstractPackageJsonTests {
         protected void CreatePackageJson(string filename, string json) {
             using (var fout = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None)) {
                 using (var writer = new StreamWriter(fout)) {
@@ -39,12 +26,12 @@ namespace NpmTests {
             }
         }
 
-        protected string CreateRootPackageDir() {
-            return TempFileManager.GetNewTempDirectory().FullName;
+        protected string CreateRootPackageDir(TemporaryFileManager manager) {
+            return manager.GetNewTempDirectory().FullName;
         }
 
-        protected string CreateRootPackage(string json) {
-            var dir = CreateRootPackageDir();
+        protected string CreateRootPackage(TemporaryFileManager manager, string json) {
+            var dir = CreateRootPackageDir(manager);
             var path = Path.Combine(dir, "package.json");
             CreatePackageJson(path, json);
             return dir;

--- a/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
@@ -20,13 +20,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NpmTests {
     [TestClass]
-    public class FileSystemPackageJsonTests : AbstractFilesystemPackageJsonTests {
+    public class FileSystemPackageJsonTests : AbstractPackageJsonTests {
         [TestMethod, Priority(0)]
         public void TestReadFromFile() {
             using (var manager = new TemporaryFileManager()) {
                 var dir = manager.GetNewTempDirectory();
                 var path = Path.Combine(dir.FullName, "package.json");
-                CreatePackageJson(path, PkgSimple);
+                FilesystemPackageJsonTestHelpers.CreatePackageJson(path, PkgSimple);
                 CheckPackage(PackageJsonFactory.Create(new FilePackageJsonSource(path)));
             }
         }
@@ -35,7 +35,7 @@ namespace NpmTests {
         public void TestReadFromDirectory() {
             using (var manager = new TemporaryFileManager()) {
                 var dir = manager.GetNewTempDirectory();
-                CreatePackageJson(Path.Combine(dir.FullName, "package.json"), PkgSimple);
+                FilesystemPackageJsonTestHelpers.CreatePackageJson(Path.Combine(dir.FullName, "package.json"), PkgSimple);
                 CheckPackage(PackageJsonFactory.Create(new DirectoryPackageJsonSource(dir.FullName)));
             }
         }

--- a/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
@@ -23,17 +23,21 @@ namespace NpmTests {
     public class FileSystemPackageJsonTests : AbstractFilesystemPackageJsonTests {
         [TestMethod, Priority(0)]
         public void TestReadFromFile() {
-            var dir = TempFileManager.GetNewTempDirectory();
-            var path = Path.Combine(dir.FullName, "package.json");
-            CreatePackageJson(path, PkgSimple);
-            CheckPackage(PackageJsonFactory.Create(new FilePackageJsonSource(path)));
+            using (var manager = new TemporaryFileManager()) {
+                var dir = manager.GetNewTempDirectory();
+                var path = Path.Combine(dir.FullName, "package.json");
+                CreatePackageJson(path, PkgSimple);
+                CheckPackage(PackageJsonFactory.Create(new FilePackageJsonSource(path)));
+            }
         }
 
         [TestMethod, Priority(0)]
         public void TestReadFromDirectory() {
-            var dir = TempFileManager.GetNewTempDirectory();
-            CreatePackageJson(Path.Combine(dir.FullName, "package.json"), PkgSimple);
-            CheckPackage(PackageJsonFactory.Create(new DirectoryPackageJsonSource(dir.FullName)));
+            using (var manager = new TemporaryFileManager()) {
+                var dir = manager.GetNewTempDirectory();
+                CreatePackageJson(Path.Combine(dir.FullName, "package.json"), PkgSimple);
+                CheckPackage(PackageJsonFactory.Create(new DirectoryPackageJsonSource(dir.FullName)));
+            }
         }
 
         private static void CheckPackage(IPackageJson pkg) {

--- a/Nodejs/Tests/NpmTests/FilesystemPackageJsonTestHelpers.cs
+++ b/Nodejs/Tests/NpmTests/FilesystemPackageJsonTestHelpers.cs
@@ -17,8 +17,8 @@
 using System.IO;
 
 namespace NpmTests {
-    public class AbstractFilesystemPackageJsonTests : AbstractPackageJsonTests {
-        protected void CreatePackageJson(string filename, string json) {
+    public static class FilesystemPackageJsonTestHelpers {
+        public static void CreatePackageJson(string filename, string json) {
             using (var fout = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None)) {
                 using (var writer = new StreamWriter(fout)) {
                     writer.Write(json);
@@ -26,11 +26,11 @@ namespace NpmTests {
             }
         }
 
-        protected string CreateRootPackageDir(TemporaryFileManager manager) {
+        public static string CreateRootPackageDir(TemporaryFileManager manager) {
             return manager.GetNewTempDirectory().FullName;
         }
 
-        protected string CreateRootPackage(TemporaryFileManager manager, string json) {
+        public static string CreateRootPackage(TemporaryFileManager manager, string json) {
             var dir = CreateRootPackageDir(manager);
             var path = Path.Combine(dir, "package.json");
             CreatePackageJson(path, json);

--- a/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
+++ b/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
@@ -24,156 +24,162 @@ namespace NpmTests {
     public class InstallUninstallPackageTests : AbstractFilesystemPackageJsonTests {
         [TestMethod, Priority(0), TestCategory("Ignore")]
         public void TestAddPackageToSimplePackageJsonThenUninstall() {
-            var rootDir = CreateRootPackage(PkgSimple);
-            var controller = NpmControllerFactory.Create(rootDir, string.Empty);
-            controller.Refresh();
-            var rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var controller = NpmControllerFactory.Create(rootDir, string.Empty);
+                controller.Refresh();
+                var rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
 
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, true);
-                task.Wait();
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, true);
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package installed.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
+                Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
+
+                var module = controller.RootPackage.Modules["sax"];
+                Assert.IsNotNull(module, "Installed package should not be null.");
+                Assert.AreEqual("sax", module.Name, "Module name mismatch.");
+                Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
+                Assert.IsTrue(
+                    module.IsListedInParentPackageJson,
+                    "Should be listed as a dependency in parent package.json.");
+                Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
+                Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
+                Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
+                Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
+                Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
+
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.UninstallPackageAsync("sax");
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package uninstalled.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
             }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package installed.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
-            Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
-
-            var module = controller.RootPackage.Modules["sax"];
-            Assert.IsNotNull(module, "Installed package should not be null.");
-            Assert.AreEqual("sax", module.Name, "Module name mismatch.");
-            Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
-            Assert.IsTrue(
-                module.IsListedInParentPackageJson,
-                "Should be listed as a dependency in parent package.json.");
-            Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
-            Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
-            Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
-            Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
-            Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
-
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.UninstallPackageAsync("sax");
-                task.Wait();
-            }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package uninstalled.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
         }
 
         [TestMethod, Priority(0)]
         public void TestAddPackageNoPackageJsonThenUninstall() {
-            var rootDir = CreateRootPackage(PkgSimple);
-            File.Delete(Path.Combine(rootDir, "package.json"));
-            var controller = NpmControllerFactory.Create(rootDir, string.Empty);
-            controller.Refresh();
-            var rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSimple);
+                File.Delete(Path.Combine(rootDir, "package.json"));
+                var controller = NpmControllerFactory.Create(rootDir, string.Empty);
+                controller.Refresh();
+                var rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
 
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, true);
-                task.Wait();
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, true);
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package installed.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
+                Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
+
+                var module = controller.RootPackage.Modules["sax"];
+                Assert.IsNotNull(module, "Installed package should not be null.");
+                Assert.AreEqual("sax", module.Name, "Module name mismatch.");
+                Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
+                Assert.IsFalse(
+                    module.IsListedInParentPackageJson,
+                    "Should be listed as a dependency in parent package.json.");
+                Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
+                Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
+                Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
+                Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
+                Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
+
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.UninstallPackageAsync("sax");
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package uninstalled.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
             }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package installed.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
-            Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
-
-            var module = controller.RootPackage.Modules["sax"];
-            Assert.IsNotNull(module, "Installed package should not be null.");
-            Assert.AreEqual("sax", module.Name, "Module name mismatch.");
-            Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
-            Assert.IsFalse(
-                module.IsListedInParentPackageJson,
-                "Should be listed as a dependency in parent package.json.");
-            Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
-            Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
-            Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
-            Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
-            Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
-
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.UninstallPackageAsync("sax");
-                task.Wait();
-            }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package uninstalled.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestAddPackageNoSavePackageJsonThenUninstall() {
-            var rootDir = CreateRootPackage(PkgSimple);
-            var controller = NpmControllerFactory.Create(rootDir, string.Empty);
-            controller.Refresh();
-            var rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var controller = NpmControllerFactory.Create(rootDir, string.Empty);
+                controller.Refresh();
+                var rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package with no dependencies should not be null.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules before package install.");
 
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, false);
-                task.Wait();
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.InstallPackageByVersionAsync("sax", "*", DependencyType.Standard, false);
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package installed.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
+                Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
+
+                var module = controller.RootPackage.Modules["sax"];
+                Assert.IsNotNull(module, "Installed package should not be null.");
+                Assert.AreEqual("sax", module.Name, "Module name mismatch.");
+                Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
+                Assert.IsFalse(
+                    module.IsListedInParentPackageJson,
+                    "Should not be listed as a dependency in parent package.json.");
+                Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
+                Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
+                Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
+                Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
+                Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
+
+                using (var commander = controller.CreateNpmCommander()) {
+                    Task<bool> task = commander.UninstallPackageAsync("sax");
+                    task.Wait();
+                }
+
+                Assert.AreNotEqual(
+                    rootPackage,
+                    controller.RootPackage,
+                    "Root package should be different after package uninstalled.");
+
+                rootPackage = controller.RootPackage;
+                Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
+                Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
             }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package installed.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package installed.");
-            Assert.AreEqual(1, rootPackage.Modules.Count, "Should be one module after package installed.");
-
-            var module = controller.RootPackage.Modules["sax"];
-            Assert.IsNotNull(module, "Installed package should not be null.");
-            Assert.AreEqual("sax", module.Name, "Module name mismatch.");
-            Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
-            Assert.IsFalse(
-                module.IsListedInParentPackageJson,
-                "Should not be listed as a dependency in parent package.json.");
-            Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
-            Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
-            Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
-            Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
-            Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
-
-            using (var commander = controller.CreateNpmCommander()) {
-                Task<bool> task = commander.UninstallPackageAsync("sax");
-                task.Wait();
-            }
-
-            Assert.AreNotEqual(
-                rootPackage,
-                controller.RootPackage,
-                "Root package should be different after package uninstalled.");
-
-            rootPackage = controller.RootPackage;
-            Assert.IsNotNull(rootPackage, "Root package should not be null after package uninstalled.");
-            Assert.AreEqual(0, rootPackage.Modules.Count, "Should be no modules after package installed.");
         }
     }
 }

--- a/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
+++ b/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
@@ -21,11 +21,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NpmTests {
     [TestClass]
-    public class InstallUninstallPackageTests : AbstractFilesystemPackageJsonTests {
+    public class InstallUninstallPackageTests : AbstractPackageJsonTests {
         [TestMethod, Priority(0), TestCategory("Ignore")]
         public void TestAddPackageToSimplePackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
                 controller.Refresh();
                 var rootPackage = controller.RootPackage;
@@ -78,7 +78,7 @@ namespace NpmTests {
         [TestMethod, Priority(0)]
         public void TestAddPackageNoPackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 File.Delete(Path.Combine(rootDir, "package.json"));
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
                 controller.Refresh();
@@ -132,7 +132,7 @@ namespace NpmTests {
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestAddPackageNoSavePackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
                 controller.Refresh();
                 var rootPackage = controller.RootPackage;

--- a/Nodejs/Tests/NpmTests/MaxPathTests.cs
+++ b/Nodejs/Tests/NpmTests/MaxPathTests.cs
@@ -22,12 +22,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace NpmTests {
 
     [TestClass]
-    public class MaxPathTests : AbstractFilesystemPackageJsonTests {
+    public class MaxPathTests : AbstractPackageJsonTests {
 
         [TestMethod, Priority(0)]
         public void TestAngularFullstackScaffoldedProject() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackageDir(manager);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackageDir(manager);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
                 controller.OutputLogged += controller_OutputLogged;
                 controller.ErrorLogged += controller_OutputLogged;

--- a/Nodejs/Tests/NpmTests/MaxPathTests.cs
+++ b/Nodejs/Tests/NpmTests/MaxPathTests.cs
@@ -25,27 +25,29 @@ namespace NpmTests {
     public class MaxPathTests : AbstractFilesystemPackageJsonTests {
 
         [TestMethod, Priority(0)]
-        public void TestAngularFullstackScaffoldedProject(){
-            var rootDir = CreateRootPackageDir();
-            var controller = NpmControllerFactory.Create(rootDir, string.Empty);
-            controller.OutputLogged += controller_OutputLogged;
-            controller.ErrorLogged += controller_OutputLogged;
-            controller.Refresh();
+        public void TestAngularFullstackScaffoldedProject() {
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackageDir(manager);
+                var controller = NpmControllerFactory.Create(rootDir, string.Empty);
+                controller.OutputLogged += controller_OutputLogged;
+                controller.ErrorLogged += controller_OutputLogged;
+                controller.Refresh();
 
-            using (var commander = controller.CreateNpmCommander()) {
-                var task = commander.InstallGlobalPackageByVersionAsync("yo", "*");
-                task.Wait();
+                using (var commander = controller.CreateNpmCommander()) {
+                    var task = commander.InstallGlobalPackageByVersionAsync("yo", "*");
+                    task.Wait();
+                }
+
+                var info = new ProcessStartInfo();
+
+                //  TODO!
             }
-
-            var info = new ProcessStartInfo();
-
-            //  TODO!
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
         public void TestInstallUninstallMaxPathGlobalModule() {
             var controller = NpmControllerFactory.Create(string.Empty, string.Empty);
-            
+
             using (var commander = controller.CreateNpmCommander()) {
                 commander.InstallGlobalPackageByVersionAsync("yo", "^1.2.0").Wait();
             }

--- a/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
+++ b/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
@@ -23,7 +23,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NpmTests {
     [TestClass]
-    public class ModuleHierarchyTests : AbstractFilesystemPackageJsonTests {
+    public class ModuleHierarchyTests : AbstractPackageJsonTests {
         protected const string PkgSingleDependency = @"{
     ""name"": ""TestPkg"",
     ""version"": ""0.1.0"",
@@ -43,7 +43,7 @@ namespace NpmTests {
         [TestMethod, Priority(0)]
         public void TestReadRootPackageNoDependencies() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var pkg = RootPackageFactory.Create(rootDir);
                 Assert.IsNotNull(pkg, "Root package should not be null.");
                 Assert.AreEqual(rootDir, pkg.Path, "Package path mismatch.");
@@ -64,7 +64,7 @@ namespace NpmTests {
         [TestMethod, Priority(0)]
         public void TestReadRootPackageOneDependency() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSingleDependency);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleDependency);
                 RunNpmInstall(rootDir);
 
                 var pkg = RootPackageFactory.Create(rootDir);
@@ -109,7 +109,7 @@ namespace NpmTests {
         [TestMethod, Priority(0)]
         public void TestReadRootPackageMissingDependency() {
             using (var manager = new TemporaryFileManager()) {
-                var rootDir = CreateRootPackage(manager, PkgSingleDependency);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleDependency);
 
                 var pkg = RootPackageFactory.Create(rootDir);
 
@@ -154,7 +154,7 @@ namespace NpmTests {
         public void TestReadRootDependencyRecursive() {
             using (var manager = new TemporaryFileManager()) {
 
-                var rootDir = CreateRootPackage(manager, PkgSingleRecursiveDependency);
+                var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleRecursiveDependency);
                 RunNpmInstall(rootDir);
 
                 var pkg = RootPackageFactory.Create(rootDir);

--- a/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
+++ b/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
@@ -42,17 +42,19 @@ namespace NpmTests {
 
         [TestMethod, Priority(0)]
         public void TestReadRootPackageNoDependencies() {
-            var rootDir = CreateRootPackage(PkgSimple);
-            var pkg = RootPackageFactory.Create(rootDir);
-            Assert.IsNotNull(pkg, "Root package should not be null.");
-            Assert.AreEqual(rootDir, pkg.Path, "Package path mismatch.");
-            var json = pkg.PackageJson;
-            Assert.IsNotNull(json, "package.json should not be null.");
-            Assert.AreEqual(json.Name, pkg.Name, "Package name mismatch.");
-            Assert.AreEqual(json.Version, pkg.Version, "Package version mismatch.");
-            var modules = pkg.Modules;
-            Assert.IsNotNull(modules, "Modules should not be null.");
-            Assert.AreEqual(0, modules.Count, "Module count mismatch.");
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSimple);
+                var pkg = RootPackageFactory.Create(rootDir);
+                Assert.IsNotNull(pkg, "Root package should not be null.");
+                Assert.AreEqual(rootDir, pkg.Path, "Package path mismatch.");
+                var json = pkg.PackageJson;
+                Assert.IsNotNull(json, "package.json should not be null.");
+                Assert.AreEqual(json.Name, pkg.Name, "Package name mismatch.");
+                Assert.AreEqual(json.Version, pkg.Version, "Package version mismatch.");
+                var modules = pkg.Modules;
+                Assert.IsNotNull(modules, "Modules should not be null.");
+                Assert.AreEqual(0, modules.Count, "Module count mismatch.");
+            }
         }
 
         private static void RunNpmInstall(string rootDir) {
@@ -61,122 +63,128 @@ namespace NpmTests {
 
         [TestMethod, Priority(0)]
         public void TestReadRootPackageOneDependency() {
-            var rootDir = CreateRootPackage(PkgSingleDependency);
-            RunNpmInstall(rootDir);
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSingleDependency);
+                RunNpmInstall(rootDir);
 
-            var pkg = RootPackageFactory.Create(rootDir);
+                var pkg = RootPackageFactory.Create(rootDir);
 
-            var json = pkg.PackageJson;
-            var dependencies = json.AllDependencies;
-            Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
+                var json = pkg.PackageJson;
+                var dependencies = json.AllDependencies;
+                Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
 
-            IDependency dep = dependencies["sax"];
-            Assert.IsNotNull(dep, "sax dependency should not be null.");
-            Assert.AreEqual(">=0.1.0 <0.2.0", dep.VersionRangeText, "Version range mismatch.");
+                IDependency dep = dependencies["sax"];
+                Assert.IsNotNull(dep, "sax dependency should not be null.");
+                Assert.AreEqual(">=0.1.0 <0.2.0", dep.VersionRangeText, "Version range mismatch.");
 
-            var modules = pkg.Modules;
-            Assert.AreEqual(1, modules.Count, "Module count mismatch");
+                var modules = pkg.Modules;
+                Assert.AreEqual(1, modules.Count, "Module count mismatch");
 
-            IPackage module = modules[0];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
-            module = modules["sax"];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
+                IPackage module = modules[0];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
+                module = modules["sax"];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
 
-            Assert.AreEqual(modules[0], modules["sax"], "Modules should be same whether retrieved by name or index.");
+                Assert.AreEqual(modules[0], modules["sax"], "Modules should be same whether retrieved by name or index.");
 
-            Assert.AreEqual("sax", module.Name, "Module name mismatch.");
+                Assert.AreEqual("sax", module.Name, "Module name mismatch.");
 
-            //  All of these should be indicated, in some way, in the Visual Studio treeview.
+                //  All of these should be indicated, in some way, in the Visual Studio treeview.
 
-            Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
+                Assert.IsNotNull(module.PackageJson, "Module package.json should not be null.");
 
-            Assert.IsTrue(
-                module.IsListedInParentPackageJson,
-                "Should be listed as a dependency in parent package.json.");
-            Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
-            Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
-            Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
-            Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
+                Assert.IsTrue(
+                    module.IsListedInParentPackageJson,
+                    "Should be listed as a dependency in parent package.json.");
+                Assert.IsFalse(module.IsMissing, "Should not be marked as missing.");
+                Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
+                Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
+                Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
 
-            //  Redundant?
-            Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
+                //  Redundant?
+                Assert.IsTrue(module.HasPackageJson, "Module should have its own package.json");
+            }
         }
 
         [TestMethod, Priority(0)]
         public void TestReadRootPackageMissingDependency() {
-            var rootDir = CreateRootPackage(PkgSingleDependency);
+            using (var manager = new TemporaryFileManager()) {
+                var rootDir = CreateRootPackage(manager, PkgSingleDependency);
 
-            var pkg = RootPackageFactory.Create(rootDir);
+                var pkg = RootPackageFactory.Create(rootDir);
 
-            var json = pkg.PackageJson;
-            var dependencies = json.AllDependencies;
-            Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
+                var json = pkg.PackageJson;
+                var dependencies = json.AllDependencies;
+                Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
 
-            IDependency dep = dependencies["sax"];
-            Assert.IsNotNull(dep, "sax dependency should not be null.");
-            Assert.AreEqual(">=0.1.0 <0.2.0", dep.VersionRangeText, "Version range mismatch.");
+                IDependency dep = dependencies["sax"];
+                Assert.IsNotNull(dep, "sax dependency should not be null.");
+                Assert.AreEqual(">=0.1.0 <0.2.0", dep.VersionRangeText, "Version range mismatch.");
 
-            var modules = pkg.Modules;
-            Assert.AreEqual(1, modules.Count, "Module count mismatch");
+                var modules = pkg.Modules;
+                Assert.AreEqual(1, modules.Count, "Module count mismatch");
 
-            IPackage module = modules[0];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
-            module = modules["sax"];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
+                IPackage module = modules[0];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
+                module = modules["sax"];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
 
-            Assert.AreEqual(modules[0], modules["sax"], "Modules should be same whether retrieved by name or index.");
+                Assert.AreEqual(modules[0], modules["sax"], "Modules should be same whether retrieved by name or index.");
 
-            Assert.AreEqual("sax", module.Name, "Module name mismatch.");
+                Assert.AreEqual("sax", module.Name, "Module name mismatch.");
 
-            //  All of these should be indicated, in some way, in the Visual Studio treeview.
+                //  All of these should be indicated, in some way, in the Visual Studio treeview.
 
-            Assert.IsNull(module.PackageJson, "Module package.json should be null for missing dependency.");
+                Assert.IsNull(module.PackageJson, "Module package.json should be null for missing dependency.");
 
-            Assert.IsTrue(
-                module.IsListedInParentPackageJson,
-                "Should be listed as a dependency in parent package.json.");
-            Assert.IsTrue(module.IsMissing, "Should be marked as missing.");
-            Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
-            Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
-            Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
+                Assert.IsTrue(
+                    module.IsListedInParentPackageJson,
+                    "Should be listed as a dependency in parent package.json.");
+                Assert.IsTrue(module.IsMissing, "Should be marked as missing.");
+                Assert.IsFalse(module.IsDevDependency, "Should not be marked as dev dependency.");
+                Assert.IsFalse(module.IsOptionalDependency, "Should not be marked as optional dependency.");
+                Assert.IsFalse(module.IsBundledDependency, "Should not be marked as bundled dependency.");
 
-            //  Redundant?
-            Assert.IsFalse(module.HasPackageJson, "Missing module should not have its own package.json");
+                //  Redundant?
+                Assert.IsFalse(module.HasPackageJson, "Missing module should not have its own package.json");
+            }
         }
 
         [TestMethod, Priority(0)]
         public void TestReadRootDependencyRecursive() {
-            var rootDir = CreateRootPackage(PkgSingleRecursiveDependency);
-            RunNpmInstall(rootDir);
+            using (var manager = new TemporaryFileManager()) {
 
-            var pkg = RootPackageFactory.Create(rootDir);
+                var rootDir = CreateRootPackage(manager, PkgSingleRecursiveDependency);
+                RunNpmInstall(rootDir);
 
-            var json = pkg.PackageJson;
-            var dependencies = json.AllDependencies;
-            Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
+                var pkg = RootPackageFactory.Create(rootDir);
 
-            IDependency dep = dependencies["express"];
-            Assert.IsNotNull(dep, "express dependency should not be null.");
-            Assert.AreEqual("4.0.0", dep.VersionRangeText, "Version range mismatch.");
+                var json = pkg.PackageJson;
+                var dependencies = json.AllDependencies;
+                Assert.AreEqual(1, dependencies.Count, "Dependency count mismatch.");
 
-            var modules = pkg.Modules;
-            Assert.AreEqual(1, modules.Count, "Module count mismatch");
+                IDependency dep = dependencies["express"];
+                Assert.IsNotNull(dep, "express dependency should not be null.");
+                Assert.AreEqual("4.0.0", dep.VersionRangeText, "Version range mismatch.");
 
-            IPackage module = modules[0];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
-            module = modules["express"];
-            Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
+                var modules = pkg.Modules;
+                Assert.AreEqual(1, modules.Count, "Module count mismatch");
 
-            Assert.AreEqual(
-                modules[0],
-                modules["express"],
-                "Modules should be same whether retrieved by name or index.");
+                IPackage module = modules[0];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by index.");
+                module = modules["express"];
+                Assert.IsNotNull(module, "Module should not be null when retrieved by name.");
 
-            Assert.AreEqual("express", module.Name, "Module name mismatch.");
+                Assert.AreEqual(
+                    modules[0],
+                    modules["express"],
+                    "Modules should be same whether retrieved by name or index.");
 
-            Assert.AreEqual("4.0.0", module.Version.ToString(), "Module version mismatch");
+                Assert.AreEqual("express", module.Name, "Module name mismatch.");
 
-            var expectedModules = new string[] {
+                Assert.AreEqual("4.0.0", module.Version.ToString(), "Module version mismatch");
+
+                var expectedModules = new string[] {
                 "accepts",
                 "buffer-crc32",
                 "cookie",
@@ -196,30 +204,31 @@ namespace NpmTests {
                 "utils-merge"
             };
 
-            modules = module.Modules;
+                modules = module.Modules;
 
-            Console.WriteLine("module.Modules includes: {0}", string.Join(", ", modules.Select(m => m.Name)));
+                Console.WriteLine("module.Modules includes: {0}", string.Join(", ", modules.Select(m => m.Name)));
 
-            Assert.AreEqual(module.PackageJson.Dependencies.Count, modules.Count, "Sub-module count mismatch.");
-            foreach (var name in expectedModules) {
-                Console.WriteLine("Expecting {0}", name);
-                var current = modules[name];
-                Assert.IsNotNull(current, "Module should not be null when retrieved by name.");
+                Assert.AreEqual(module.PackageJson.Dependencies.Count, modules.Count, "Sub-module count mismatch.");
+                foreach (var name in expectedModules) {
+                    Console.WriteLine("Expecting {0}", name);
+                    var current = modules[name];
+                    Assert.IsNotNull(current, "Module should not be null when retrieved by name.");
 
-                Assert.AreEqual(name, current.Name, "Module name mismatch.");
+                    Assert.AreEqual(name, current.Name, "Module name mismatch.");
 
-                Assert.IsNotNull(current.PackageJson, "Module package.json should not be null.");
+                    Assert.IsNotNull(current.PackageJson, "Module package.json should not be null.");
 
-                Assert.IsTrue(
-                    current.IsListedInParentPackageJson,
-                    "Should be listed as a dependency in parent package.json.");
-                Assert.IsFalse(current.IsMissing, "Should not be marked as missing.");
-                Assert.IsFalse(current.IsDevDependency, "Should not be marked as dev dependency.");
-                Assert.IsFalse(current.IsOptionalDependency, "Should not be marked as optional dependency.");
-                Assert.IsFalse(current.IsBundledDependency, "Should not be marked as bundled dependency.");
+                    Assert.IsTrue(
+                        current.IsListedInParentPackageJson,
+                        "Should be listed as a dependency in parent package.json.");
+                    Assert.IsFalse(current.IsMissing, "Should not be marked as missing.");
+                    Assert.IsFalse(current.IsDevDependency, "Should not be marked as dev dependency.");
+                    Assert.IsFalse(current.IsOptionalDependency, "Should not be marked as optional dependency.");
+                    Assert.IsFalse(current.IsBundledDependency, "Should not be marked as bundled dependency.");
 
-                //  Redundant?
-                Assert.IsTrue(current.HasPackageJson, "Module should have its own package.json");
+                    //  Redundant?
+                    Assert.IsTrue(current.HasPackageJson, "Module should have its own package.json");
+                }
             }
         }
     }

--- a/Nodejs/Tests/NpmTests/NpmTests.csproj
+++ b/Nodejs/Tests/NpmTests/NpmTests.csproj
@@ -82,7 +82,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System" />
-    <Compile Include="AbstractFilesystemPackageJsonTests.cs" />
+    <Compile Include="FilesystemPackageJsonTestHelpers.cs" />
     <Compile Include="AbstractPackageJsonTests.cs" />
     <Compile Include="InstallUninstallPackageTests.cs" />
     <Compile Include="FileSystemPackageJsonTests.cs" />

--- a/Nodejs/Tests/NpmTests/TemporaryFileManager.cs
+++ b/Nodejs/Tests/NpmTests/TemporaryFileManager.cs
@@ -26,7 +26,7 @@ namespace NpmTests {
     /// <remarks>
     /// Each TemporaryFileManager can have a pre- and postfix applied to each file/directory.
     /// </remarks>
-    public class TemporaryFileManager {
+    public class TemporaryFileManager : IDisposable {
         #region Static variables
 
         public const string DEFAULT_EXTENSION = "tmp";


### PR DESCRIPTION
**Defect**
`AbstractFilesystemPackageJsonTests` generates a few test warnings because it has `[TestInitialize]` and `[TestUninitialize]` methods, but is not marked `[TestClass]`.

**Fix**
Remove these init methods and make `AbstractFilesystemPackageJsonTests` use an explicit  TemporaryFileManager for its functions. This makes it clearer what tests need this functionality.

I also renamed the `AbstractFilesystemPackageJsonTests` class since it now can be made static.