### PR TITLE
Always install node.d.ts typing file

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -152,11 +152,9 @@ namespace Microsoft.NodejsTools.Project {
                     package.IsDependency
                     || package.IsOptionalDependency
                     || package.IsDevDependency
-                    || !package.IsListedInParentPackageJson)
-                .Select(package => package.Name)
-                .Concat(new[] { "node" });
+                    || !package.IsListedInParentPackageJson);
 
-            TryToAcquireTypings(currentPackages);
+            TryToAcquireTypings(currentPackages.Select(package => package.Name));
         }
 #endif
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -133,11 +133,14 @@ namespace Microsoft.NodejsTools.Project {
                 return;
             }
 
-            var currentPackages = controller.RootPackage.Modules.Where(package =>
-                package.IsDependency
-                || package.IsOptionalDependency
-                || package.IsDevDependency
-                || !package.IsListedInParentPackageJson);
+            var currentPackages = controller.RootPackage.Modules
+                .Where(package =>
+                    package.IsDependency
+                    || package.IsOptionalDependency
+                    || package.IsDevDependency
+                    || !package.IsListedInParentPackageJson)
+                .Select(package => package.Name)
+                .Concat(new[] { "node" });
 
             TypingsAcquirer
                 .AcquireTypings(currentPackages, null /*redirector*/)


### PR DESCRIPTION
This change ensures that we install `node.d.ts` for intellisense, even if `node` is not explicitly required by another installed package. 

I think we should merge this change in because it makes things better. However, there is currently an issue where `OnIdleNodeModules` is never fired for projects without any node modules. Because this callback is never fired, we never try to acquire any typings. I'm looking into handling that, but a proper fix may involve changing the existing behavior of the code.

closes #770