### PR TITLE
Set correct main in AzureWebWorker 

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/package.json
@@ -2,7 +2,7 @@
   "name": "$npmsafeprojectname$",
   "version": "0.0.0",
   "description": "$projectname$",
-  "main": "server.js",
+  "main": "worker.js",
   "author": {
     "name": "$username$",
     "email": ""


### PR DESCRIPTION
Use `worker` as `main` instead of `server` for AzureWebWorker template.

closes #619