### PR TITLE
Fix duplicate TypeScriptCompile entries being created

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -76,6 +76,10 @@ namespace Microsoft.NodejsTools.Project {
 #endif
 
         internal override int IncludeInProject(bool includeChildren) {
+            if (!Parent.ItemNode.IsExcluded) {
+                return 0;
+            }
+
             // Check if parent folder is designated as containing client-side code.
             var isContent = false;
             var folderNode = this.Parent as NodejsFolderNode;
@@ -89,7 +93,6 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             var includeInProject = base.IncludeInProject(includeChildren);
-
             if (isContent && Url.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
                 this.ItemNode.ItemTypeName = ProjectFileConstants.Content;
             }


### PR DESCRIPTION
**Bug**
In NTVS 1.2 Alpha, we end up calling `IncludeInProject` much more often than we used to thanks to automatic type acquisition. This exposed a fun bug higher with Typescript or some (external?) code.

When a `*.d.ts` file is in a project and then re-included, this code ends up creating a new `TypeScriptCompile` for the file. It does not remove the existing entry, resulting in the same `TypeScriptCompile` being listed multiple times. This is annoying because it modifies the project files and requires you to resave them ever time a project is open.

**Fix**
Only run `IncludeInProject` if the file is not already included.