### PR TITLE
Add Debug Fallback to current directory for debugging the TestAdapter

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace Microsoft.NodejsTools.TestFrameworks {
     class TestFrameworkDirectories {
-        private const string ExportRunnerFramework = "ExportRunner";
+        public const string ExportRunnerFramework = "ExportRunner";
         private const string TestFrameworksDirectory = "TestFrameworks";
 
         private readonly Dictionary<string, string> _frameworkDirectories;

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace Microsoft.NodejsTools.TestFrameworks {
     class TestFrameworkDirectories {
-        public const string ExportRunnerFramework = "ExportRunner";
+        private const string ExportRunnerFramework = "ExportRunner";
         private const string TestFrameworksDirectory = "TestFrameworks";
 
         private readonly Dictionary<string, string> _frameworkDirectories;

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -14,21 +14,20 @@
 //
 //*********************************************************//
 
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.NodejsTools.TestFrameworks {
     class TestFrameworkDirectories {
+        public const string ExportRunnerFramework = "ExportRunner";
+        private const string TestFrameworksDirectory = "TestFrameworks";
+
         private readonly Dictionary<string, string> _frameworkDirectories;
-        public const string ExportRunnerFramework = "ExportRunner"; 
 
         public TestFrameworkDirectories() {
-            string installFolder = GetExecutingAssemblyPath();
             _frameworkDirectories = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
-            string baseTestframeworkFolder = installFolder + @"\TestFrameworks";
-            foreach (string directory in Directory.GetDirectories(baseTestframeworkFolder)) {
+            foreach (string directory in Directory.GetDirectories(GetBaseTestframeworkFolder())) {
                 string name = Path.GetFileName(directory);
                 _frameworkDirectories.Add(name, directory);
             }
@@ -47,7 +46,17 @@ namespace Microsoft.NodejsTools.TestFrameworks {
             return new List<string>(_frameworkDirectories.Values);
         }
 
-        private string GetExecutingAssemblyPath() {
+        private static string GetBaseTestframeworkFolder() {
+            string installFolder = GetExecutingAssemblyPath();
+            string baseDirectory = Path.Combine(installFolder, TestFrameworksDirectory);
+#if DEBUG
+            // To allow easier debugging of the test adapter, try to use the local directory as a fallback.
+            baseDirectory = Directory.Exists(baseDirectory) ? baseDirectory : Path.Combine(Directory.GetCurrentDirectory(), TestFrameworksDirectory);
+#endif
+            return baseDirectory;
+        }
+
+        private static string GetExecutingAssemblyPath() {
             string codeBase = System.Reflection.Assembly.GetExecutingAssembly().CodeBase;
             UriBuilder uri = new UriBuilder(codeBase);
             string path = Uri.UnescapeDataString(uri.Path);


### PR DESCRIPTION
Currently, debugging the test adapter code for `vstest.console.exe` is difficult since the `TestFrameworks` directory lookup is based on the executing assembly location and always fails, unless you copy over `TestFrameworks ` to the dll location.

This change adds a debug only fallback to also check the current directory location for the lookup of the TestFrameworks directory. This allows us to launch and debug TestAdapter directly in visual studio.

I've updated the wiki page to explain this as well: https://github.com/Microsoft/nodejstools/wiki/Debugging-the-NTVS-TestAdapter-code-with-vstest.console.exe