### PR TITLE
Fix null dereference in Diagnostics command.

### DIFF
--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -173,10 +173,14 @@ namespace Microsoft.NodejsTools.Commands {
 
         private static string GetProjectProperty(EnvDTE.Project project, string name) {
             try {
-                return project.Properties.Item(name).Value.ToString();
+                var item = project.Properties.Item(name);
+                if (item != null && item.Value != null) {
+                    return item.Value.ToString();
+                }
             } catch {
-                return "<undefined>";
+                // noop
             }
+            return "<undefined>";
         }
 
         public override int CommandId {


### PR DESCRIPTION
I hit a null dereference on `DiagnosticsCommand.GetProjectProperty` while debugging. This exception is handled so there should be no userbad, but we still should check for null instead of throwing an exception.