### PR TITLE
Fix Debugger display of JS strings that contain Date strings

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
@@ -33,6 +33,10 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
         private ConcurrentDictionary<int, TaskCompletionSource<JObject>> _messages =
             new ConcurrentDictionary<int, TaskCompletionSource<JObject>>();
 
+        private readonly static Newtonsoft.Json.JsonSerializerSettings jsonSettings = new Newtonsoft.Json.JsonSerializerSettings() {
+            DateParseHandling = Newtonsoft.Json.DateParseHandling.None
+        };
+
         public DebuggerClient(IDebuggerConnection connection) {
             Utilities.ArgumentNotNull("connection", connection);
 
@@ -116,7 +120,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
         /// <param name="sender">Sender.</param>
         /// <param name="args">Event arguments.</param>
         private void OnOutputMessage(object sender, MessageEventArgs args) {
-            JObject message = JObject.Parse(args.Message);
+            var message = Newtonsoft.Json.JsonConvert.DeserializeObject<JObject>(args.Message, jsonSettings);
             var messageType = (string)message["type"];
 
             switch (messageType) {


### PR DESCRIPTION
Addresses #106.

**Bug**
Json.net will automatically try to parse strings that look like date strings. If one of these is recieved as the value in a Node debug message, we end up displaying the wrong value in the debugger.

**Fix**
Make sure we always use DateTimeParse.None when dealing with messages from the debugger. If we do need to parse a date string, we should handle those cases explicitly.

closes #106