### PR TITLE
Log exception and re-throw

### DIFF
--- a/Nodejs/Product/TestAdapter/TestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscoverer.cs
@@ -1,15 +1,15 @@
 ﻿//*********************************************************//
 //    Copyright (c) Microsoft. All rights reserved.
-//    
+//
 //    Apache 2.0 License
-//    
+//
 //    You may obtain a copy of the License at
 //    http://www.apache.org/licenses/LICENSE-2.0
-//    
-//    Unless required by applicable law or agreed to in writing, software 
-//    distributed under the License is distributed on an "AS IS" BASIS, 
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
-//    implied. See the License for the specific language governing 
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//    implied. See the License for the specific language governing
 //    permissions and limitations under the License.
 //
 //*********************************************************//
@@ -89,6 +89,9 @@ namespace Microsoft.NodejsTools.TestAdapter {
                         //Debug.Fail("Before Discover");
                         DiscoverTests(testItems, proj, discoverySink, logger);
                     }
+                } catch (Exception ex) {
+                    logger.SendMessage(TestMessageLevel.Error, ex.Message);
+                    throw ex;
                 } finally {
                     // Disposing buildEngine does not clear the document cache in
                     // VS 2013, so manually unload all projects before disposing.
@@ -144,7 +147,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                             CodeFilePath = (fi != null) ? fi.Filename : filePath,
                             LineNumber = (fi != null && fi.LineNumber.HasValue) ? fi.LineNumber.Value : discoveredTest.SourceLine,
                             DisplayName = discoveredTest.TestName
-                        });                                    
+                        });
 
                 }
                 logger.SendMessage(TestMessageLevel.Informational, string.Format("Processing finished for framework of {0}", testFx));


### PR DESCRIPTION
Fixing bug #852.

When running under `vstest.console.exe`, exceptions were swallowed. We should log it out and re-throw.

Repro:
`"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe" MyProject.njsproj`

Expected:
```
Microsoft (R) Test Execution Command Line Tool Version 14.0.25123.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Error: The imported project "C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v11.0\Node.js Tools\Microsoft.NodejsTools.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.  C:\Users\JohnDoe\Source\Repos\MyProject\MyProject.njsproj
```

Actual:
```
Microsoft (R) Test Execution Command Line Tool Version 14.0.25123.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
```