### PR TITLE
Fix potential parse error for large hex numbers

### DIFF
--- a/Nodejs/Product/Analysis/JavaScript/jsparser.cs
+++ b/Nodejs/Product/Analysis/JavaScript/jsparser.cs
@@ -3902,7 +3902,13 @@ namespace Microsoft.NodejsTools.Parsing
                             }
 
                             // parse the number as a hex integer, converted to a double
-                            doubleValue = (double)System.Convert.ToInt64(str, 16);
+                            long hexValue;
+                            if (Int64.TryParse(str.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out hexValue)) {
+                                doubleValue = hexValue;
+                            } else {
+                                doubleValue = 0;
+                                return false;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
**Defect**
Very large hex numbers cause `ConvertNumericLiteralToDouble` to throw an exception when `Convert.toInt64` is called.

**Fix**
Use `int64.TryParse` instead to handle this case without throwing an exception.