### PR TITLE
Remove dev11 and dev12 guards in NodeJs files

### DIFF
--- a/Common/Tests/MockVsTests/MockVsRunningDocumentTable.cs
+++ b/Common/Tests/MockVsTests/MockVsRunningDocumentTable.cs
@@ -19,11 +19,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudioTools.MockVsTests {
-    class MockVsRunningDocumentTable : IVsRunningDocumentTable
-#if DEV12_OR_LATER
-        , IVsRunningDocumentTable4
-#endif
-        {
+    class MockVsRunningDocumentTable : IVsRunningDocumentTable, IVsRunningDocumentTable4 {
         private readonly MockVs _vs;
         private readonly Dictionary<uint, DocInfo> _table = new Dictionary<uint, DocInfo>();
         private readonly Dictionary<string, uint> _ids = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
@@ -303,7 +299,6 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
             throw new NotImplementedException();
         }
 
-#if DEV12_OR_LATER
         public uint GetRelatedSaveTreeItems(uint cookie, uint grfSave, uint celt, VSSAVETREEITEM[] rgSaveTreeItems) {
             throw new NotImplementedException();
         }
@@ -379,6 +374,5 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         public Guid GetDocumentProjectGuid(uint cookie) {
             throw new NotImplementedException();
         }
-#endif
     }
 }

--- a/Common/Tests/MockVsTests/MockVsRunningDocumentTable.cs
+++ b/Common/Tests/MockVsTests/MockVsRunningDocumentTable.cs
@@ -19,7 +19,11 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudioTools.MockVsTests {
-    class MockVsRunningDocumentTable : IVsRunningDocumentTable, IVsRunningDocumentTable4 {
+    class MockVsRunningDocumentTable : IVsRunningDocumentTable
+#if DEV12_OR_LATER
+        , IVsRunningDocumentTable4
+#endif
+        {
         private readonly MockVs _vs;
         private readonly Dictionary<uint, DocInfo> _table = new Dictionary<uint, DocInfo>();
         private readonly Dictionary<string, uint> _ids = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
@@ -299,6 +303,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
             throw new NotImplementedException();
         }
 
+#if DEV12_OR_LATER
         public uint GetRelatedSaveTreeItems(uint cookie, uint grfSave, uint celt, VSSAVETREEITEM[] rgSaveTreeItems) {
             throw new NotImplementedException();
         }
@@ -374,5 +379,6 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         public Guid GetDocumentProjectGuid(uint cookie) {
             throw new NotImplementedException();
         }
+#endif
     }
 }

--- a/Nodejs/Product/InteractiveWindow/InteractiveWindow.vsct
+++ b/Nodejs/Product/InteractiveWindow/InteractiveWindow.vsct
@@ -245,10 +245,6 @@
             bitmap strip containing the bitmaps and then there are the numeric ids of the elements used 
             inside a button definition. An important aspect of this declaration is that the element id 
             must be the actual index (1-based) of the bitmap inside the bitmap strip. -->
-            <Bitmap guid="guidReplToolbarImages" href="..\..\..\Common\Product\Icons\Dev11.0\ReplToolBarImages.bmp" usedList="bmpCancelEval, bmpResetSession, bmpClearScreen"
-                    Condition="Defined(DEV11)"/>
-            <Bitmap guid="guidReplToolbarImages" href="..\..\..\Common\Product\Icons\Dev12.0\ReplToolBarImages.bmp" usedList="bmpCancelEval, bmpResetSession, bmpClearScreen"
-                    Condition="Defined(DEV12)"/>
             <Bitmap guid="guidReplToolbarImages" href="..\..\..\Common\Product\Icons\Dev14.0\ReplToolBarImages.bmp" usedList="bmpCancelEval, bmpResetSession, bmpClearScreen"
                     Condition="Defined(DEV14)"/>
             <Bitmap guid="guidReplToolbarImages" href="..\..\..\Common\Product\Icons\Dev15.0\ReplToolBarImages.bmp" usedList="bmpCancelEval, bmpResetSession, bmpClearScreen"

--- a/Nodejs/Product/Nodejs/Classifier/NodejsClassifierProvider.cs
+++ b/Nodejs/Product/Nodejs/Classifier/NodejsClassifierProvider.cs
@@ -77,11 +77,7 @@ namespace Microsoft.NodejsTools.Classifier {
 
         [Export]
         [Name(NodejsPredefinedClassificationTypeNames.Operator)]
-#if DEV11_OR_LATER
         [BaseDefinition(PredefinedClassificationTypeNames.Operator)]
-#else
-        [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
-#endif
         internal static ClassificationTypeDefinition OperatorClassificationDefinition = null; // Set via MEF
 
         #endregion

--- a/Nodejs/Product/Nodejs/Editor/BraceCompletion/BraceCompletionContext.cs
+++ b/Nodejs/Product/Nodejs/Editor/BraceCompletion/BraceCompletionContext.cs
@@ -13,7 +13,6 @@
 //    permissions and limitations under the License.
 //
 //*********************************************************//
-#if DEV12_OR_LATER
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
@@ -146,4 +145,3 @@ namespace Microsoft.NodejsTools.Editor.BraceCompletion {
         }
     }
 }
-#endif

--- a/Nodejs/Product/Nodejs/Editor/BraceCompletion/BraceCompletionContextProvider.cs
+++ b/Nodejs/Product/Nodejs/Editor/BraceCompletion/BraceCompletionContextProvider.cs
@@ -13,7 +13,6 @@
 //    permissions and limitations under the License.
 //
 //*********************************************************//
-#if DEV12_OR_LATER
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using Microsoft.NodejsTools.Classifier;
@@ -66,4 +65,3 @@ namespace Microsoft.NodejsTools.Editor.BraceCompletion {
         }
     }
 }
-#endif

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectPackage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectPackage.cs
@@ -22,9 +22,6 @@ using Microsoft.VisualStudioTools.Project;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio;
 using Microsoft.NodejsTools;
-#if DEV11
-using Microsoft.VisualStudio.Shell.Interop;
-#endif
 
 namespace Microsoft.NodejsTools.Project {
     //Set the projectsTemplatesDirectory to a non-existant path to prevent VS from including the working directory as a valid template path

--- a/Nodejs/Product/Nodejs/ProvideEditorExtension2Attribute.cs
+++ b/Nodejs/Product/Nodejs/ProvideEditorExtension2Attribute.cs
@@ -71,12 +71,10 @@ namespace Microsoft.NodejsTools {
             _extensions = extensions;
         }
 
-#if DEV11_OR_LATER
         public ProvideEditorExtension2Attribute(object factoryType, string extension, int priority, __VSPHYSICALVIEWATTRIBUTES commonViewAttributes, params string[] extensions) :
             this(factoryType, extension, priority, extensions) {
             _commonViewAttrs = commonViewAttributes;
         }
-#endif
 
         /// <include file='doc\ProvideEditorExtensionAttribute.uex' path='docs/doc[@for="ProvideEditorExtensionAttribute.Extension"]' />
         /// <devdoc>

--- a/Nodejs/Product/ProjectWizard/CloudServiceWizard.cs
+++ b/Nodejs/Product/ProjectWizard/CloudServiceWizard.cs
@@ -31,11 +31,7 @@ namespace Microsoft.NodejsTools.ProjectWizard {
         private IWizard _wizard;
         private readonly bool _recommendUpgrade;
 
-#if DEV11
-        const string AzureToolsDownload = "https://go.microsoft.com/fwlink/p/?linkid=323511";
-#elif DEV12
-        const string AzureToolsDownload = "https://go.microsoft.com/fwlink/p/?linkid=323510";
-#elif DEV14
+#if DEV14
         const string AzureToolsDownload = "http://go.microsoft.com/fwlink/?LinkID=517353";
 #elif DEV15
         // TODO - add Azure Tools download url when available

--- a/Nodejs/Product/ProjectWizard/SettingsManagerCreator.cs
+++ b/Nodejs/Product/ProjectWizard/SettingsManagerCreator.cs
@@ -25,11 +25,7 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudioTools {
     static class SettingsManagerCreator {
-#if DEV11
-        const string VSVersion = "11.0";
-#elif DEV12
-        const string VSVersion = "12.0";
-#elif DEV14
+#if DEV14
         const string VSVersion = "14.0";
 #elif DEV15
         const string VSVersion = "15.0";

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -491,12 +491,11 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
                         OnTestContainersChanged(e.Project);
                         break;
-#if DEV12_OR_LATER
+
                     // Dev12 renames files instead of overwriting them when
                     // saving, so we need to listen for renames where the new
                     // path is part of the project.
                     case TestFileChangedReason.Renamed:
-#endif
                     case TestFileChangedReason.Changed:
                         OnTestContainersChanged(GetTestProjectFromFile(e.File));
                         break;

--- a/Nodejs/Tests/Core.UI/BasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/BasicProjectTests.cs
@@ -711,21 +711,13 @@ namespace Microsoft.Nodejs.Tests.UI {
                     Keyboard.Type("."); // bad filename
                     Keyboard.Type(System.Windows.Input.Key.Enter);
 
-#if DEV11_OR_LATER
                     VisualStudioApp.CheckMessageBox(MessageBoxButton.Ok, "Directory names cannot contain any of the following characters");
-#else
-                VisualStudioApp.CheckMessageBox(MessageBoxButton.Ok, ". is an invalid filename");
-#endif
                     System.Threading.Thread.Sleep(1000);
 
                     Keyboard.Type(".."); // another bad filename
                     Keyboard.Type(System.Windows.Input.Key.Enter);
 
-#if DEV11_OR_LATER
                     VisualStudioApp.CheckMessageBox(MessageBoxButton.Ok, "Directory names cannot contain any of the following characters");
-#else
-                VisualStudioApp.CheckMessageBox(MessageBoxButton.Ok, ".. is an invalid filename");
-#endif
                     System.Threading.Thread.Sleep(1000);
 
                     Keyboard.Type("Y"); // another bad filename

--- a/Nodejs/Tests/Core.UI/SmartIndent.cs
+++ b/Nodejs/Tests/Core.UI/SmartIndent.cs
@@ -349,9 +349,7 @@ bar""
                 int indentSize = 4,
                 int tabSize = 4) {
                     _options.AddRange(new[] {
-#if DEV12_OR_LATER
                     new OptionHolder("TextEditor", "Node.js", "BraceCompletion", braceCompletion),
-#endif
                     new OptionHolder("TextEditor", "Node.js", "InsertTabs", insertTabs),
                     new OptionHolder("TextEditor", "Node.js", "IndentSize", indentSize),
                     new OptionHolder("TextEditor", "Node.js", "TabSize", tabSize)


### PR DESCRIPTION
Part of #761. We now only support dev14 and dev15, so these guards are not needed going forward.

Does not touch files in `common`.