### PR TITLE
Preserve stack when rethrowing exceptions in C# files

### DIFF
--- a/Nodejs/Product/Npm/sqlite/SQLite.cs
+++ b/Nodejs/Product/Npm/sqlite/SQLite.cs
@@ -1427,14 +1427,12 @@ namespace SQLite
 
 			try {
 				rowsAffected = Execute (q, ps.ToArray ());
-			}
-			catch (SQLiteException ex) {
-
+			} catch (SQLiteException ex) {
 				if (ex.Result == SQLite3.Result.Constraint && SQLite3.ExtendedErrCode (this.Handle) == SQLite3.ExtendedResult.ConstraintNotNull) {
-					throw NotNullConstraintViolationException.New (ex, map, obj);
+					throw NotNullConstraintViolationException.New(ex, map, obj);
 				}
 
-				throw ex;
+				throw;
 			}
 
 			if (rowsAffected > 0)

--- a/Nodejs/Product/TestAdapter/TestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscoverer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     }
                 } catch (Exception ex) {
                     logger.SendMessage(TestMessageLevel.Error, ex.Message);
-                    throw ex;
+                    throw;
                 } finally {
                     // Disposing buildEngine does not clear the document cache in
                     // VS 2013, so manually unload all projects before disposing.


### PR DESCRIPTION
Two small changes to make sure we preserve the stack when catching and rethrowing an exception in our c# code.