### PR TITLE
Allow running .npm commands in Repl Window from any proj types.

### DIFF
--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -163,6 +163,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string PropertiesClassLocalSubPackage = "PropertiesClassLocalSubPackage";
         internal const string PropertiesClassNpm = "PropertiesClassNpm";
         internal const string ReplInitializationMessage = "ReplInitializationMessage";
+        internal const string ReplWindowNpmInitNoYesFlagWarning = "ReplWindowNpmInitNoYesFlagWarning";
         internal const string RequestedVersionRangeNone = "RequestedVersionRangeNone";
         internal const string ScriptArgumentsToolTip = "ScriptArgumentsToolTip";
         internal const string ScriptFileToolTip = "ScriptFileTooltip";

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -58,6 +58,13 @@ namespace Microsoft.NodejsTools.Repl {
             // at beginning and end of string (e.g. '--global')
             npmArguments = string.Format(" {0} ", npmArguments);
 
+            // Prevent running `npm init` without the `-y` flag since it will freeze the repl window,
+            // waiting for user input that will never come.
+            if (npmArguments.Contains(" init ") && !(npmArguments.Contains(" -y ") || npmArguments.Contains(" --yes "))) {
+                window.WriteError(SR.GetString(SR.ReplWindowNpmInitNoYesFlagWarning));
+                return ExecutionResult.Failure;
+            }
+
             var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
             IEnumerable<IVsProject> loadedProjects = solution.EnumerateLoadedProjects(onlyNodeProjects: false);
 

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -61,7 +61,7 @@ namespace Microsoft.NodejsTools.Repl {
             var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
             var loadedProjects = solution.EnumerateLoadedProjects(onlyNodeProjects: false);
 
-            var projectNameToDirectoryDictionary = new Dictionary<string, Tuple<string, IVsHierarchy>>();
+            var projectNameToDirectoryDictionary = new Dictionary<string, Tuple<string, IVsHierarchy>>(StringComparer.OrdinalIgnoreCase);
             foreach (IVsProject project in loadedProjects) {
                 var hierarchy = (IVsHierarchy)project;
                 object extObject;

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NodejsTools.Repl {
             npmArguments = string.Format(" {0} ", npmArguments);
 
             var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
-            var loadedProjects = solution.EnumerateLoadedProjects(onlyNodeProjects: false);
+            IEnumerable<IVsProject> loadedProjects = solution.EnumerateLoadedProjects(onlyNodeProjects: false);
 
             var projectNameToDirectoryDictionary = new Dictionary<string, Tuple<string, IVsHierarchy>>(StringComparer.OrdinalIgnoreCase);
             foreach (IVsProject project in loadedProjects) {
@@ -77,6 +77,10 @@ namespace Microsoft.NodejsTools.Repl {
                 }
 
                 string projectName = dteProject.Name;
+                if (string.IsNullOrEmpty(projectName)) {
+                    continue;
+                }
+
                 string projectDirectory = Path.GetDirectoryName(dteProject.FullName);
                 if (!string.IsNullOrEmpty(projectDirectory)) {
                     projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectDirectory, hierarchy));

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -111,20 +111,6 @@ namespace Microsoft.NodejsTools.Repl {
             }
 
             var npmReplRedirector = new NpmReplRedirector(window);
-            
-            if (!isGlobalCommand && !File.Exists(Path.Combine(projectDirectoryPath, "package.json"))) {
-                await ExecuteNpmCommandAsync(
-                    npmReplRedirector,
-                    npmPath,
-                    projectDirectoryPath,
-                    new[] { "init", "--yes" },
-                    null);
-
-                if (npmReplRedirector.HasErrors) {
-                    return ExecutionResult.Failure;
-                }
-            }
-
             await ExecuteNpmCommandAsync(
                 npmReplRedirector,
                 npmPath,

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -61,10 +61,26 @@ namespace Microsoft.NodejsTools.Repl {
             var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
             var loadedProjects = solution.EnumerateLoadedProjects(onlyNodeProjects: false);
 
-            // Prefer Node projects, but fall back to a non-node project if no Node projects are loaded.
-            var projectNameToDirectoryDictionary = GetProjectInfo(solution.EnumerateLoadedProjects(onlyNodeProjects: true));
-            if (!projectNameToDirectoryDictionary.Any()) {
-                projectNameToDirectoryDictionary = GetProjectInfo(solution.EnumerateLoadedProjects(onlyNodeProjects: false));
+            var projectNameToDirectoryDictionary = new Dictionary<string, Tuple<string, IVsHierarchy>>();
+            foreach (IVsProject project in loadedProjects) {
+                var hierarchy = (IVsHierarchy)project;
+                object extObject;
+
+                var projectResult = hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out extObject);
+                if (!ErrorHandler.Succeeded(projectResult)) {
+                    continue;
+                }
+
+                EnvDTE.Project dteProject = extObject as EnvDTE.Project;
+                if (dteProject == null) {
+                    continue;
+                }
+
+                string projectName = dteProject.Name;
+                string projectDirectory = Path.GetDirectoryName(dteProject.FullName);
+                if (!string.IsNullOrEmpty(projectDirectory)) {
+                    projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectDirectory, hierarchy));
+                }
             }
 
             Tuple<string, IVsHierarchy> projectInfo;
@@ -200,31 +216,6 @@ namespace Microsoft.NodejsTools.Repl {
         }
 
         #endregion
-
-        private static Dictionary<string, Tuple<string, IVsHierarchy>> GetProjectInfo(IEnumerable<IVsProject> loadedProjects) {
-            var projectNameToDirectoryDictionary = new Dictionary<string, Tuple<string, IVsHierarchy>>();
-            foreach (IVsProject project in loadedProjects) {
-                var hierarchy = (IVsHierarchy)project;
-                object extObject;
-
-                var projectResult = hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out extObject);
-                if (!ErrorHandler.Succeeded(projectResult)) {
-                    continue;
-                }
-
-                EnvDTE.Project dteProject = extObject as EnvDTE.Project;
-                if (dteProject == null) {
-                    continue;
-                }
-
-                string projectName = dteProject.Name;
-                string projectDirectory = Path.GetDirectoryName(dteProject.FullName);
-                if (!string.IsNullOrEmpty(projectDirectory)) {
-                    projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectDirectory, hierarchy));
-                }
-            }
-            return projectNameToDirectoryDictionary;
-        }
 
         internal class NpmReplRedirector : Redirector {
             

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -88,6 +88,26 @@ namespace Microsoft.NodejsTools.Repl {
                     continue;
                 }
 
+                // Try checking the `ProjectHome` property first
+                EnvDTE.Properties properties = dteProject.Properties;
+                if (dteProject.Properties != null) {
+                    EnvDTE.Property projectHome = null;
+                    try {
+                        projectHome = properties.Item("ProjectHome");
+                    } catch (ArgumentException) {
+                        // noop
+                    }
+
+                    if (projectHome != null) {
+                        var projectHomeDirectory = projectHome.Value as string;
+                        if (!string.IsNullOrEmpty(projectHomeDirectory)) {
+                            projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectHomeDirectory, hierarchy));
+                            continue;
+                        }
+                    }
+                }
+
+                // Otherwise, fall back to using fullname
                 string projectDirectory = Path.GetDirectoryName(dteProject.FullName);
                 if (!string.IsNullOrEmpty(projectDirectory)) {
                     projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectDirectory, hierarchy));

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -473,6 +473,9 @@ NAME2=value2
   <data name="ReplInitializationMessage" xml:space="preserve">
     <value>Node.js interactive window. Type .help for a list of commands.</value>
   </data>
+  <data name="ReplWindowNpmInitNoYesFlagWarning" xml:space="preserve">
+    <value>Please run '.npm init -y' to create a new package.json file.</value>
+  </data>
   <data name="NodeExePathDescription" xml:space="preserve">
     <value>Specifies the path to the node.exe executable.</value>
   </data>


### PR DESCRIPTION
**Defect**
We currently only support running `.npm` commands in node projects for the Repl window. #480

**Fix**
This change allows us to run repl window commands in other project types as well, including having a mix of node and other projects in a single solution. This change does not fix the case where you have multiple Node projects in a single solution.

Since these projects may not have a `package.json` file for npm to use, also added a command to create it. 

closes #156, closes #480
