### PR TITLE
Fix some errors in runtests

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -21,8 +21,7 @@
 [CmdletBinding()]
 param(
     [string[]] $vstarget,
-	[Parameter(Position=0)][string[]] $args
-
+    [Parameter(Position=0)][string[]] $args
 )
 
 $rootDir = $PSScriptRoot
@@ -49,7 +48,7 @@ $nodejstoolsroot = $PSScriptRoot
 foreach($vsVersion in $target_versions) {
 	$vstest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio $($vsVersion.number)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 	if (Test-Path $vstest) {   
-        $testFiles = $tests | % { ".\BuildOutput\Debug$($vsVersion.number)\Tests\$_.dll" }
+        $testFiles = $tests | % { ".\BuildOutput\Release$($vsVersion.number)\Tests\$_.dll" }
         & "$vstest" /settings:$("$nodejstoolsroot\Build\default." + $vstarget + "Exp.testsettings") @args $testFiles
 	} else {
         Write-Warning "Could not find valid vstest.console for VS $($vsVersion)"

--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -20,7 +20,9 @@
 
 [CmdletBinding()]
 param(
-    [string[]] $vstarget
+    [string[]] $vstarget,
+	[Parameter(Position=0)][string[]] $args
+
 )
 
 $rootDir = $PSScriptRoot
@@ -42,11 +44,13 @@ if (-not $target_versions) {
     throw "Could not find any valid versions of Visual Studio installed"
 }
 
+$nodejstoolsroot = $PSScriptRoot
+
 foreach($vsVersion in $target_versions) {
 	$vstest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio $($vsVersion.number)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 	if (Test-Path $vstest) {   
-        $testFiles = $tests | % { ".\BuildOutput\Release$($vsVersion.number)\Tests\$_.dll" }
-        & "$vstest" /settings:$("$nodejstoolsroot\Build\default." + $selectedVsVersion + "Exp.testsettings") @args $testFiles
+        $testFiles = $tests | % { ".\BuildOutput\Debug$($vsVersion.number)\Tests\$_.dll" }
+        & "$vstest" /settings:$("$nodejstoolsroot\Build\default." + $vstarget + "Exp.testsettings") @args $testFiles
 	} else {
         Write-Warning "Could not find valid vstest.console for VS $($vsVersion)"
     }

--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -43,13 +43,11 @@ if (-not $target_versions) {
     throw "Could not find any valid versions of Visual Studio installed"
 }
 
-$nodejstoolsroot = $PSScriptRoot
-
 foreach($vsVersion in $target_versions) {
 	$vstest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio $($vsVersion.number)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 	if (Test-Path $vstest) {   
         $testFiles = $tests | % { ".\BuildOutput\Release$($vsVersion.number)\Tests\$_.dll" }
-        & "$vstest" /settings:$("$nodejstoolsroot\Build\default." + $vstarget + "Exp.testsettings") @args $testFiles
+        & "$vstest" /settings:$("$rootDir\Build\default." + $vstarget + "Exp.testsettings") @args $testFiles
 	} else {
         Write-Warning "Could not find valid vstest.console for VS $($vsVersion)"
     }


### PR DESCRIPTION
#890 introduced some regressions with `runtests.ps1`. A few small fixes:

* Use updated variable in place of `selectedVsVersion` to select test settings file.
* Set `nodejstoolsroot ` to root of NTVS
* Forward args to `vstest.console.exe`