### PR TITLE
Pass setting to runtests.ps1 script

### DIFF
--- a/Tools/runtests.ps1
+++ b/Tools/runtests.ps1
@@ -21,6 +21,6 @@ if ($selectedVsVersion -eq '') {
 	return
 }
 
-$testFiles = $tests | % { ".\BuildOutput\Release$selectedVsVersion\Tests\$_.dll" }
+$testFiles = $tests | % { ".\BuildOutput\Debug$selectedVsVersion\Tests\$_.dll" }
 
-& "$vstest" @args $testFiles
+& "$vstest" /settings:$(".\Build\default." + $selectedVsVersion + "Exp.testsettings") @args $testFiles

--- a/Tools/runtests.ps1
+++ b/Tools/runtests.ps1
@@ -5,6 +5,8 @@ $vsversions = @("15.0", "14.0", "12.0")
 # AzurePublishing.Tests.UI are currently skipped.
 $tests = @("JSAnalysisTests", "Nodejs.Tests.UI", "NodeTests","NpmTests", "ProfilerTests", "SharedProjectTests")
 
+$nodejstoolsroot = "$PSScriptRoot\.."
+
 # Try to get the path to the vstest.console test runner
 $selectedVsVersion = ''
 $vstest =  ''
@@ -21,6 +23,6 @@ if ($selectedVsVersion -eq '') {
 	return
 }
 
-$testFiles = $tests | % { ".\BuildOutput\Release$selectedVsVersion\Tests\$_.dll" }
+$testFiles = $tests | % { "$nodejstoolsroot\BuildOutput\Release$selectedVsVersion\Tests\$_.dll" }
 
-& "$vstest" /settings:$(".\Build\default." + $selectedVsVersion + "Exp.testsettings") @args $testFiles
+& "$vstest" /settings:$("$nodejstoolsroot\Build\default." + $selectedVsVersion + "Exp.testsettings") @args $testFiles

--- a/Tools/runtests.ps1
+++ b/Tools/runtests.ps1
@@ -21,6 +21,6 @@ if ($selectedVsVersion -eq '') {
 	return
 }
 
-$testFiles = $tests | % { ".\BuildOutput\Debug$selectedVsVersion\Tests\$_.dll" }
+$testFiles = $tests | % { ".\BuildOutput\Release$selectedVsVersion\Tests\$_.dll" }
 
 & "$vstest" /settings:$(".\Build\default." + $selectedVsVersion + "Exp.testsettings") @args $testFiles


### PR DESCRIPTION
Small change to automatically pass `settings` flag to `vstest.console.exe` for in our `runtests.ps1` script to simplify running UI tests.