### PR TITLE
Vs14u2 add dts files to project

### DIFF
--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -384,9 +384,9 @@ namespace Microsoft.VisualStudioTools.Project {
             }
             set {
                 this.parentNode = value;
+                OnParentSet(value);
             }
         }
-
 
         [System.ComponentModel.BrowsableAttribute(false)]
         public uint ID {
@@ -970,6 +970,12 @@ namespace Microsoft.VisualStudioTools.Project {
                 return false;
             }
         }
+
+        /// <summary>
+        /// Invoked when the Node's parent is updated.
+        /// </summary>
+        /// <param name="parent">New parent node.</param>
+        protected virtual void OnParentSet(HierarchyNode parent) { /*noop*/ }
 
         protected virtual void RaiseOnItemRemoved(string documentToRemove, string[] filesToBeDeleted) {
             if (!String.IsNullOrWhiteSpace(documentToRemove)) {
@@ -1780,7 +1786,8 @@ namespace Microsoft.VisualStudioTools.Project {
                 }
             }
 
-            node.parentNode = this;
+            node.Parent = this;
+
             ProjectMgr.OnItemAdded(this, node, previousVisible);
 #if DEV10
             // Dev10 won't check the IsHiddenItem flag when we add an item, and it'll just

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -17,6 +17,7 @@
 using System;
 using System.IO;
 using Microsoft.VisualStudioTools.Project;
+using Microsoft.VisualStudioTools;
 #if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
@@ -36,6 +37,16 @@ namespace Microsoft.NodejsTools.Project {
             } else {
                 Analyze();
             }
+        }
+
+        protected override void OnParentSet(HierarchyNode parent) {
+#if DEV14_OR_LATER
+            if (Url.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0) {
+                ProjectMgr.Site.GetUIThread().Invoke(() => {
+                    this.IncludeInProject(true);
+                });
+            }
+#endif
         }
 
         internal void Analyze() {
@@ -80,15 +91,21 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             var includeInProject = base.IncludeInProject(includeChildren);
-            
+
             if (isContent && Url.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
                 this.ItemNode.ItemTypeName = ProjectFileConstants.Content;
             }
-            
+
             ProjectMgr.Analyzer.AnalyzeFile(Url, ShouldAnalyze);
-            
+
             UpdateParentContentType();
             ItemNode.ItemTypeChanged += ItemNode_ItemTypeChanged;
+
+#if DEV14_OR_LATER
+            ProjectMgr.Site.GetUIThread().Invoke(() => {
+                ProjectMgr.OnItemAdded(this.Parent, this);
+            });
+#endif
 
             return includeInProject;
         }
@@ -98,10 +115,10 @@ namespace Microsoft.NodejsTools.Project {
             // Don't report errors since the file won't remain part of the project. This removes the errors from the list.
             ProjectMgr.Analyzer.AnalyzeFile(Url, false);
             var excludeFromProject = base.ExcludeFromProject();
-            
+
             UpdateParentContentType();
             ItemNode.ItemTypeChanged -= ItemNode_ItemTypeChanged;
-            
+
             return excludeFromProject;
         }
 
@@ -118,7 +135,7 @@ namespace Microsoft.NodejsTools.Project {
             base.RenameChildNodes(parentNode);
             this.ProjectMgr.Analyzer.ReloadComplete();
         }
-        
+
         protected override NodeProperties CreatePropertiesObject() {
             if (IsLinkFile) {
                 return new NodejsLinkFileNodeProperties(this);
@@ -136,7 +153,7 @@ namespace Microsoft.NodejsTools.Project {
 
             UpdateParentContentType();
         }
-        
+
         private void UpdateParentContentType() {
             var parent = this.Parent as NodejsFolderNode;
             if (parent != null) {

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         protected override void OnParentSet(HierarchyNode parent) {
-#if DEV14_OR_LATER
+#if DEV14
             if (Url.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0) {
                 ProjectMgr.Site.GetUIThread().Invoke(() => {
                     this.IncludeInProject(true);
@@ -101,7 +101,7 @@ namespace Microsoft.NodejsTools.Project {
             UpdateParentContentType();
             ItemNode.ItemTypeChanged += ItemNode_ItemTypeChanged;
 
-#if DEV14_OR_LATER
+#if DEV14
             ProjectMgr.Site.GetUIThread().Invoke(() => {
                 ProjectMgr.OnItemAdded(this.Parent, this);
             });


### PR DESCRIPTION
There are two problems with Intellisense in Dev14 Update 2, when using typescript for Javascript Intellisense:
* You have to rename the d.ts files to trigger Intellisense to work. Just including the file in the project is not enough
* typings files are not automatically picked up or added to the project.

This change fixes both of these issues.

The first for the first is triggering an `OnItemAdded` to get an included d.ts file noticed by type script

The second part is fixed by auto including any file node that is in the typings directory.