### PR TITLE
Limit Execution time of IsMissing check for #679

### DIFF
--- a/Nodejs/Product/Npm/SPI/Package.cs
+++ b/Nodejs/Product/Npm/SPI/Package.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class Package : RootPackage, IPackage {
@@ -55,7 +56,14 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         }
 
         public bool IsMissing {
-            get { return IsListedInParentPackageJson && !Directory.Exists(Path); }
+            get {
+                if (!IsListedInParentPackageJson)
+                    return false;
+                // Limit execution time of check
+                var task = new Task<bool>(() => Directory.Exists(Path));
+                task.Start();
+                return !task.Wait(250) || !task.Result;
+            }
         }
 
         public bool IsDevDependency {

--- a/Nodejs/Product/Npm/SPI/Package.cs
+++ b/Nodejs/Product/Npm/SPI/Package.cs
@@ -57,8 +57,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         public bool IsMissing {
             get {
-                if (!IsListedInParentPackageJson)
+                if (!IsListedInParentPackageJson) {
                     return false;
+                }
                 // Limit execution time of check
                 var task = new Task<bool>(() => Directory.Exists(Path));
                 task.Start();


### PR DESCRIPTION
Investigating #679. I can't repo the problem, but from the provided dump, believe that one work around may be to limit how long `Directory.Exists` spends executing. This call may hang for network drives and in other cases.

This logic adds a 250ms timeout to the call. If the call times out, or the directory does not exist, we return that the package is missing.
