### PR TITLE
Fix dispose pattern in a few more cases

### DIFF
--- a/Nodejs/Product/Nodejs/Classifier/SnapshotSpanSourceCodeReader.cs
+++ b/Nodejs/Product/Nodejs/Classifier/SnapshotSpanSourceCodeReader.cs
@@ -42,6 +42,8 @@ namespace Microsoft.NodejsTools {
         protected override void Dispose(bool disposing) {
             _snapshot = null;
             _position = 0;
+
+            base.Dispose(disposing);
         }
 
         public override int Peek() {

--- a/Nodejs/Product/Nodejs/Debugger/Communication/WebSocketNetworkClient.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/WebSocketNetworkClient.cs
@@ -49,6 +49,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
         }
 
         public void Dispose() {
+            _stream.Dispose();
             try {
                 _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None).GetAwaiter().GetResult();
                 _webSocket.Dispose();

--- a/Nodejs/Product/Nodejs/Intellisense/AnalysisQueue.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/AnalysisQueue.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NodejsTools.Intellisense {
             private readonly HashSet<IGroupableAnalysisProject> _enqueuedGroups;
             [NonSerialized]
             private DateTime _lastSave;
-            private CancellationTokenSource _cancel;
+            private readonly CancellationTokenSource _cancel;
             private bool _isAnalyzing;
             private int _analysisPending;
             private static readonly TimeSpan _SaveAnalysisTime = TimeSpan.FromMinutes(15);
@@ -137,6 +137,9 @@ namespace Microsoft.NodejsTools.Intellisense {
 
             void IDisposable.Dispose() {
                 Stop();
+
+                _cancel.Dispose();
+                _workEvent.Dispose();
             }
 
             #endregion

--- a/Nodejs/Product/Nodejs/Intellisense/AnalysisQueue.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/AnalysisQueue.cs
@@ -135,7 +135,7 @@ namespace Microsoft.NodejsTools.Intellisense {
 
             #region IDisposable Members
 
-            void IDisposable.Dispose() {
+            public void Dispose() {
                 Stop();
 
                 _cancel.Dispose();

--- a/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
@@ -16,21 +16,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading;
-using System.Windows;
-using System.Windows.Threading;
 using Microsoft.NodejsTools.Analysis;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.NodejsTools.Intellisense {
     sealed partial class VsProjectAnalyzer {
 
-        class BufferParser {
+        class BufferParser : IDisposable {
             internal VsProjectAnalyzer _parser;
             private readonly Timer _timer;
             private IList<ITextBuffer> _buffers;
@@ -49,18 +43,6 @@ namespace Microsoft.NodejsTools.Intellisense {
                 AttachedViews = 1;
 
                 InitBuffer(buffer);
-            }
-
-            public void StopMonitoring() {
-                foreach (var buffer in _buffers) {
-                    buffer.ChangedLowPriority -= BufferChangedLowPriority;
-                    buffer.Properties.RemoveProperty(typeof(BufferParser));
-                    if (_document != null) {
-                        _document.EncodingChanged -= EncodingChanged;
-                        _document = null;
-                    }
-                }
-                _timer.Dispose();
             }
 
             public ITextBuffer[] Buffers {
@@ -270,6 +252,24 @@ namespace Microsoft.NodejsTools.Intellisense {
                     return _document;
                 }
             }
+
+            #region IDisposable
+            private bool disposedValue = false;
+
+            protected virtual void Dispose(bool disposing) {
+                if (!disposedValue) {
+                    if (disposing) {
+                        _timer.Dispose();
+                    }
+
+                    disposedValue = true;
+                }
+            }
+
+            public void Dispose() {
+                Dispose(true);
+            }
+            #endregion
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
@@ -1327,7 +1327,7 @@ namespace Microsoft.NodejsTools.Intellisense {
             }
 
             if (_analysisQueue != null) {
-                _analysisQueue.Stop();
+                _analysisQueue.Dispose();
             }
 
             foreach (var bufferParser in _activeBufferParsers) {

--- a/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/VsProjectAnalyzer.cs
@@ -1330,6 +1330,13 @@ namespace Microsoft.NodejsTools.Intellisense {
                 _analysisQueue.Stop();
             }
 
+            foreach (var bufferParser in _activeBufferParsers) {
+                bufferParser.Dispose();
+            }
+            _activeBufferParsers.Clear();
+
+            _queueActivityEvent.Dispose();
+
             TaskProvider.Dispose();
         }
 

--- a/Nodejs/Product/Nodejs/NodejsEditorFactory.cs
+++ b/Nodejs/Product/Nodejs/NodejsEditorFactory.cs
@@ -123,24 +123,10 @@ namespace Microsoft.NodejsTools {
         }
 
         public virtual int Close() {
+            _serviceProvider?.Dispose();
             return VSConstants.S_OK;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="grfCreateDoc"></param>
-        /// <param name="pszMkDocument"></param>
-        /// <param name="pszPhysicalView"></param>
-        /// <param name="pvHier"></param>
-        /// <param name="itemid"></param>
-        /// <param name="punkDocDataExisting"></param>
-        /// <param name="ppunkDocView"></param>
-        /// <param name="ppunkDocData"></param>
-        /// <param name="pbstrEditorCaption"></param>
-        /// <param name="pguidCmdUI"></param>
-        /// <param name="pgrfCDW"></param>
-        /// <returns></returns>
         public virtual int CreateEditorInstance(
                         uint createEditorFlags,
                         string documentMoniker,

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -103,6 +103,10 @@ namespace Microsoft.NodejsTools.Project {
                     _npmController.CommandCompleted -= NpmController_CommandCompleted;
                 }
 
+                _devModulesNode.Dispose();
+                _optionalModulesNode.Dispose();
+                _globalModulesNode.Dispose();
+
                 _isDisposed = true;
             }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -55,8 +55,8 @@ namespace Microsoft.NodejsTools.Project {
 #endif
 
         // We delay analysis until things calm down in the node_modules folder.
-        internal Queue<NodejsFileNode> DelayedAnalysisQueue = new Queue<NodejsFileNode>();
-        private object _idleNodeModulesLock = new object();
+        internal readonly Queue<NodejsFileNode> DelayedAnalysisQueue = new Queue<NodejsFileNode>();
+        private readonly object _idleNodeModulesLock = new object();
         private volatile bool _isIdleNodeModules = false;
         private Timer _idleNodeModulesTimer;
 
@@ -1016,6 +1016,8 @@ namespace Microsoft.NodejsTools.Project {
                 RemoveChild(ModulesNode);
                 ModulesNode?.Dispose();
                 ModulesNode = null;
+
+                DelayedAnalysisQueue.Clear();
 #if DEV14
                 _typingsAcquirer = null;
 #endif


### PR DESCRIPTION
Using the VS static analyzer to find objects that are not being disposed properly and fixing some of these.

Related to #870. Still trying to track down who exactly is holding onto the NodeJsProject node after it is unloaded