### PR TITLE
Auto-Dts: Add PackageSet collection

### DIFF
--- a/Common/Tests/Utilities/AssertUtil.cs
+++ b/Common/Tests/Utilities/AssertUtil.cs
@@ -68,30 +68,24 @@ namespace TestUtilities
             Assert.Inconclusive("Missing Dependency: {0}", dependency);
         }
 
-        public static void ArrayEquals(IList expected, IList actual)
-        {
-            if (expected == null)
-            {
+        public static void ArrayEquals<T>(IEnumerable<T> expected, IEnumerable<T> actual) {
+            if (expected == null) {
                 throw new ArgumentNullException("expected");
             }
-            if (actual == null)
-            {
+            if (actual == null) {
                 Assert.Fail("AssertUtils.ArrayEquals failure. Actual collection is null.");
             }
 
-            if (expected.Count != actual.Count)
-            {
-                Assert.Fail("AssertUtils.ArrayEquals failure. Expected collection with length {0} but got collection with length {1}",
-                    expected.Count, actual.Count);
+            Assert.AreEqual(expected.Count(), actual.Count());
+
+            var expectedIt = expected.GetEnumerator();
+            var actualIt = actual.GetEnumerator();
+
+            while (expectedIt.MoveNext() && actualIt.MoveNext()) {
+                Assert.AreEqual(expectedIt.Current, actualIt.Current);
             }
-            for (int i = 0; i < expected.Count; i++)
-            {
-                if (!expected[i].Equals(actual[i]))
-                {
-                    Assert.Fail("AssertUtils.ArrayEquals failure. Expected value {0} at position {1} but got value {2}",
-                        expected[i], i, actual[i]);
-                }
-            }
+            Assert.IsFalse(expectedIt.MoveNext());
+            Assert.IsFalse(actualIt.MoveNext());
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1")]

--- a/Nodejs/Product/Nodejs/TypingAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingAcquisition.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NodejsTools {
 
             using (var process = ProcessOutput.Run(
                 tsdPath,
-                new[] { "install", "--save" }.Concat(packages.Select(GetPackageTsdName)),
+                TsdInstallArguments(packages),
                 pathToRootProjectDirectory,
                 null,
                 false,
@@ -84,6 +84,10 @@ namespace Microsoft.NodejsTools {
 
         private static string GetPackageTsdName(IPackage package) {
             return package.Name;
+        }
+
+        private static IEnumerable<string> TsdInstallArguments(IEnumerable<IPackage> packages) {
+            return new[] { "install", }.Concat(packages.Select(GetPackageTsdName)).Concat(new[] { "--save" });
         }
     }
 }

--- a/Nodejs/Product/Npm/Npm.csproj
+++ b/Nodejs/Product/Npm/Npm.csproj
@@ -186,6 +186,7 @@
     <Compile Include="SPI\PackageCatalogHelper.cs" />
     <Compile Include="SPI\PackageJson.cs" />
     <Compile Include="SPI\PackageProxy.cs" />
+    <Compile Include="PackageSet.cs" />
     <Compile Include="SPI\Person.cs" />
     <Compile Include="SPI\PkgStringArray.cs" />
     <Compile Include="SPI\PkgFiles.cs" />

--- a/Nodejs/Product/Npm/PackageComparer.cs
+++ b/Nodejs/Product/Npm/PackageComparer.cs
@@ -30,4 +30,22 @@ namespace Microsoft.NodejsTools.Npm {
             return x.Name.CompareTo(y.Name);
         }
     }
+
+    public class PackageEqualityComparer : EqualityComparer<IPackage> {
+        public override bool Equals(IPackage p1, IPackage p2) {
+            return p1.Name == p2.Name
+                && p1.Version == p2.Version
+                && p1.IsBundledDependency == p2.IsBundledDependency
+                && p1.IsDevDependency == p2.IsDevDependency
+                && p1.IsListedInParentPackageJson == p2.IsListedInParentPackageJson
+                && p1.IsMissing == p2.IsMissing
+                && p1.IsOptionalDependency == p2.IsOptionalDependency;
+        }
+
+        public override int GetHashCode(IPackage obj) {
+            if (obj.Name == null || obj.Version == null)
+                return obj.GetHashCode();
+            return obj.Name.GetHashCode() ^ obj.Version.GetHashCode();
+        }
+    }
 }

--- a/Nodejs/Product/Npm/PackageSet.cs
+++ b/Nodejs/Product/Npm/PackageSet.cs
@@ -1,0 +1,110 @@
+//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.NodejsTools.Npm {
+    /// <summary>
+    /// Immutable collection of packages.
+    /// </summary>
+    public class PackageSet : IEnumerable<IPackage> {
+        /// <summary>
+        /// Different between a left package set and right package set.
+        /// </summary>
+        public class Diff {
+            public static readonly Diff Empty =
+                new Diff(
+                    PackageSet.Empty,
+                    Enumerable.Empty<IPackage>(),
+                    Enumerable.Empty<IPackage>());
+
+            private PackageSet _rightPackages;
+
+            private IEnumerable<IPackage> _added;
+            private IEnumerable<IPackage> _removed;
+
+            public static Diff Create(PackageSet l, PackageSet r) {
+                var added = r.Except(l, new PackageEqualityComparer());
+                var removed = l.Except(r, new PackageEqualityComparer());
+                return new Diff(r, added, removed);
+            }
+
+            private Diff(PackageSet r, IEnumerable<IPackage> added, IEnumerable<IPackage> removed) {
+                _rightPackages = r;
+                _added = added;
+                _removed = removed;
+            }
+
+            public Diff Concat(Diff other) {
+                return new Diff(
+                    NewPackages.Concat(other.NewPackages),
+                    Added.Concat(other.Added),
+                    Removed.Concat(other.Removed));
+            }
+
+            /// <summary>
+            /// Set of packages in R.
+            /// </summary>
+            public PackageSet NewPackages { get { return _rightPackages; } }
+
+            /// <summary>
+            /// Elements that are in R that are not in L.
+            /// </summary>
+            public IEnumerable<IPackage> Added { get { return _added; } }
+
+            /// <summary>
+            /// Elements that are in L that are in in R.
+            /// </summary>
+            public IEnumerable<IPackage> Removed { get { return _removed; } }
+        }
+
+        public static PackageSet Empty = new PackageSet(Enumerable.Empty<IPackage>());
+
+        private readonly IEnumerable<IPackage> _packages;
+
+        public PackageSet(IEnumerable<IPackage> packages) {
+            _packages = packages.Distinct(new PackageEqualityComparer());
+        }
+
+        public IEnumerator<IPackage> GetEnumerator() {
+            return _packages.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return _packages.GetEnumerator();
+        }
+
+        public PackageSet Concat(PackageSet other) {
+            return new PackageSet(_packages.Concat(other));
+        }
+
+        /// <summary>
+        /// Compare this package set to another package set, returning an added/removed
+        /// diff of the two.
+        /// </summary>
+        /// <param name="other">Package set to compare against.</param>
+        public Diff DiffAgainst(PackageSet other) {
+            return Diff.Create(this, other);
+        }
+
+        public Diff DiffAgainst(IEnumerable<IPackage> other) {
+            return DiffAgainst(new PackageSet(other));
+        }
+    }
+}

--- a/Nodejs/Tests/NpmTests/NpmTests.csproj
+++ b/Nodejs/Tests/NpmTests/NpmTests.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+    <Reference Include="Moq, Version=4.2.1312.1622, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Compile Include="AbstractFilesystemPackageJsonTests.cs" />
     <Compile Include="AbstractPackageJsonTests.cs" />
@@ -94,6 +95,7 @@
     <Compile Include="NpmSearchTests.cs" />
     <Compile Include="PackageJsonDependencyTests.cs" />
     <Compile Include="PackageJsonTests.cs" />
+    <Compile Include="PackageSetTests.cs" />
     <Compile Include="ProblematicPackageJsonTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SemverVersionTestHelper.cs" />

--- a/Nodejs/Tests/NpmTests/PackageSetTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageSetTests.cs
@@ -1,0 +1,138 @@
+//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using TestUtilities;
+using Microsoft.NodejsTools.Npm;
+using System.Linq;
+using Moq;
+
+namespace NodejsTests {
+    [TestClass]
+    public class PackageSetTests {
+        [TestMethod]
+        public void ShouldBeEmptyForEmptySetOfPackages() {
+            var p = new PackageSet(Enumerable.Empty<IPackage>());
+            Assert.IsFalse(p.Any());
+        }
+
+        [TestMethod]
+        public void ConcatShouldJoinAllPackagesWithoutDuplicates() {
+            var p1 = Mock.Of<IPackage>();
+            var p2 = Mock.Of<IPackage>();
+            var p3 = Mock.Of<IPackage>();
+
+            var set1 = new PackageSet(new[] { p1, p2 });
+            var set2 = new PackageSet(new[] { p1, p3 });
+
+            var joined = set1.Concat(set2);
+            AssertUtil.ArrayEquals(new[] { p1, p2, p3 }, joined);
+        }
+
+        [TestMethod]
+        public void DiffShouldReturnEmptyDiffForEmptyPackageSets() {
+            var package1 = new PackageSet(Enumerable.Empty<IPackage>());
+            var package2 = new PackageSet(Enumerable.Empty<IPackage>());
+
+            var diff = package1.DiffAgainst(package2);
+            Assert.IsFalse(diff.Added.Any());
+            Assert.IsFalse(diff.Removed.Any());
+        }
+
+        [TestMethod]
+        public void DiffShouldReturnAllAsAddedWhenEmpty() {
+            var packageList = new [] {
+                Mock.Of<IPackage>(),
+                Mock.Of<IPackage>(),
+                Mock.Of<IPackage>()
+            };
+
+            var package1 = new PackageSet(Enumerable.Empty<IPackage>());
+            var package2 = new PackageSet(packageList);
+
+            var diff = package1.DiffAgainst(package2);
+            AssertUtil.ArrayEquals(packageList, diff.Added);
+            Assert.IsFalse(diff.Removed.Any());
+        }
+
+        [TestMethod]
+        public void DiffShouldReturnAllAsRemovedAgainstWhenDiffedAgainstEmpty() {
+            var packageList = new [] {
+                Mock.Of<IPackage>(),
+                Mock.Of<IPackage>(),
+                Mock.Of<IPackage>()
+            };
+
+            var package1 = new PackageSet(packageList);
+            var package2 = new PackageSet(Enumerable.Empty<IPackage>());
+
+            var diff = package1.DiffAgainst(package2);
+            Assert.IsFalse(diff.Added.Any());
+            AssertUtil.ArrayEquals(packageList, diff.Removed);
+        }
+
+        [TestMethod]
+        public void DiffShouldReturnForPackagesSetsWithSharedPackages() {
+            var p1 = Mock.Of<IPackage>();
+            var p2 = Mock.Of<IPackage>();
+            var p3 = Mock.Of<IPackage>();
+
+            var package1 = new PackageSet(new [] { p1, p2 });
+            var package2 = new PackageSet(new [] { p1, p3 });
+
+            var diff = package1.DiffAgainst(package2);
+            AssertUtil.ArrayEquals(new [] { p3 }, diff.Added);
+            AssertUtil.ArrayEquals(new [] { p2 }, diff.Removed);
+        }
+        
+        [TestMethod]
+        public void DiffShouldNotMarkPackagesWithSameValuesAsDifferent() {
+            var ver = new SemverVersion(1, 2, 3);
+            var name = "package";
+
+            var p1 = Mock.Of<IPackage>(x => x.Name == name && x.Version == ver);
+            var p2 = Mock.Of<IPackage>();
+            var newP1 = Mock.Of<IPackage>(x => x.Name == name && x.Version == ver);
+
+            var package1 = new PackageSet(new [] { p1, p2 });
+            var package2 = new PackageSet(new [] { newP1 });
+
+            var diff = package1.DiffAgainst(package2);
+            Assert.IsFalse(diff.Added.Any());
+            AssertUtil.ArrayEquals(new [] { p2 }, diff.Removed);
+        }
+
+        [TestMethod]
+        public void DiffShouldMarkPackagesWithSameNameButDifferentVersionsAsDifferent() {
+            var p1Version = new SemverVersion(1, 2, 3);
+            var p2Version = new SemverVersion(1, 2, 4);
+
+            var name = "package";
+
+            var p1 = Mock.Of<IPackage>(x => x.Name == name && x.Version == p1Version);
+            var p2 = Mock.Of<IPackage>();
+            var newP1 = Mock.Of<IPackage>(x => x.Name == name && x.Version == p2Version);
+
+            var package1 = new PackageSet(new [] { p1, p2 });
+            var package2 = new PackageSet(new [] { newP1 });
+
+            var diff = package1.DiffAgainst(package2);
+            AssertUtil.ArrayEquals(new [] { newP1 }, diff.Added);
+            AssertUtil.ArrayEquals(new [] { p1, p2 }, diff.Removed);
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic collection type to manage and compare sets of packages. This makes it easier to track what package  have been added or removed (we currently rely on UI nodes to track the current state.)