### PR TITLE
Fix for #15 - build: Numeric comparison error

### DIFF
--- a/Build/Common.Build.settings
+++ b/Build/Common.Build.settings
@@ -109,7 +109,7 @@
     definitions.
     -->
     <VSMajorVersion>$([System.Double]::Parse($(VSTarget)))</VSMajorVersion>
-    <_VSUpdateVersion Condition="$(VSUpdateVersion)=='' and $(VisualStudioVersion)!='10.0'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\DevDiv\vs\Servicing\$(VSTarget)\devenv', 'UpdateVersion', null, RegistryView.Registry32))</_VSUpdateVersion>
+    <_VSUpdateVersion Condition="$(VSUpdateVersion)=='' and $(VisualStudioVersion)!='10.0'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\vs\Servicing\$(VSTarget)\devenv', 'UpdateVersion', null, RegistryView.Registry32))</_VSUpdateVersion>
     <VSUpdateVersion Condition="$(VSUpdateVersion)=='' and $(_VSUpdateVersion)!=''">$([System.Int32]::Parse($(_VSUpdateVersion.Substring($([MSBuild]::Add(1, $(_VSUpdateVersion.LastIndexOf(`.`))))))))</VSUpdateVersion>
     
     <!-- Features default to true for release builds -->


### PR DESCRIPTION
@johnmcbride reported this error when opening the NodeJsProject with VS2013 #15 . He also came up with a solution, but this was never merged into our branch.

This change applies the suggested solution of removing Wow6432Node from the registry path. I confirmed that msbuild works, as does building through visual studio 2015.

Closes #15