### PR TITLE
Use appveyor.yaml for CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,6 @@
     - nodejs_version: 4
       vs_version: 14.0
       architecture: x64
-    - nodejs_version: 0.12
-      vs_version: 12.0
-      architecture: x64
     - nodejs_version: 5
       vs_version: 14.0
       architecture: x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,20 +16,29 @@
   install: &default_install_script
     - ps: >-
         Install-Product node $env:nodejs_version $env:architecture
+
         node -v
+
         "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
+
         $node = which node
+
         $node = $node.Replace("/c/", "C:\").Replace("/", "\") + ".exe"
+
         echo $node
+
         netsh advfirewall firewall add rule name="Nodejs" dir=in action=allow program="$node" enable=yes
   build_script: &default_build_script
     - ps: >-
         regedit /s c:\projects\nodejstools\Nodejs\Prerequisites\EnableSkipVerification.reg
+
         msiexec /package C:\projects\nodejstools\Common\Tests\Prerequisites\VSTestHost.msi /quiet
+
         powershell -ExecutionPolicy RemoteSigned C:\projects\nodejstools\Nodejs\Setup\BuildRelease.ps1 C:\NTVS_Out -skipcopy -skipdebug -skipclean -vsTarget $env:vs_version
   test_script: &default_test_script
     - ps: >-
         $testsettings_version = $env:vs_version -replace '11.0', '12.0'
+
         vstest.console /TestCaseFilter:"TestCategory!=AppVeyorIgnore&TestCategory!=Ignore" /logger:Appveyor $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\NpmTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\NodeTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\ProfilerTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\JSAnalysisTests.dll") /settings:$("C:\projects\nodejstools\Build\default." + $testsettings_version + "Exp.testsettings")
 -
   version: 1.0.{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+-
+  version: 1.0.{build}
+  branches:
+    only:
+    - master
+  skip_tags: true
+  image: Visual Studio 2015
+  environment:
+    matrix:
+    - nodejs_version: 4
+      vs_version: 14.0
+      architecture: x64
+    - nodejs_version: 0.12
+      vs_version: 12.0
+      architecture: x64
+    - nodejs_version: 5
+      vs_version: 14.0
+      architecture: x86
+  install: &default_install_script
+    - ps: >-
+        Install-Product node $env:nodejs_version $env:architecture
+        node -v
+        "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
+        $node = which node
+        $node = $node.Replace("/c/", "C:\").Replace("/", "\") + ".exe"
+        echo $node
+        netsh advfirewall firewall add rule name="Nodejs" dir=in action=allow program="$node" enable=yes
+  build_script: &default_build_script
+    - ps: >-
+        regedit /s c:\projects\nodejstools\Nodejs\Prerequisites\EnableSkipVerification.reg
+        msiexec /package C:\projects\nodejstools\Common\Tests\Prerequisites\VSTestHost.msi /quiet
+        powershell -ExecutionPolicy RemoteSigned C:\projects\nodejstools\Nodejs\Setup\BuildRelease.ps1 C:\NTVS_Out -skipcopy -skipdebug -skipclean -vsTarget $env:vs_version
+  test_script: &default_test_script
+    - ps: >-
+        $testsettings_version = $env:vs_version -replace '11.0', '12.0'
+        vstest.console /TestCaseFilter:"TestCategory!=AppVeyorIgnore&TestCategory!=Ignore" /logger:Appveyor $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\NpmTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\NodeTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\ProfilerTests.dll") $("C:\projects\nodejstools\BuildOutput\Release" + $env:vs_version + "\Tests\JSAnalysisTests.dll") /settings:$("C:\projects\nodejstools\Build\default." + $testsettings_version + "Exp.testsettings")
+-
+  version: 1.0.{build}
+  branches:
+    only:
+    - v1.1.x
+  skip_tags: true
+  image: Visual Studio 2015
+  environment:
+    matrix:
+    - nodejs_version: 4
+      vs_version: 14.0
+      architecture: x64
+    - nodejs_version: 0.12
+      vs_version: 12.0
+      architecture: x64
+    - nodejs_version: 5
+      vs_version: 14.0
+      architecture: x86
+  install: *default_install_script
+  build_script: *default_build_script
+  test_script: *default_test_script


### PR DESCRIPTION
This allows us to use some more fancy configuration options for CI.

Creates two configurations, one for master and one for v1.1.x. Master no longer builds VS12, but v1.1.x will