### PR TITLE
Ensure Types are only Automatically Acquired for ES6 Preview

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -107,7 +107,7 @@ namespace Microsoft.NodejsTools.Project {
 #if DEV14
         private bool ShouldAcquireTypingsAutomatically {
             get {
-                if (!NodejsPackage.Instance.IntellisenseOptionsPage.EnableES6Preview) {
+                if (!NodejsPackage.Instance.IntellisenseOptionsPage.AnalysisLevel != Options.AnalysisLevel.Preview) {
                     return false;
                 }
 


### PR DESCRIPTION
This previously was gated incorrectly using the `EnableES6Preview` property, which actually just tells if the "ES6" preview option should be shown at all.

We should gate using the selected Analysis level instead. 

closes #813