### PR TITLE
Use safe cast for fsReadDirSync impl to try to fix #664

### DIFF
--- a/Nodejs/Product/Analysis/Analysis/NodejsModuleBuilder.Specializations.cs
+++ b/Nodejs/Product/Analysis/Analysis/NodejsModuleBuilder.Specializations.cs
@@ -341,8 +341,8 @@ namespace Microsoft.NodejsTools.Analysis {
         }
 
         private static IAnalysisSet FsReadDirSync(FunctionValue func, Node node, AnalysisUnit unit, IAnalysisSet @this, IAnalysisSet[] args) {
-            CallNode call = (CallNode)node;
-            if (call.Arguments.Length == 1) {
+            var call = node as CallNode;
+            if (call != null && call.Arguments.Length == 1) {
                 var ee = new ExpressionEvaluator(unit);
                 IAnalysisSet arraySet;
                 ReadDirSyncArrayValue array;

--- a/Nodejs/Product/Analysis/Analysis/NodejsModuleBuilder.Specializations.cs
+++ b/Nodejs/Product/Analysis/Analysis/NodejsModuleBuilder.Specializations.cs
@@ -315,7 +315,6 @@ namespace Microsoft.NodejsTools.Analysis {
         }
 
         private static IAnalysisSet FsBasename(FunctionValue func, Node node, AnalysisUnit unit, IAnalysisSet @this, IAnalysisSet[] args) {
-            CallNode call = (CallNode)node;
             IAnalysisSet res = AnalysisSet.Empty;
             if (args.Length == 2) {
                 foreach (var extArg in args[1]) {


### PR DESCRIPTION
Trying to address #664. I haven't been able to repo, but I suspect that the issue is that one of the included node packages is using fs.readdirSync differently than we expect (i.e., not just calling it). When the analyzer finds this usage, it crashes on the cast.

This change makes the cast an `as` cast instead.Again, without a repo, I can't be 100% sure this is the root cause, but using a safe cast may very well fix the problem. It shouldn't make anything more broken at least.
