### PR TITLE
Fix for #765 - Open With and Window/open

### DIFF
--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -20,8 +20,7 @@ using System;
 
 namespace Microsoft.NodejsTools
 {
-    static class Guids
-    {
+    static class Guids {
         public const string NodejsPackageString = "FE8A8C3D-328A-476D-99F9-2A24B75F8C7F";
         public const string NodejsCmdSetString = "695e37e2-c6df-4e0a-8833-f688e4c65f1f";
         public const string NodejsDebugLanguageString = "{65791609-BA29-49CF-A214-DBFF8AEC3BC2}";
@@ -29,7 +28,8 @@ namespace Microsoft.NodejsTools
         public const string NodejsEditorFactoryPromptEncodingString = "C8576E92-EFB6-4414-8F63-C84D474A539E";
         //do not remove the curly braces. Without curly braces, in certain cases some language service features (e.g. snippets)  will fail to load because
         //some comparisons in native code surround the guid string with curlies, and they'll fail to match unless we also surround the guid string with curlies.
-        public const string NodejsLanguageInfoString = "{ABD5E8A5-5A35-4BE9-BCAF-E10C1212CB40}";
+        public const string NodejsLanguageInfoGuidString = "ABD5E8A5-5A35-4BE9-BCAF-E10C1212CB40";
+        public const string NodejsLanguageInfoString = "{" + NodejsLanguageInfoGuidString + "}";
         public const string NodejsNpmCmdSetString = "9F4B31B4-09AC-4937-A2E7-F4BC02BB7DBA";
         public const string NodejsProjectFactoryString = "3AF33F2E-1136-4D97-BBB7-1795711AC8B8";
         public const string NodejsBaseProjectFactoryString = "9092AA53-FB77-4645-B42D-1CCCA6BD08BD";

--- a/Nodejs/Product/Nodejs/NodejsEditorFactory.cs
+++ b/Nodejs/Product/Nodejs/NodejsEditorFactory.cs
@@ -249,7 +249,7 @@ namespace Microsoft.NodejsTools {
         }
 
         private void InitializeLanguageService(IVsTextLines textLines) {
-            InitializeLanguageService(textLines, typeof(NodejsEditorFactory).GUID);
+            InitializeLanguageService(textLines, typeof(NodejsLanguageInfo).GUID);
         }
 
         private IntPtr CreateDocumentView(string documentMoniker, string physicalView, IVsHierarchy hierarchy, uint itemid, IVsTextLines textLines, bool createdDocData, out string editorCaption, out Guid cmdUI) {

--- a/Nodejs/Product/Nodejs/NodejsLanguageInfo.cs
+++ b/Nodejs/Product/Nodejs/NodejsLanguageInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NodejsTools {
     /// provide a code window manager so that we can have a navigation bar (actually we don't, this
     /// should be switched over to using our TextViewCreationListener instead).
     /// </summary>
-    [Guid("ABD5E8A5-5A35-4BE9-BCAF-E10C1212CB40")]
+    [Guid(Guids.NodejsLanguageInfoGuidString)]
     internal sealed class NodejsLanguageInfo : IVsLanguageInfo, IVsLanguageDebugInfo {
         private readonly IServiceProvider _serviceProvider;
         private readonly IComponentModel _componentModel;


### PR DESCRIPTION
#765 - Can't open the same js file in mutliple windows

I believe the root cause is `InitializeLanguageService ` where we are passing in the `NodejsEditorFactory` guid instead of the `NodejsLanguageServiceGuid`. This causes `InitializeLanguageService` to throw an exception.

Change also removed a copy and pasted guid string.

closes #765