### PR TITLE
Gate VS 2015 *.d.ts include in project

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -40,8 +40,7 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         protected override void OnParentSet(HierarchyNode parent) {
-#if DEV14
-            if (ProjectMgr == null || ProjectMgr.Analyzer == null) {
+            if (ProjectMgr == null || ProjectMgr.Analyzer == null || !ProjectMgr.ShouldAcquireTypingsAutomatically) {
                 return;
             }
 
@@ -50,7 +49,6 @@ namespace Microsoft.NodejsTools.Project {
                     this.IncludeInProject(true);
                 });
             }
-#endif
         }
 
         internal void Analyze() {
@@ -105,11 +103,11 @@ namespace Microsoft.NodejsTools.Project {
             UpdateParentContentType();
             ItemNode.ItemTypeChanged += ItemNode_ItemTypeChanged;
 
-#if DEV14
-            ProjectMgr.Site.GetUIThread().Invoke(() => {
-                ProjectMgr.OnItemAdded(this.Parent, this);
-            });
-#endif
+            if (ProjectMgr.ShouldAcquireTypingsAutomatically) {
+                ProjectMgr.Site.GetUIThread().Invoke(() => {
+                    ProjectMgr.OnItemAdded(this.Parent, this);
+                });
+            }
 
             return includeInProject;
         }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -104,9 +104,10 @@ namespace Microsoft.NodejsTools.Project {
 #endif
         }
 
-#if DEV14
-        private bool ShouldAcquireTypingsAutomatically {
+
+        internal bool ShouldAcquireTypingsAutomatically {
             get {
+#if DEV14
                 if (!NodejsPackage.Instance.IntellisenseOptionsPage.EnableES6Preview) {
                     return false;
                 }
@@ -116,9 +117,13 @@ namespace Microsoft.NodejsTools.Project {
                 });
                 task.Wait();
                 return !task.Result;
+#else
+                return false;
+#endif
             }
         }
 
+#if DEV14
         private TypingsAcquisition TypingsAcquirer {
             get {
                 if (_typingsAcquirer != null) {


### PR DESCRIPTION
**Defect**
We added some new auto include-in-project logic for *.d.ts files in order to support Salsa Intellisense for Javascript. Unfortunately, while the typings acquisition is gated properly, the logic to automatically add `*.d.ts` files to the VS solution was not gated currently.

This results in *.d.ts files being automatically included in TypeScript projects, potentially breaking people who already have a `typings` directory

**Fix**
Gate the include-in-project work.

Switched to using feature gating too in `NodeJsFileNode` instead of compiler switches. This is generally more maintainable.

closes #805