### PR TITLE
Fix potential out of range access in ShowSetAsStartupFileCommandOnNode

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -1139,9 +1139,11 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         private bool ShowSetAsStartupFileCommandOnNode(IList<HierarchyNode> selectedNodes) {
+            if (selectedNodes.Count != 1) {
+                return false;
+            }
             var selectedNodeUrl = selectedNodes[0].Url;
-            return selectedNodes.Count == 1 &&
-                (IsCodeFile(selectedNodeUrl) ||
+            return (IsCodeFile(selectedNodeUrl) ||
                 // for some reason, the default express 4 template's startup file lacks an extension.
                 string.IsNullOrEmpty(Path.GetExtension(selectedNodeUrl)));
         }


### PR DESCRIPTION
I started hitting an out of range exceptions in `ShowSetAsStartupFileCommandOnNode` after enabling `Start web browser on launch` for a short running console app. This fix just makes sure we don't try to access elements of empty arrays in this method.