### PR TITLE
Bump Version up to 1.2

### DIFF
--- a/Nodejs/Product/AssemblyVersion.cs
+++ b/Nodejs/Product/AssemblyVersion.cs
@@ -37,7 +37,7 @@ class AssemblyVersionInfo {
     // This version string (and the comment for Version) should be updated
     // manually between minor releases (e.g. from 1.0 to 1.1).
     // Servicing branches and prereleases should retain the value.
-    public const string FileVersion = "1.1";
+    public const string FileVersion = "1.2";
 
     // This version should never change from "4100.00"; BuildRelease.ps1
     // will replace it with a generated value.
@@ -63,6 +63,6 @@ class AssemblyVersionInfo {
     // Defaults to "1.0.0.(2012|2013|2015)"
     public const string StableVersion = ReleaseVersion + "." + VSVersionSuffix;
 
-    // Defaults to "1.1.4100.00"
+    // Defaults to "1.2.4100.00"
     public const string Version = FileVersion + "." + BuildNumber;
 }

--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8">
     <Name>Node.js Tools - Interactive Window</Name>
     <Author>Microsoft</Author>
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <Description xml:space="preserve">Node.js Tools - Interactive Window</Description>
     <MoreInfoUrl>http://nodejstools.codeplex.com</MoreInfoUrl>
     <GettingStartedGuide>http://nodejstools.codeplex.com</GettingStartedGuide>

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -1,6 +1,6 @@
 ﻿<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.1" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.2" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools</DisplayName>
     <Description xml:space="preserve">Provides support for editing and debugging Node.js programs.</Description>
     <MoreInfo>http://nodejstools.codeplex.com</MoreInfo>

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -18,7 +18,7 @@
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="4.5" />
     <Dependency Id="TestWindow.Microsoft.0771d463-d74d-4e95-aac2-39d3c7ec1f97" IsRequired="false" DisplayName="Test Explorer" Version="11.0" />
-    <Dependency Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8" IsRequired="true" DisplayName="Node.js Tools - Interactive Window" Version="1.0"/>
+    <Dependency Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8" IsRequired="true" DisplayName="Node.js Tools - Interactive Window" Version="1.2"/>
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="B515653F-FB69-4B64-9D3F-F1FCF8421DD0">
     <Name>Node.js Tools - Profiling</Name>
     <Author>Microsoft</Author>
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <Description xml:space="preserve">Provides support for profiling Node.js projects</Description>
     <MoreInfoUrl>http://nodejstools.codeplex.com</MoreInfoUrl>
     <GettingStartedGuide>http://nodejstools.codeplex.com</GettingStartedGuide>
@@ -24,7 +24,7 @@
     <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
       <Name>Visual Studio MPF</Name>
     </Reference>
-    <Reference Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" MinVersion="1.1" MaxVersion="1.1">
+    <Reference Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" MinVersion="1.2" MaxVersion="1.2">
       <Name>Node.js Tools for Visual Studio</Name>
     </Reference>
   </References>


### PR DESCRIPTION
Just upgrading package version to 1.2.

Closes #777

After merging this patch, developers may have problems deploying a new build. Try following these steps: https://social.msdn.microsoft.com/Forums/en-US/98dda5fc-1b07-474a-a73e-4e1a4cc23ab8/vsix-development-error-vssdk1040-there-was-a-problem-enabling-the-extension-with-a-vsix-identifier?forum=vsx
to delete the experimental hive of VS. I did this and was able to rebuild again after that.