### PR TITLE
Gate NTVS 1.2 to VS 2015 update 2

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -73,4 +73,15 @@
     </Property>
   </Fragment>
 
+  <Fragment>
+    <Property Id="VS_IS_UNSUPPORTED_2015_VERSION" Secure="yes">
+      <?if "$(var.VSTargetVersion)"="14.0" ?>
+      <DirectorySearch Id="VSDevEnvFilePathSearch" Path="[VSINSTALLPATH]">
+		<FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="14.0.0.0" MaxVersion="14.0.25122.0"/>
+      </DirectorySearch>
+      <?endif ?>
+    </Property>
+  </Fragment>
+
+  
 </Wix>

--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -83,5 +83,4 @@
     </Property>
   </Fragment>
 
-  
 </Wix>

--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -74,10 +74,10 @@
   </Fragment>
 
   <Fragment>
-    <Property Id="VS_IS_UNSUPPORTED_2015_VERSION" Secure="yes">
+    <Property Id="VS_IS_2015_UPDATE_2_OR_LATER" Secure="yes">
       <?if "$(var.VSTargetVersion)"="14.0" ?>
       <DirectorySearch Id="VSDevEnvFilePathSearch" Path="[VSINSTALLPATH]">
-		<FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="14.0.0.0" MaxVersion="14.0.25122.0"/>
+        <FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="14.0.25123.0"/>
       </DirectorySearch>
       <?endif ?>
     </Property>

--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -74,10 +74,10 @@
   </Fragment>
 
   <Fragment>
-    <Property Id="VS_IS_2015_UPDATE_2_OR_LATER" Secure="yes">
+    <Property Id="VS_IS_2015_PRE_UPDATE_2" Secure="yes">
       <?if "$(var.VSTargetVersion)"="14.0" ?>
       <DirectorySearch Id="VSDevEnvFilePathSearch" Path="[VSINSTALLPATH]">
-        <FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="14.0.25123.0"/>
+        <FileSearch Id="VSDevEnvFileVersionSearch" Name="devenv.exe" MinVersion="14.0.0.0" MaxVersion="14.0.25122.0"/>
       </DirectorySearch>
       <?endif ?>
     </Property>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -25,8 +25,8 @@
         <PropertyRef Id="VS_PRERELEASE"/>
         <Condition Message="!(loc.VSPrerelease)"> NOT VS_PRERELEASE OR Installed </Condition>
         
-        <PropertyRef Id="VS_IS_2015_UPDATE_2_OR_LATER"/>
-        <Condition Message="!(loc.VSRequires2015Update2)"> VS_IS_2015_UPDATE_2_OR_LATER OR Installed </Condition>
+        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/>
+        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 OR Installed </Condition>
         
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -25,8 +25,8 @@
         <PropertyRef Id="VS_PRERELEASE"/>
         <Condition Message="!(loc.VSPrerelease)"> NOT VS_PRERELEASE OR Installed </Condition>
         
-		<PropertyRef Id="VS_PRERELEASE"/>
-        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_UNSUPPORTED_2015_VERSION OR Installed </Condition>
+        <PropertyRef Id="VS_IS_2015_UPDATE_2_OR_LATER"/>
+        <Condition Message="!(loc.VSRequires2015Update2)"> VS_IS_2015_UPDATE_2_OR_LATER OR Installed </Condition>
         
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -25,6 +25,9 @@
         <PropertyRef Id="VS_PRERELEASE"/>
         <Condition Message="!(loc.VSPrerelease)"> NOT VS_PRERELEASE OR Installed </Condition>
         
+		<PropertyRef Id="VS_PRERELEASE"/>
+        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_UNSUPPORTED_2015_VERSION OR Installed </Condition>
+        
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>
 

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -13,7 +13,7 @@
     <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
-	<String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
+    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
     <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
     <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>
     <String Id="DevEnvSetup_Rollback">Removing extension from !(loc.VSProductName)...</String>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -13,6 +13,7 @@
     <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+	<String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
     <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
     <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>
     <String Id="DevEnvSetup_Rollback">Removing extension from !(loc.VSProductName)...</String>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
@@ -13,7 +13,7 @@
     <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
-	<String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
+    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
     <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
     <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>
     <String Id="DevEnvSetup_Rollback">Removing extension from !(loc.VSProductName)...</String>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
@@ -13,6 +13,7 @@
     <String Id="WDInstallPathButNoExe">Your version of !(loc.WDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VWDInstallPathButNoExe">Your version of !(loc.VWDProductName) is not supported.  Please install the latest update from http://www.visualstudio.com/.</String>
     <String Id="VSPrerelease">A pre-release version of !(loc.VSProductName) was detected.  This version of !(loc.ProductName) is not supported on pre-release builds of !(loc.VSProductName).  Please upgrade to !(loc.VSProductName).</String>
+	<String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String>
     <String Id="NetFx45NotInstalled">The Microsoft .NET Framework 4.5 is required. Please install it from http://go.microsoft.com/fwlink/?LinkId=398711</String>
     <String Id="DevEnvSetup">Registering extension in !(loc.VSProductName)...</String>
     <String Id="DevEnvSetup_Rollback">Removing extension from !(loc.VSProductName)...</String>


### PR DESCRIPTION
**Bug**
Currently you can install NTVS 1.2 Alpha on Pre Update 2 VS 2015 just fine, but many features will not work as expected.

**Fix**
This change prevents installing NTVS 1.2 alpha on version of VS 2015 pre update 2

closes #806