### PR TITLE
Remove Nodejsfilenode watcher logic

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -25,13 +25,8 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.NodejsTools.Project {
     class NodejsFileNode : CommonFileNode {
-        private FileSystemWatcher _watcher;
-
         public NodejsFileNode(NodejsProjectNode root, ProjectElement e)
             : base(root, e) {
-#if FALSE
-            CreateWatcher(Url);
-#endif
             if (Url.Contains(AnalysisConstants.NodeModulesFolder)) {
                 root.EnqueueForDelayedAnalysis(this);
             } else {
@@ -163,50 +158,6 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        private void CloseWatcher() {
-            if (_watcher == null) {
-                ProjectMgr.UnregisterFileChangeNotification(this);
-            } else {
-                _watcher.EnableRaisingEvents = false;
-                _watcher.Dispose();
-                _watcher = null;
-            }
-        }
-
-        // TODO: Need to update analysis for files changed outside of VS
-        private void CreateWatcher(string filename) {
-#if FALSE
-            if (CommonUtils.IsSubpathOf(ProjectMgr.ProjectHome, filename)) {
-                // we want to subscribe to the project's file system watcher so users
-                // can continue to rename the directory which contains this file.
-                ProjectMgr.RegisterFileChangeNotification(this, FileContentsChanged);
-            } else {
-                // this is a link file which lives outside of our project directory,
-                // we'll need to watch the file directly, which means we're going to
-                // prevent it's parent directory from being renamed.
-                _watcher = new FileSystemWatcher(Path.GetDirectoryName(filename), Path.GetFileName(filename));
-                _watcher.EnableRaisingEvents = true;
-                _watcher.Changed += FileContentsChanged;
-                _watcher.Renamed += FileContentsChanged;
-                _watcher.NotifyFilter = NotifyFilters.LastWrite;
-            }
-#endif
-        }
-
-        internal override void RenameInStorage(string oldName, string newName) {
-            CloseWatcher();
-            bool renamed = false;
-            try {
-                base.RenameInStorage(oldName, newName);
-                renamed = true;
-                CreateWatcher(newName);
-            } finally {
-                if (!renamed) {
-                    CreateWatcher(oldName);
-                }
-            }
-        }
-
         public new NodejsProjectNode ProjectMgr {
             get {
                 return (NodejsProjectNode)base.ProjectMgr;
@@ -216,13 +167,11 @@ namespace Microsoft.NodejsTools.Project {
         public override void Remove(bool removeFromStorage) {
             ItemNode.ItemTypeChanged -= ItemNode_ItemTypeChanged;
             base.Remove(removeFromStorage);
-            CloseWatcher();
         }
 
         public override void Close() {
             ItemNode.ItemTypeChanged -= ItemNode_ItemTypeChanged;
             base.Close();
-            CloseWatcher();
         }
     }
 }


### PR DESCRIPTION
This logic is currently all commented out. This change just removes it. It is always in source control if we need to restore it