### PR TITLE
Fix an argument exception in `OnTestContainersChanged`

### DIFF
--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -550,14 +550,13 @@ namespace Microsoft.NodejsTools.TestAdapter {
             string projectPath;
             if (project != null &&
                 project.TryGetProjectPath(out projectPath) &&
+                !string.IsNullOrEmpty(projectPath) &&
                 _knownProjects.TryGetValue(projectPath, out projectInfo) &&
+                projectInfo != null &&
                 projectInfo.HasRequestedContainers) {
 
                 if (!_building || !_detectingChanges) {
-                    var evt = TestContainersUpdated;
-                    if (evt != null) {
-                        evt(this, EventArgs.Empty);
-                    }
+                    TestContainersUpdated?.Invoke(this, EventArgs.Empty);
                     return true;
                 }
             }


### PR DESCRIPTION
**Bug**
When unloading a project with the Test Explorer window open, an exception is thrown in `OnTestContainersChanged` because `TryGetProjectPath` returns null

**Fix**
Add two additional checks to handle the case where the project has been unloaded but the test explorer is still referencing it.

Also auto corrected a delegate invocation in the body of the function.