### PR TITLE
Make sure auto-dts is disabled for typescript projects

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -14,10 +14,13 @@
 //
 //*********************************************************//
 
+using System;
+
 namespace Microsoft.NodejsTools {
     internal class NodejsConstants {
         internal const string JavaScriptExtension = ".js";
         internal const string TypeScriptExtension = ".ts";
+        internal const string TypeScriptDeclarationExtension = ".d.ts";
         internal const string MapExtension = ".map";
         internal const string NodejsProjectExtension = ".njsproj";
 
@@ -69,5 +72,14 @@ namespace Microsoft.NodejsTools {
         internal const string TypeScript = "TypeScript";
 
         internal const string NodeToolsProcessIdEnvironmentVariable = "_NTVS_PID";
+
+        /// <summary>
+        /// Checks whether a relative and double-backslashed seperated path contains a folder name.
+        /// </summary>
+        public static bool ContainsNodeModulesOrBowerComponentsFolder(string path) {
+            string tmp = "\\" + path + "\\";
+            return tmp.IndexOf("\\" + NodeModulesFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0
+                || tmp.IndexOf("\\" + BowerComponentsFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
     }
 }

--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -76,7 +76,7 @@ namespace Microsoft.NodejsTools {
         /// <summary>
         /// Checks whether a relative and double-backslashed seperated path contains a folder name.
         /// </summary>
-        public static bool ContainsNodeModulesOrBowerComponentsFolder(string path) {
+        internal static bool ContainsNodeModulesOrBowerComponentsFolder(string path) {
             string tmp = "\\" + path + "\\";
             return tmp.IndexOf("\\" + NodeModulesFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0
                 || tmp.IndexOf("\\" + BowerComponentsFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0;

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -241,15 +241,6 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
             return !dirName.Split(new char[] { '/', '\\' }).Any(name => name.StartsWith("."));
         }
 
-        /// <summary>
-        /// Checks whether a relative and double-backslashed seperated path contains a folder name.
-        /// </summary>
-        private static bool ContainsNodeModulesOrBowerComponentsFolder(string path) {
-            string tmp = "\\" + path + "\\";
-            return tmp.IndexOf("\\" + NodejsConstants.NodeModulesFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                tmp.IndexOf("\\" + NodejsConstants.BowerComponentsFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0;
-        }
-
         internal static void WriteProjectXml(
             XmlWriter writer,
             string projectPath,
@@ -329,7 +320,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
 
             // Exclude node_modules and bower_components folders.
             if (excludeNodeModules) {
-                folders.RemoveWhere(folder => ContainsNodeModulesOrBowerComponentsFolder(folder));
+                folders.RemoveWhere(NodejsConstants.ContainsNodeModulesOrBowerComponentsFolder);
             }
 
             writer.WriteStartElement("ItemGroup");
@@ -431,7 +422,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
             }
 
             foreach (var dir in directories) {
-                if (excludeNodeModules && ContainsNodeModulesOrBowerComponentsFolder(dir)) {
+                if (excludeNodeModules && NodejsConstants.ContainsNodeModulesOrBowerComponentsFolder(dir)) {
                     continue;
                 }
                 try {

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NodejsTools.Project {
                 return;
             }
 
-            if (Url.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0) {
+            if (Url.EndsWith(NodejsConstants.TypeScriptDeclarationExtension, StringComparison.OrdinalIgnoreCase) && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0) {
                 ProjectMgr.Site.GetUIThread().Invoke(() => {
                     this.IncludeInProject(true);
                 });

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NodejsTools.Project {
         private readonly Dictionary<NodejsProjectImageName, int> _imageIndexFromNameDictionary = new Dictionary<NodejsProjectImageName, int>();
 
 #if DEV14
-        private bool _projectHasTypeScriptFiles = false;
+        private bool _projectIsOnlyJavascript = false;
         private TypingsAcquisition _typingsAcquirer;
 #endif
 
@@ -108,7 +108,7 @@ namespace Microsoft.NodejsTools.Project {
 #if DEV14
         private bool ShouldAcquireTypingsAutomatically {
             get {
-                return !_projectHasTypeScriptFiles
+                return _projectIsOnlyJavascript
                     && NodejsPackage.Instance.IntellisenseOptionsPage.EnableES6Preview;
             }
         }
@@ -244,8 +244,10 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         protected override void FinishProjectCreation(string sourceFolder, string destFolder) {
+            bool foundTypeScriptFile = false;
             foreach (MSBuild.ProjectItem item in this.BuildProject.Items) {
                 if (String.Equals(Path.GetExtension(item.EvaluatedInclude), NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase)) {
+                    foundTypeScriptFile = true;
 
                     // Create the 'typings' folder
                     var typingsFolder = Path.Combine(ProjectHome, "Scripts", "typings");
@@ -276,6 +278,7 @@ namespace Microsoft.NodejsTools.Project {
                     break;
                 }
             }
+            _projectIsOnlyJavascript = !foundTypeScriptFile;
 
             base.FinishProjectCreation(sourceFolder, destFolder);
         }
@@ -286,7 +289,7 @@ namespace Microsoft.NodejsTools.Project {
             if (string.Equals(Path.GetExtension(fileName), NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase) && !IsTypeScriptProject) {
                 // enable type script on the project automatically...
 #if DEV14
-                _projectHasTypeScriptFiles = true;
+                _projectIsOnlyJavascript = false;
 #endif
                 SetProjectProperty(NodejsConstants.EnableTypeScript, "true");
                 SetProjectProperty(NodejsConstants.TypeScriptSourceMap, "true");


### PR DESCRIPTION
**Defect**
Previously, auto typings acquisition was based on an opt-out flag. We opted a project out of typings acquisition if it had any TypeScript files. This caused a race condition for projects that had not fully loaded.

**Fix**
This inverts the condition to make it opt-in instead. Only if we fully load a project and find that it contains no typescript files do we enable auto-dts.


Closes #776