### PR TITLE
Small argument exception fixes in TestAdapter

### DIFF
--- a/Common/Product/TestAdapter/VsProjectExtensions.cs
+++ b/Common/Product/TestAdapter/VsProjectExtensions.cs
@@ -108,12 +108,17 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
             if (props == null) {
                 return null;
             }
-            var projHome = props.Item("ProjectHome");
-            if (projHome == null) {
+
+            try {
+                var projHome = props.Item("ProjectHome");
+                if (projHome == null) {
+                    return null;
+                }
+
+                return projHome.Value as string;
+            } catch (ArgumentException) {
                 return null;
             }
-
-            return projHome.Value as string;
         }
 
         /// <summary>

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -428,6 +428,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 ProjectInfo projectInfo;
                 string projectPath;
                 if (e.Project.TryGetProjectPath(out projectPath) &&
+                    !string.IsNullOrEmpty(projectPath) &&
                     _knownProjects.TryGetValue(projectPath, out projectInfo)) {
                     _knownProjects.Remove(projectPath);
 


### PR DESCRIPTION
Fixes two small issues I ran into while messing around with the TestAdapter code:

* In `VsProjectExtensions.cs`, during shutdown with the test explorer open, `props.Item` fails to find a value and throws an exception. Changed to return null instead.

* In `TestContainerDiscoverer.cs`, `_knownProjects.TryGetValue` will fail if `e.Project.TryGetProjectPath(out projectPath)` returns true but sets `projectPath` to null.