### PR TITLE
Check the existance of the target dir in `GetTopLevelPackageDirectories`

### DIFF
--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -151,11 +151,13 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         private static IEnumerable<KeyValuePair<string, IPackageJson>> GetTopLevelPackageDirectories(string modulesBase) {
             var topLevelDirectories = Enumerable.Empty<string>();
-            try {
-                topLevelDirectories = Directory.EnumerateDirectories(modulesBase);
-            } catch (IOException) {
-                // We want to handle DirectoryNotFound, DriveNotFound, PathTooLong
-            } catch (UnauthorizedAccessException) {
+            if (Directory.Exists(modulesBase)) {
+                try {
+                    topLevelDirectories = Directory.EnumerateDirectories(modulesBase);
+                } catch (IOException) {
+                    // We want to handle DirectoryNotFound, DriveNotFound, PathTooLong
+                } catch (UnauthorizedAccessException) {
+                }
             }
 
             // Go through every directory in node_modules, and see if it's required as a top-level dependency


### PR DESCRIPTION
Just check if the directory existing before attempting to enumerate over it.

No user bad here, but this has been annoying me while debugging. Plus, there's no reason to throw an exception if we don't have to.