### PR TITLE
Fix for #749 - LogConverter.ParseAddress sometimes throws an error

### DIFF
--- a/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
+++ b/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
@@ -380,7 +380,9 @@ namespace Microsoft.NodejsTools.LogParsing {
         private static ulong ParseAddress(string address) {
             ulong res;
             if (address.StartsWith("0x") || address.StartsWith("0X")) {
-                return UInt64.Parse(address.Substring(2), NumberStyles.AllowHexSpecifier);
+                if (UInt64.TryParse(address.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out res)) {
+                    return res;
+                }
             } else if (UInt64.TryParse(address, out res)) {
                 return res;
             }


### PR DESCRIPTION
Change the hex number path of LogConverter.ParseAddress to use TryParse instead of parse. Return 0 if parsing fails.

closes #749