### PR TITLE
Unblock Lightweight install Smart Indent Provider null deref

### DIFF
--- a/Nodejs/Product/Nodejs/SmartIndent.cs
+++ b/Nodejs/Product/Nodejs/SmartIndent.cs
@@ -241,6 +241,10 @@ namespace Microsoft.NodejsTools {
         /// Enumerates all of the classifications in reverse starting at start to the beginning of the file.
         /// </summary>
         private static IEnumerator<ITagSpan<ClassificationTag>> EnumerateClassificationsInReverse(ITagger<ClassificationTag> classifier, SnapshotPoint start) {
+            if (classifier == null) {
+                yield break;
+            }
+
             var curLine = start.GetContainingLine();
             var spanEnd = start;
 

--- a/Nodejs/Product/Nodejs/SmartIndentProvider.cs
+++ b/Nodejs/Product/Nodejs/SmartIndentProvider.cs
@@ -50,13 +50,10 @@ namespace Microsoft.NodejsTools {
         #region ISmartIndentProvider Members
 
         public ISmartIndent CreateSmartIndent(ITextView textView) {
-            if (_taggerProvider == null)
-                return null;
-
             return new SmartIndent(
                 textView,
                 _editorOptionsFactory.GetOptions(textView),
-                _taggerProvider.CreateTagger<ClassificationTag>(textView.TextBuffer));
+                _taggerProvider == null ? null : _taggerProvider.CreateTagger<ClassificationTag>(textView.TextBuffer));
         }
 
         #endregion


### PR DESCRIPTION
**Bug**
For #821 and the VS 15 lightweight installer, we currently run into a null dereference in `SmartIndentProvider` because some expected component is not found.

**Fix**
This is not really a fix but unblocks testing on willow. It is still not clear why we are getting zero `classifierProviders` (they may be coming from the Javascript language service which Willow would not have).

What this change does in unblock some aspects of the lightweight installer for testing purposes. It lets us try out the interactive window and other features, but these will throw an null deref if you attempt an operation that uses the SmartIndent provider.
