### PR TITLE
Update Extension More Info Setting to point to Github

### DIFF
--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -5,8 +5,8 @@
     <Author>Microsoft</Author>
     <Version>1.2</Version>
     <Description xml:space="preserve">Node.js Tools - Interactive Window</Description>
-    <MoreInfoUrl>https://github.com/Microsoft/nodejstools/</MoreInfoUrl>
-    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
+    <MoreInfoUrl>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfoUrl>
+    <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=785972</GettingStartedGuide>
     <Locale>1033</Locale>
     <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>

--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -5,8 +5,8 @@
     <Author>Microsoft</Author>
     <Version>1.2</Version>
     <Description xml:space="preserve">Node.js Tools - Interactive Window</Description>
-    <MoreInfoUrl>http://nodejstools.codeplex.com</MoreInfoUrl>
-    <GettingStartedGuide>http://nodejstools.codeplex.com</GettingStartedGuide>
+    <MoreInfoUrl>https://github.com/Microsoft/nodejstools/</MoreInfoUrl>
+    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
     <Locale>1033</Locale>
     <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -3,8 +3,8 @@
     <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.2" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools</DisplayName>
     <Description xml:space="preserve">Provides support for editing and debugging Node.js programs.</Description>
-    <MoreInfo>http://nodejstools.codeplex.com</MoreInfo>
-    <GettingStartedGuide>http://nodejstools.codeplex.com</GettingStartedGuide>
+    <MoreInfo>https://github.com/Microsoft/nodejstools/</MoreInfo>
+    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
     <Icon>NodeJS.ico</Icon>
     <PreviewImage>NodeJS_200x.png</PreviewImage>
   </Metadata>

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -3,8 +3,8 @@
     <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.2" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools</DisplayName>
     <Description xml:space="preserve">Provides support for editing and debugging Node.js programs.</Description>
-    <MoreInfo>https://github.com/Microsoft/nodejstools/</MoreInfo>
-    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
+    <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>
+    <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=785972</GettingStartedGuide>
     <Icon>NodeJS.ico</Icon>
     <PreviewImage>NodeJS_200x.png</PreviewImage>
   </Metadata>

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -5,8 +5,8 @@
     <Author>Microsoft</Author>
     <Version>1.2</Version>
     <Description xml:space="preserve">Provides support for profiling Node.js projects</Description>
-    <MoreInfoUrl>https://github.com/Microsoft/nodejstools/</MoreInfoUrl>
-    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
+    <MoreInfoUrl>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfoUrl>
+    <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=785972</GettingStartedGuide>
     <Locale>1033</Locale>
     <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -5,8 +5,8 @@
     <Author>Microsoft</Author>
     <Version>1.2</Version>
     <Description xml:space="preserve">Provides support for profiling Node.js projects</Description>
-    <MoreInfoUrl>http://nodejstools.codeplex.com</MoreInfoUrl>
-    <GettingStartedGuide>http://nodejstools.codeplex.com</GettingStartedGuide>
+    <MoreInfoUrl>https://github.com/Microsoft/nodejstools/</MoreInfoUrl>
+    <GettingStartedGuide>https://github.com/Microsoft/nodejstools/wiki</GettingStartedGuide>
     <Locale>1033</Locale>
     <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>


### PR DESCRIPTION
Updates both the `more info` and `Getting Started` links to point to our GitHub instead of to CodePlex