### PR TITLE
Fix `ProvideSourceControlProvider` ambiguous reference

### DIFF
--- a/Common/Tests/SccPackage/SccPackage.cs
+++ b/Common/Tests/SccPackage/SccPackage.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TestSccPackage
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [Guid(Guids.guidSccPackagePkgString)]
     [ProvideService(typeof(TestSccProvider), ServiceName="Test Source Provider")]
-    [ProvideSourceControlProvider("Test Source Provider", Guids.guidSccPackageCmdSetString, typeof(SccPackage), typeof(TestSccProvider))]
+    [@ProvideSourceControlProvider("Test Source Provider", Guids.guidSccPackageCmdSetString, typeof(SccPackage), typeof(TestSccProvider))]
     [ProvideMenuResource(1000, 1)]                              // This attribute is needed to let the shell know that this package exposes some menus.
     public sealed class SccPackage : Package
     {


### PR DESCRIPTION
**Bug**
After installing Update 2 of VS2015, a reference to `ProvideSourceControlProvider` in `SccPackage.cs`  is now considered ambiguous, preventing me from building the installer

**Fix**
Just make the reference explicit by adding an `@` to the name