### PR TITLE
Fix for prompting multiple times to include node_modules. 

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             if (Url.EndsWith(NodejsConstants.TypeScriptDeclarationExtension, StringComparison.OrdinalIgnoreCase)
-              && Url.StartsWith(Path.Combine(ProjectMgr.ProjectFolder, @"typings"), StringComparison.OrdinalIgnoreCase)) {
+              && Url.StartsWith(Path.Combine(ProjectMgr.ProjectFolder, @"typings\"), StringComparison.OrdinalIgnoreCase)) {
                 ProjectMgr.Site.GetUIThread().Invoke(() => {
                     this.IncludeInProject(true);
                 });

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -40,8 +40,7 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             if (Url.EndsWith(NodejsConstants.TypeScriptDeclarationExtension, StringComparison.OrdinalIgnoreCase)
-              && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0
-              && Url.IndexOf(@"\node_modules\", StringComparison.OrdinalIgnoreCase) < 0) {
+              && Url.StartsWith(Path.Combine(ProjectMgr.ProjectFolder, @"typings"), StringComparison.OrdinalIgnoreCase)) {
                 ProjectMgr.Site.GetUIThread().Invoke(() => {
                     this.IncludeInProject(true);
                 });

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -39,7 +39,9 @@ namespace Microsoft.NodejsTools.Project {
                 return;
             }
 
-            if (Url.EndsWith(NodejsConstants.TypeScriptDeclarationExtension, StringComparison.OrdinalIgnoreCase) && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0) {
+            if (Url.EndsWith(NodejsConstants.TypeScriptDeclarationExtension, StringComparison.OrdinalIgnoreCase)
+              && Url.IndexOf(@"\typings\", StringComparison.OrdinalIgnoreCase) >= 0
+              && Url.IndexOf(@"\node_modules\", StringComparison.OrdinalIgnoreCase) < 0) {
                 ProjectMgr.Site.GetUIThread().Invoke(() => {
                     this.IncludeInProject(true);
                 });


### PR DESCRIPTION
Fixes users getting prompted multiple times to include `node_modules` in their project if an installed npm package includes a `typings` directory.

closes #860