### PR TITLE
Remove "Test" prefix from test method names

### DIFF
--- a/Nodejs/Tests/AnalysisTests/AnalysisDictionaryTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisDictionaryTests.cs
@@ -27,7 +27,7 @@ namespace NodejsTests {
     [TestClass]
     public class AnalysisDictionaryTests {
         [TestMethod, Priority(0)]
-        public void TestBasic() {
+        public void Basic() {
             var dict = new AnalysisDictionary<string, string>();
             Assert.IsFalse(dict.Remove("Foo"));
             dict.Add("1", "One");
@@ -110,13 +110,13 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestAddExisting() {
+        public void AddExisting() {
             var dict = new AnalysisDictionary<string, string>() { { "1", "One" } };
             AssertUtil.Throws<ArgumentException>(() => dict.Add("1", "Two"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestGrowth() {
+        public void Growth() {
             var dict = new AnalysisDictionary<string, string>();
             for (int i = 0; i < 25; i++) {
                 dict[i.ToString()] = i.ToString();
@@ -137,7 +137,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReplaceExisting() {
+        public void ReplaceExisting() {
             // same object reference
             var dict = new AnalysisDictionary<string, string>();
             var value = "1";
@@ -160,7 +160,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestRemoveExisting() {
+        public void RemoveExisting() {
             var dict = new AnalysisDictionary<Hashable, string>();
             var one = new Hashable(1, (self, x) => x._hash == 1);
             var two = new Hashable(1, (self, x) => x._hash == 1);
@@ -170,7 +170,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestNull() {
+        public void Null() {
             var dict = new AnalysisDictionary<string, string>();
             string dummy;
             AssertUtil.Throws<ArgumentNullException>(
@@ -188,7 +188,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestAddRemoveAdd() {
+        public void AddRemoveAdd() {
             // same object reference
             var dict = new AnalysisDictionary<string, string>();
             var value = "1";
@@ -215,7 +215,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestCollision() {
+        public void Collision() {
             // difference object reference, but equal.
             var dict = new AnalysisDictionary<Hashable, string>();
             List<Hashable> items = new List<Hashable>();
@@ -239,7 +239,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestComparer() {
+        public void Comparer() {
             // difference object reference, but equal.
             foreach (var dict in new[] {
                 new AnalysisDictionary<string, string>(MyComparer.Instance),
@@ -253,7 +253,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestEnumeration() {
+        public void Enumeration() {
             var dict = new AnalysisDictionary<string, string>() { { "1", "One" } };
             var enumer = dict.GetEnumerator();
             while (enumer.MoveNext()) {
@@ -267,7 +267,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestClear() {
+        public void Clear() {
             var dict = new AnalysisDictionary<string, string>();
             dict.Clear();
             Assert.AreEqual(0, dict.Count);
@@ -289,7 +289,7 @@ namespace NodejsTests {
         /// that we pick up the new value correctly.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestThreadedReaderUpdatedValue() {
+        public void ThreadedReaderUpdatedValue() {
             var comparer = new SynchronizedComparer();
 
             var dict = new AnalysisDictionary<Hashable, string>(comparer);
@@ -313,7 +313,7 @@ namespace NodejsTests {
         /// value that we don't find the non-equivalent value.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestThreadedReaderValueRemoved() {
+        public void ThreadedReaderValueRemoved() {
             var comparer = new SynchronizedComparer();
 
             var dict = new AnalysisDictionary<Hashable, string>(comparer);
@@ -334,7 +334,7 @@ namespace NodejsTests {
         /// Tests concurrent writer with concurrent reader
         /// </summary>
         [TestMethod, Priority(2)]
-        public void TestThreaded() {
+        public void Threaded() {
             var dict = new AnalysisDictionary<string, string>();
             var keys = new[] { "1", "2", "3", "4", "5", "6" };
             foreach (var key in keys) {

--- a/Nodejs/Tests/AnalysisTests/AnalysisHashSetTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisHashSetTests.cs
@@ -27,7 +27,7 @@ namespace AnalysisTests {
     [TestClass]
     public class AnalysisHashSetTests {
         [TestMethod, Priority(0)]
-        public void TestEmpty() {
+        public void Empty() {
             TestEmptySet(AnalysisSet.Empty);
             TestObjectSet(AnalysisSet.Empty);
             TestEmptySet(AnalysisSet.EmptyUnion);
@@ -39,7 +39,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestWrapperSelfSet() {
+        public void WrapperSelfSet() {
             var projectEntry = CreateProjectEntry();
             var value = new TestAnalysisValue(projectEntry);
 
@@ -48,7 +48,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestSetOfOne() {
+        public void SetOfOne() {
             var projectEntry = CreateProjectEntry();
             var value = new TestAnalysisValue(projectEntry);
             
@@ -56,7 +56,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestSetOfTwo() {
+        public void SetOfTwo() {
             var projectEntry = CreateProjectEntry();
             var value1 = new TestAnalysisValue(projectEntry);
             var value2 = new TestAnalysisValue(projectEntry);
@@ -65,7 +65,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestHashSet() {
+        public void HashSet() {
             var projectEntry = CreateProjectEntry();
             List<AnalysisProxy> values = new List<AnalysisProxy>();
             for (int i = 0; i < 10; i++) {

--- a/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
@@ -40,7 +40,7 @@ namespace AnalysisTests {
         /// https://nodejstools.codeplex.com/workitem/945
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestFunctionApply() {
+        public void FunctionApply() {
             string code = @"
 function g() {
     this.abc = 42;
@@ -64,7 +64,7 @@ var x = new f().abc;
         /// https://nodejstools.codeplex.com/workitem/945
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestToString() {
+        public void ToString() {
             string code = @"
 var x = new Object();
 var y = x.toString();
@@ -81,7 +81,7 @@ var y = x.toString();
         /// https://nodejstools.codeplex.com/workitem/965
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestBuiltinDoc() {
+        public void BuiltinDoc() {
             string code = @"
 var x = 'abc'
 ";
@@ -98,7 +98,7 @@ var x = 'abc'
         /// https://nodejstools.codeplex.com/workitem/935
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestAllMembers() {
+        public void AllMembers() {
             string code = @"
 function f() {
     if(true) {
@@ -123,7 +123,7 @@ var x = f();
         /// https://nodejstools.codeplex.com/workitem/950
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestReturnValues() {
+        public void ReturnValues() {
             string code = @"
 function f(x) {
     return x;
@@ -142,7 +142,7 @@ f({def:'abc'});
         }
 
         [TestMethod, Priority(0)]
-        public void TestArguments() {
+        public void Arguments() {
             string code = @"
 function f() {
     return arguments[0];
@@ -173,7 +173,7 @@ var z = g('abc', 0);
         }
 
         [TestMethod, Priority(0)]
-        public void TestAssignmentScope() {
+        public void AssignmentScope() {
             string code = @"
 var rjs;
 function f() {
@@ -198,7 +198,7 @@ x = g();";
         /// https://nodejstools.codeplex.com/workitem/987
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestMembersListsInvalidIdentifier() {
+        public void MembersListsInvalidIdentifier() {
             string code = @"
 var x = {};
 x['./foo/quox.js'] = 42;
@@ -219,7 +219,7 @@ var z = x['./foo/quox.js'];
 
 
         [TestMethod, Priority(0)]
-        public void TestPrimitiveMembers() {
+        public void PrimitiveMembers() {
             string code = @"
 var b = true;
 var n = 42.0;
@@ -264,7 +264,7 @@ function f() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayForEach() {
+        public void ArrayForEach() {
             string code = @"
 var arr = [1,2,3];
 function f(a) {
@@ -280,7 +280,7 @@ arr.forEach(f);
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayPush() {
+        public void ArrayPush() {
             string code = @"
 var arr = [];
 arr.push(42);
@@ -294,7 +294,7 @@ var x = arr[0];
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayPop() {
+        public void ArrayPop() {
             string code = @"
 var arr = [];
 arr.push(42);
@@ -316,7 +316,7 @@ var y = arr2.pop();
         }
 
         [TestMethod, Priority(0)]
-        public void TestArraySetIndex() {
+        public void ArraySetIndex() {
             string code = @"
 var arr = [];
 arr[0] = 42;
@@ -340,7 +340,7 @@ var y = arr2[0];
         }
 
         [TestMethod, Priority(0)]
-        public void TestArraySlice() {
+        public void ArraySlice() {
             string code = @"
 var arr = [1,2,3];
 var x = arr.slice(1,2)[0];
@@ -353,7 +353,7 @@ var x = arr.slice(1,2)[0];
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayConcat() {
+        public void ArrayConcat() {
             string code = @"
 var arr = ['abc', 'def'];
 x = {};
@@ -379,7 +379,7 @@ arr.concat('all').forEach(function f(a) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestPrototypeGetter() {
+        public void PrototypeGetter() {
             string code = @"
 function MyObject() {
 }
@@ -400,7 +400,7 @@ var y = x.myprop;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionDefineGetter() {
+        public void FunctionDefineGetter() {
             string code = @"function f() {
 }
 
@@ -415,7 +415,7 @@ var x = f.abc;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionPrototypeLookup() {
+        public void FunctionPrototypeLookup() {
             string code = @"function f() {
 }
 
@@ -436,7 +436,7 @@ var x = f.xyz();
         }
 
         [TestMethod, Priority(0)]
-        public void TestProtoSetCorrectly() {
+        public void ProtoSetCorrectly() {
             string code = @"function f() { }
 f.prototype.abc = 42
 var x = (new f()).__proto__.abc;
@@ -449,7 +449,7 @@ var x = (new f()).__proto__.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestInfiniteDescriptors() {
+        public void InfiniteDescriptors() {
             string code = @"x = {abc:42}
 
 function f(x) {
@@ -464,7 +464,7 @@ f(x)
         }
 
         [TestMethod, Priority(0)]
-        public void TestCopyDescriptor() {
+        public void CopyDescriptor() {
             string code = @"x = {abc:42}
 
 desc = Object.getOwnPropertyDescriptor(x, 'abc')
@@ -504,7 +504,7 @@ for(var propName in copied) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestThisFlows() {
+        public void ThisFlows() {
             string code = @"
 function f() {
     this.func();
@@ -528,7 +528,7 @@ var x = new f().value;
         /// This needs to flow when our function call analysis exceeds our limits.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestThisFlows2() {
+        public void ThisFlows2() {
             string code = @"
 var app = {};
 app.init = function() {
@@ -551,7 +551,7 @@ var x = app.foo;
         }
         
         [TestMethod, Priority(0)]
-        public void TestThisPassedAndReturned() {
+        public void ThisPassedAndReturned() {
             string code = @"function X(csv) {
     abc = 100;
     return csv;
@@ -606,7 +606,7 @@ SimpleTest.prototype._performRequest = function (webResource, body, options, cal
         }
 
         [TestMethod, Priority(0)]
-        public void TestPropertyGotoDef() {
+        public void PropertyGotoDef() {
             string code = @"
 Object.defineProperty(Object.prototype, 'should', { set: function() { }, get: function() { 42 } });
 var x = {};
@@ -623,7 +623,7 @@ var x = {};
         /// https://nodejstools.codeplex.com/workitem/1097
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestAttributeGotoDef() {
+        public void AttributeGotoDef() {
             string code = @"
 var x = {}; 
 x.abc = 42; 
@@ -642,7 +642,7 @@ x.abc
         /// https://nodejstools.codeplex.com/workitem/1464
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestBuiltinRequireGotoDef() {
+        public void BuiltinRequireGotoDef() {
             string code = @"
 var assert = require('assert'); 
 ";
@@ -656,7 +656,7 @@ var assert = require('assert');
         }
 
         [TestMethod, Priority(0)]
-        public void TestGlobals() {
+        public void Globals() {
             string code = @"
 var x = 42;
 ";
@@ -669,7 +669,7 @@ var x = 42;
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefinitiveAssignmentScoping() {
+        public void DefinitiveAssignmentScoping() {
             string code = @"
 var x = {abc:42};
 x = x.abc;
@@ -685,7 +685,7 @@ x = x.abc;
         /// https://nodejstools.codeplex.com/workitem/949
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestDefinitiveAssignmentScoping2() {
+        public void DefinitiveAssignmentScoping2() {
             string code = @"
 a = b = c = 2;
 a
@@ -708,7 +708,7 @@ c
         }
 
         [TestMethod, Priority(0)]
-        public void TestSignatureHelp() {
+        public void SignatureHelp() {
             string code = @"
 function foo(x, y) {}
 foo(123, 'abc');
@@ -745,7 +745,7 @@ abc(abc);
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestJSDoc() {
+        public void JSDoc() {
             string code = @"
 /** Documentation for f.
   * 
@@ -801,7 +801,7 @@ Another paragraph that won't show up anywhere. This one has a {@link}.
         }
 
         [TestMethod, Priority(0)]
-        public void TestStringMembers() {
+        public void StringMembers() {
             string code = @"
 var x = 'abc';
 ";
@@ -813,7 +813,7 @@ var x = 'abc';
         }
 
         [TestMethod, Priority(0)]
-        public void TestBadIndexes() {
+        public void BadIndexes() {
             string code = @"
 var x = {};
 x[] = 42;
@@ -826,7 +826,7 @@ var y = x[];
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefinitiveAssignmentMerged() {
+        public void DefinitiveAssignmentMerged() {
             string code = @"
 if(true) {
     y = 100;
@@ -844,7 +844,7 @@ x = y;
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefinitiveAssignment() {
+        public void DefinitiveAssignment() {
             string code = @"
 a = 100;
 // int value
@@ -863,7 +863,7 @@ a = 'abc';
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefinitiveAssignmentNested() {
+        public void DefinitiveAssignmentNested() {
             string code = @"
 a = 100;
 // a int value
@@ -906,7 +906,7 @@ b = 'abc';
         /// we return the value if the function returns an object.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestConstruct() {
+        public void Construct() {
             var code = @"function f() {
      return {abc:42};
 }
@@ -951,7 +951,7 @@ var x = new f();
         }
 
         [TestMethod, Priority(0)]
-        public void TestConstructReturnFunction() {
+        public void ConstructReturnFunction() {
             var code = @"function f() {
      function inner() {
      }
@@ -978,7 +978,7 @@ var x = new f();
 
 
         [TestMethod, Priority(0)]
-        public void TestExports() {
+        public void Exports() {
             string code = @"
 exports.num = 42;
 module.exports.str = 'abc'
@@ -995,7 +995,7 @@ module.exports.str = 'abc'
         }
 
         [TestMethod, Priority(0)]
-        public void TestAccessorDescriptor() {
+        public void AccessorDescriptor() {
             string code = @"
 function f() {
 }
@@ -1010,7 +1010,7 @@ x = f.foo;
         }
 
         [TestMethod, Priority(0)]
-        public void TestDefineProperties() {
+        public void DefineProperties() {
             string code = @"
 function f() {
 }
@@ -1032,7 +1032,7 @@ x = f.abc;
         /// we need to enqueue the callers.
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestDefinePropertiesDependencies() {
+        public void DefinePropertiesDependencies() {
             string code = @"
 var x =  {};
 var properties = function() {
@@ -1071,7 +1071,7 @@ Object.defineProperties(x, createProperties());
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionExpression() {
+        public void FunctionExpression() {
             string code = @"
 var abc = {abc: function abcdefg() { } };
 var x = abcdefg;
@@ -1081,7 +1081,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestGlobal() {
+        public void Global() {
             var analysis = ProcessText(";");
 
             AssertUtil.ContainsExactly(
@@ -1097,7 +1097,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestNumberFunction() {
+        public void NumberFunction() {
             var analysis = ProcessText(";");
 
             foreach (var numberValue in new[] { "length", "MAX_VALUE", "MIN_VALUE", "NaN", "NEGATIVE_INFINITY", "POSITIVE_INFINITY" }) {
@@ -1136,7 +1136,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSimpleClosure() {
+        public void SimpleClosure() {
             var code = @" function f()
 {
  var x = 42;
@@ -1158,7 +1158,7 @@ var x = abcdefg;
         //}
 
         [TestMethod, Priority(0)]
-        public void TestNumber() {
+        public void Number() {
             string code = "x = 42;";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1174,7 +1174,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableLookup() {
+        public void VariableLookup() {
             string code = "x = 42; y = x;";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1184,7 +1184,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclaration() {
+        public void VariableDeclaration() {
             var analysis = ProcessText("var x = 42;");
             AssertUtil.ContainsExactly(
                 analysis.GetTypeIdsByIndex("x", 0),
@@ -1193,7 +1193,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestStringLiteral() {
+        public void StringLiteral() {
             string code = "x = 'abc';";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1203,7 +1203,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayLiteral() {
+        public void ArrayLiteral() {
             string code = "x = [1,2,3];";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1213,7 +1213,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestTrueFalse() {
+        public void TrueFalse() {
             string code = "x = true;";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1230,7 +1230,7 @@ var x = abcdefg;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpecializedExtend() {
+        public void SpecializedExtend() {
             var code = @"function extend(obj) {
     if (!_.isObject(obj)) return obj;
     var source, prop;
@@ -1260,7 +1260,7 @@ extend(x, {abc:42});
         }
 
         [TestMethod, Priority(0)]
-        public void TestBackboneExtend() {
+        public void BackboneExtend() {
             var code = @"function extend(protoProps, staticProps) {
     var parent = this;
     var child;
@@ -1306,7 +1306,7 @@ var myinst = new myclass();
         }
 
         [TestMethod, Priority(0)]
-        public void TestLodashAssign() {
+        public void LodashAssign() {
             var code = @"
 var assign = function(object, source, guard) {
      var index, iterable = object, result = iterable;
@@ -1351,7 +1351,7 @@ var z = y.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestObjectKeys() {
+        public void ObjectKeys() {
             var code = @"
 var foo = {};
 
@@ -1382,7 +1382,7 @@ var str = foo.str.value;
 
 
         [TestMethod, Priority(0)]
-        public void TestObjectLiteral() {
+        public void ObjectLiteral() {
             string code = "x = {abc:42};";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -1420,7 +1420,7 @@ var str = foo.str.value;
         }
 
         [TestMethod, Priority(1)]
-        public void TestConstructor() {
+        public void Constructor() {
             var code = @"function f() {
 	this.abc = 42;
 }
@@ -1442,7 +1442,7 @@ var z = y.abc";
         }
 
         [TestMethod, Priority(2)]
-        public void TestForInLoop() {
+        public void ForInLoop() {
             var analysis = ProcessText("for(var x in ['a','b','c']) { }");
             AssertUtil.ContainsExactly(
                 analysis.GetTypeIdsByIndex("x", 0),
@@ -1461,7 +1461,7 @@ var z = y.abc";
 
 
         [TestMethod, Priority(0)]
-        public void TestFunctionCreation() {
+        public void FunctionCreation() {
             var analysis = ProcessText(@"function f() {
 }
 f.prototype.abc = 42
@@ -1487,7 +1487,7 @@ var x = f.prototype.constructor.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestPrototypeNoMerge() {
+        public void PrototypeNoMerge() {
             var analysis = ProcessText(@"
 var abc = Function.prototype;
 abc.bar = 42;
@@ -1504,7 +1504,7 @@ var x = new f().bar;
         /// This shouldn't stack overflow...
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestRecursiveForEach() {
+        public void RecursiveForEach() {
             var analysis = ProcessText(@"
 var x = [null];
 x[0] = x.forEach;
@@ -1516,7 +1516,7 @@ x.forEach(x.forEach);
         /// Array instances created via array constructor should be unique
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNewArrayUnique() {
+        public void NewArrayUnique() {
             var analysis = ProcessText(@"
 var arr1 = new Array(5);
 var arr2 = new Array(10);
@@ -1539,7 +1539,7 @@ arr2.foo = 'abc';
         /// Array instances created via array constructor should be unique
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNewObjectUnique() {
+        public void NewObjectUnique() {
             var analysis = ProcessText(@"
 var obj1 = new Object(5);
 var obj2 = new Object(10);
@@ -1559,7 +1559,7 @@ obj2.foo = 'abc';
         }
 
         [TestMethod, Priority(0)]
-        public void TestObjectInstanceNoPrototype() {
+        public void ObjectInstanceNoPrototype() {
             var analysis = ProcessText(@"
 var x = new Object().prototype;
 var y = {}.prototype;
@@ -1575,7 +1575,7 @@ var y = {}.prototype;
         }
 
         [TestMethod, Priority(0)]
-        public void TestKeysSpecialization() {
+        public void KeysSpecialization() {
             var analysis = ProcessText(@"
 function keys(o) {
   var a = []
@@ -1592,7 +1592,7 @@ var x = keys({'abc':42});
         }
 
         [TestMethod, Priority(0)]
-        public void TestMergeSpecialization() {
+        public void MergeSpecialization() {
             var analysis = ProcessText(@"function merge(a, b){
   if (a && b) {
     for (var key in b) {
@@ -1621,7 +1621,7 @@ var x = g.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestMergeDescriptorsSpecialization() {
+        public void MergeDescriptorsSpecialization() {
             var analysis = ProcessText(@"var merge = function exports(dest, src) {
     Object.getOwnPropertyNames(src).forEach(function (name) {
         var descriptor = Object.getOwnPropertyDescriptor(src, name)
@@ -1649,7 +1649,7 @@ var x = g.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestToObjectSpecialization() {
+        public void ToObjectSpecialization() {
             var analysis = ProcessText(@"function toObject(value) {
       return isObject(value) ? value : Object(value);
     }
@@ -1663,7 +1663,7 @@ var x = toObject('abc');
         }
 
         [TestMethod, Priority(0)]
-        public void TestMergeSpecialization2() {
+        public void MergeSpecialization2() {
             var analysis = ProcessText(@"function merge (to, from) {
   var keys = Object.keys(from)
     , i = keys.length
@@ -1702,7 +1702,7 @@ var x = g.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestMergeCloneSpecialization2() {
+        public void MergeCloneSpecialization2() {
             var analysis = ProcessText(@"function mergeClone (to, from) {
   var keys = Object.keys(from)
     , i = keys.length
@@ -1746,7 +1746,7 @@ var x = g.abc;
 
 
         [TestMethod, Priority(0)]
-        public void TestCloneSpecialization() {
+        public void CloneSpecialization() {
             var analysis = ProcessText(@"function clone (obj) {
   if (obj === undefined || obj === null)
     return obj;
@@ -1764,7 +1764,7 @@ var y = x.abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestWrapFunctionSpecialization() {
+        public void WrapFunctionSpecialization() {
             var code = @"function wrapfunction(fn, message) {
   if (typeof fn !== 'function') {
     throw new TypeError('argument fn must be a function')
@@ -1802,7 +1802,7 @@ var res = wrapped(42);
         }
 
         [TestMethod, Priority(0)]
-        public void TestStringCasing() {
+        public void StringCasing() {
             string code = @"
 var x = {};
 ['upper'].forEach(function f(attr) { x[attr.toUpperCase()] = 42; });
@@ -1823,7 +1823,7 @@ var x = {};
         }
 
         [TestMethod, Priority(0)]
-        public void TestBuiltinFunctionDocumentation() {
+        public void BuiltinFunctionDocumentation() {
             string code = @"
 var func = Object.defineProperties;
 ";
@@ -1838,7 +1838,7 @@ var func = Object.defineProperties;
         /// are defined by JavaScript
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestImmutableObjects() {
+        public void ImmutableObjects() {
             string code = @"
 global.Infinity = 'abc'
 var x = global.Infinity";
@@ -1854,7 +1854,7 @@ var x = global.Infinity";
         /// https://nodejstools.codeplex.com/workitem/1039
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNodejsCallbacks() {
+        public void NodejsCallbacks() {
             string code = @"
 var http = require('http');
 var https = require('https');
@@ -1971,7 +1971,7 @@ net.connect('', function(c) {
         /// https://nodejstools.codeplex.com/workitem/914
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNodejsSpecializations() {
+        public void NodejsSpecializations() {
             string code = @"
 var pid = process.pid;
 var platform = process.platform;
@@ -1991,7 +1991,7 @@ var title = process.title;
         /// https://nodejstools.codeplex.com/workitem/1077
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNodejsPathMembers() {
+        public void NodejsPathMembers() {
             string code = @"
 var path = require('path');
 var join = path.join('a', 'b');
@@ -2019,7 +2019,7 @@ var extname = path.extname('/tmp/foo.txt');
         /// https://nodejstools.codeplex.com/workitem/1077
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNodejsBufferInstanceMembers() {
+        public void NodejsBufferInstanceMembers() {
             string code = @"
 var buf1 = new require('buffer').Buffer(42);
 var buf2 = require('buffer').Buffer(42);";
@@ -2042,7 +2042,7 @@ var buf2 = require('buffer').Buffer(42);";
         }
 
         [TestMethod, Priority(0)]
-        public void TestNodejsCreateFunctions() {
+        public void NodejsCreateFunctions() {
             var code = @"var x = require('http').createServer(null, null);
 var y = require('net').createServer(null, null);
 ";
@@ -2060,7 +2060,7 @@ var y = require('net').createServer(null, null);
 
 
         [TestMethod, Priority(0)]
-        public void TestSetPrototypeSpecialization() {
+        public void SetPrototypeSpecialization() {
             StringBuilder code = new StringBuilder(@"function setProto(obj, proto) {
   if (typeof Object.setPrototypeOf === 'function')
     return Object.setPrototypeOf(obj, proto)
@@ -2103,7 +2103,7 @@ var y = require('net').createServer(null, null);
         }
 
         [TestMethod, Priority(0)]
-        public void TestCopySpecialization() {
+        public void CopySpecialization() {
             var analysis = ProcessText(@"function copy (obj) {
   var o = {}
   Object.keys(obj).forEach(function (i) {
@@ -2130,7 +2130,7 @@ var abc2 = c2.bar;
         }
 
         [TestMethod, Priority(0)]
-        public void TestCreateSpecialization() {
+        public void CreateSpecialization() {
             var analysis = ProcessText(@"function F() {
 }
 
@@ -2153,7 +2153,7 @@ abc2 = create({bar:'abc'}).bar
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionParametersMultipleCallers() {
+        public void FunctionParametersMultipleCallers() {
             var analysis = ProcessText(@"function f(a) {
     return a;
 }
@@ -2172,7 +2172,7 @@ var y = f('abc');
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionParameters() {
+        public void FunctionParameters() {
             var analysis = ProcessText(@"function x(a) { return a; }
 var y = x(42);");
             AssertUtil.ContainsExactly(
@@ -2182,7 +2182,7 @@ var y = x(42);");
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionReturn() {
+        public void FunctionReturn() {
             var analysis = ProcessText("function x() { return 42; }");
             AssertUtil.ContainsExactly(
                 analysis.GetTypeIdsByIndex("x()", 0),
@@ -2191,7 +2191,7 @@ var y = x(42);");
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunction() {
+        public void Function() {
             var analysis = ProcessText("function x() { }");
             AssertUtil.ContainsExactly(
                 analysis.GetTypeIdsByIndex("x", 0),
@@ -2236,7 +2236,7 @@ var y = x(42);");
         }
 
         [TestMethod, Priority(0)]
-        public void TestNewFunction() {
+        public void NewFunction() {
             string code = "function y() { return 42; }\r\nx = new y();";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -2253,7 +2253,7 @@ var y = x(42);");
         }
 
         [TestMethod, Priority(0)]
-        public void TestNewFunctionInstanceVariable() {
+        public void NewFunctionInstanceVariable() {
             string code = "function f() { this.abc = 42; }\r\nx = new f();";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -2278,7 +2278,7 @@ abcy = new y();";
         }
 
         [TestMethod, Priority(0)]
-        public void TestSimplePrototype() {
+        public void SimplePrototype() {
             string code = @"
 function f() {
 }
@@ -2298,7 +2298,7 @@ x = new j();
         }
 
         [TestMethod, Priority(0)]
-        public void TestTypeOf() {
+        public void TypeOf() {
             string code = "x = typeof 42;";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(
@@ -2308,7 +2308,7 @@ x = new j();
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableShadowing() {
+        public void VariableShadowing() {
             var code = @"var a = 'abc';
 function f() {
 console.log(a);
@@ -2328,7 +2328,7 @@ f();";
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionExpressionNameScoping() {
+        public void FunctionExpressionNameScoping() {
             var code = @"var x = function abc() {
     // here
     var x = 42;
@@ -2351,7 +2351,7 @@ x.bar = 42;
 
 
         [TestMethod, Priority(0)]
-        public void TestFunctionExpressionNameScopingNested() {
+        public void FunctionExpressionNameScopingNested() {
             var code = @"
 function f() {
     var x = function abc() {
@@ -2377,7 +2377,7 @@ function f() {
         }
         
         [TestMethod, Priority(0)]
-        public void TestFunctionClosureCall() {
+        public void FunctionClosureCall() {
             var code = @"function abc() {
     function g(x) {
         function inner() {
@@ -2404,7 +2404,7 @@ var y = abc()('abc');
 
 
         [TestMethod, Priority(0)]
-        public void TestTypes() {
+        public void Types() {
             string code = "x = {undefined:undefined, number:42, string:'str', null:null, boolean:true, function: function() {}, object: {}}";
             var analysis = ProcessText(code);
             var testCases = new[] { 
@@ -2434,7 +2434,7 @@ var y = abc()('abc');
         }
 
         [TestMethod, Priority(0)]
-        public void TestDateTime() {
+        public void DateTime() {
             var code = @"var d = Date;
 ";
 
@@ -2456,7 +2456,7 @@ var y = abc()('abc');
         }
 
         [TestMethod, Priority(0)]
-        public void TestDescriptions() {
+        public void Descriptions() {
             var code = @"var n = 1;
 var b = true;
 var s = 'str';
@@ -2490,7 +2490,7 @@ var undef = undefined;
         }
 
         [TestMethod, Priority(0)]
-        public void TestUtilInherits() {
+        public void UtilInherits() {
             var code = @"util = require('util');
 
 function f() {
@@ -2517,7 +2517,7 @@ var abc = new f().abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestUtilInherits2() {
+        public void UtilInherits2() {
             var code = @"util = require('util');
 
 function f() {
@@ -2548,7 +2548,7 @@ var abc = new g().abc;
         /// to the internal [[Prototype]] property.
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestDunderProto() {
+        public void DunderProto() {
             // shouldn't crash
             var code = @"
 function f() { }
@@ -2574,7 +2574,7 @@ var x = new f().abc;
         /// https://nodejstools.codeplex.com/workitem/974
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestInvalidGrouping() {
+        public void InvalidGrouping() {
             // shouldn't crash
             var code = @"var x = ();
 ";
@@ -2601,7 +2601,7 @@ Class.prototype.foo = function(fn) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestEventEmitter() {
+        public void EventEmitter() {
             var code = @"
 var events = require('events')
 ee = new events.EventEmitter();
@@ -2619,7 +2619,7 @@ ee.emit('myevent', 42)
         }
 
         [TestMethod, Priority(0)]
-        public void TestAnalysisWrapperLifetime() {
+        public void AnalysisWrapperLifetime() {
                 var server1 = @"var mymod = require('./mymod.js');
 mymod.value = {abc:42}";
                 var server2 = @"var mymod = require('./mymod.js');
@@ -2645,7 +2645,7 @@ exports.f = f;
         }
 
         [TestMethod, Priority(0)]
-        public void TestExportsLocation() {
+        public void ExportsLocation() {
             var server = @"var mymod = require('./mymod.js');";
             var entries = Analysis.Analyze(
                 new AnalysisFile("server.js", server),
@@ -2663,7 +2663,7 @@ exports.f = f;
         }
 
         [TestMethod, Priority(0)]
-        public void TestBadString() {
+        public void BadString() {
             var code = "var x = '\uD83D';";
             var analysis = ProcessText(code);
             AssertUtil.ContainsExactly(

--- a/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
@@ -64,7 +64,7 @@ var x = new f().abc;
         /// https://nodejstools.codeplex.com/workitem/945
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestToString() {
+        public void ToStringTest() {
             string code = @"
 var x = new Object();
 var y = x.toString();

--- a/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
+++ b/Nodejs/Tests/AnalysisTests/AnalysisTests.cs
@@ -64,7 +64,7 @@ var x = new f().abc;
         /// https://nodejstools.codeplex.com/workitem/945
         /// </summary>
         [TestMethod, Priority(0)]
-        public void ToString() {
+        public void TestToString() {
             string code = @"
 var x = new Object();
 var y = x.toString();

--- a/Nodejs/Tests/AnalysisTests/FormatterTests.cs
+++ b/Nodejs/Tests/AnalysisTests/FormatterTests.cs
@@ -49,7 +49,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestAnonymousFunction() {
+        public void AnonymousFunction() {
             TestCode(
 @"a('hello', 15, function(err, res) {
 console.log(err);
@@ -70,7 +70,7 @@ console.log(err);
         /// https://nodejstools.codeplex.com/workitem/1351
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestNestedFunctionAndArrayLiteral() {
+        public void NestedFunctionAndArrayLiteral() {
             TestCode(
 @"var a = require('a');
 a.mount('/', [
@@ -103,7 +103,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestJsonArray() {
+        public void JsonArray() {
             TestCode(
 @"(function (seedData) {
     seedData.initialNotes = [{
@@ -140,7 +140,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatAfterInvalidKey() {
+        public void FormatAfterInvalidKey() {
             Assert.AreEqual(0, Formatter.GetEditsAfterKeystroke("function f  () { }", 0, ':').Length);
         }
 
@@ -148,7 +148,7 @@ a.mount('/', [
         /// 
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestSemicolonEndOfDocument() {
+        public void SemicolonEndOfDocument() {
             var testCode = new[] { 
                 // https://nodejstools.codeplex.com/workitem/1102
                 new { Before = "x=1\r\nconsole.log( 'hi');", After = "x=1\r\nconsole.log('hi');" },
@@ -165,7 +165,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatAfterEnter() {
+        public void FormatAfterEnter() {
             var testCode = new[] { 
                 // https://nodejstools.codeplex.com/workitem/1078
                 new { Before = "function f() {\r\n    if(true)!\r\n}", After = "function f() {\r\n    if (true)\r\n\r\n}" },
@@ -199,7 +199,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatAfterSemiColon() {
+        public void FormatAfterSemiColon() {
             string surroundingCode = "x=1";
             var testCode = new[] { 
                 new { Before = "function f() {    \r\n    return   42;\r\n}", After = "function f() {    \r\n    return 42;\r\n}" },
@@ -231,7 +231,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestSemicolonOnOwnLine() {
+        public void SemicolonOnOwnLine() {
             // https://nodejstools.codeplex.com/workitem/1473
             TestCode(
     @"function f() {
@@ -255,7 +255,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormattingFunctionAsArgumentToFunction() {
+        public void FormattingFunctionAsArgumentToFunction() {
             // Format dedenting first argument too much
             // https://nodejstools.codeplex.com/workitem/1463
             TestCode(
@@ -303,7 +303,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayLiteral() {
+        public void ArrayLiteral() {
             var testCode = new[] { 
                 // https://nodejstools.codeplex.com/workitem/1474
                 new { Before = "function f() {\r\n    console.log('hi')\r\n    x = [1,2,3]\r\n}",
@@ -328,7 +328,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatAfterBadFor() {
+        public void FormatAfterBadFor() {
             TestCode(@"function g() { 
  for(int i = 0; i<1000000; i++) { 
  }",
@@ -344,7 +344,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestIndexingOnFollowingLine() {
+        public void IndexingOnFollowingLine() {
             // https://nodejstools.codeplex.com/workitem/1465
             TestCode(
     @"g()
@@ -357,12 +357,12 @@ a.mount('/', [
         /// https://nodejstools.codeplex.com/workitem/1204
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestShebang() {
+        public void Shebang() {
             TestCode("#!/usr/env/node\r\n function f() {\r\n}", "#!/usr/env/node\r\nfunction f() {\r\n}");
         }
 
         [TestMethod, Priority(0)]
-        public void TestInvalidTrailingQuote() {
+        public void InvalidTrailingQuote() {
             TestCode("var x = foo()'", "var x = foo() '");
             TestCode("return 42'", "return 42 '");
             TestCode("continue'", "continue '");
@@ -372,7 +372,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestMember() {
+        public void Member() {
             TestCode(" a.b", "a.b");
             TestCode("a .b", "a.b");
             TestCode("a. b", "a.b");
@@ -380,7 +380,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestInvalidMember() {
+        public void InvalidMember() {
             TestCode("x.42", "x.42");
             TestCode("x3.42", "x3.42");
             TestCode("x_.23", "x_.23");
@@ -390,7 +390,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestCall() {
+        public void Call() {
             TestCode("a()", "a()");
             TestCode("a ()", "a()");
             TestCode("a( b)", "a(b)");
@@ -414,7 +414,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnaryOperator() {
+        public void UnaryOperator() {
             TestCode("typeof  x", "typeof x");
             TestCode("delete  x", "delete x");
             TestCode("void  x", "void x");
@@ -422,7 +422,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestEmpty() {
+        public void Empty() {
             TestCode("if (true);", "if (true);");
             TestCode("if (true) ;", "if (true);");
 
@@ -450,13 +450,13 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestNew() {
+        public void New() {
             TestCode("var x = new  Blah();", "var x = new Blah();");
 
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatRange() {
+        public void FormatRange() {
             string surroundingCode = "x=1";
             var testCode = new[] { 
                 new { Before = "function f() {    \r\n    return   42;\r\n}", After = "function f() {\r\n    return 42;\r\n}" },
@@ -487,7 +487,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatAfterCloseBrace() {
+        public void FormatAfterCloseBrace() {
             string surroundingCode = "x=1";
             var testCode = new[] { 
                 new { Before = "while(true) {\r\nblah\r\n!", After = "while (true) {\r\n    blah\r\n}" },
@@ -520,7 +520,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestLabeledStatement() {
+        public void LabeledStatement() {
             TestCode(@"foo: {
     42;
 }",
@@ -531,7 +531,7 @@ a.mount('/', [
         }
 
         [TestMethod, Priority(0)]
-        public void TestContinue() {
+        public void Continue() {
             TestCode(
 @"while (true) {
     continue
@@ -566,7 +566,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestBlock() {
+        public void Block() {
             TestCode(
                 "{\nvar b;\n}",
                 "{\n    var b;\n}",
@@ -589,7 +589,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestBreak() {
+        public void Break() {
             TestCode(
 @"while (true) {
     break
@@ -632,7 +632,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunction() {
+        public void Function() {
             TestCode(
 @"function f () {
 }",
@@ -648,7 +648,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestReturn() {
+        public void Return() {
             TestCode(
 @"function f() {
     return
@@ -686,7 +686,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestYield() {
+        public void Yield() {
             TestCode(
 @"function *f() {
     yield
@@ -742,7 +742,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestThrow() {
+        public void Throw() {
             TestCode(
 @"function f() {
     throw
@@ -780,7 +780,7 @@ label:
         }
 
         [TestMethod, Priority(0)]
-        public void TestObjectLiteral() {
+        public void ObjectLiteral() {
             TestCode(
 @"x = { get   foo() { }, set   foo(value) { } }",
 @"x = { get foo() { }, set foo(value) { } }"
@@ -851,7 +851,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestIndentObjectLiteralWithoutComma() {
+        public void IndentObjectLiteralWithoutComma() {
             // https://nodejstools.codeplex.com/workitem/1782
             TestCode(@"Main.Test.prototype = {
     testFunc: function () {
@@ -895,7 +895,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestDoWhile() {
+        public void DoWhile() {
             TestCode(@"do
     { var a
 }   while (1)",
@@ -907,7 +907,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestControlFlowBraceCombo() {
+        public void ControlFlowBraceCombo() {
             var options = new FormattingOptions() { OpenBracesOnNewLineForControl = false, SpaceAfterKeywordsInControlFlowStatements = false };
 
             TestCode(
@@ -930,7 +930,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis() {
+        public void SpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis() {
             var options = new FormattingOptions() { SpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis = true };
 
             TestCode(
@@ -1076,7 +1076,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis2() {
+        public void SpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis2() {
             var options = new FormattingOptions() { SpaceAfterOpeningAndBeforeClosingNonEmptyParenthesis = false };
 
             TestCode(
@@ -1215,12 +1215,12 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestArithmetic() {
+        public void Arithmetic() {
             TestCode("a+.0", "a + .0");
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDecl() {
+        public void VariableDecl() {
             TestCode(@"var i = 0, j = 1;", @"var i = 0, j = 1;");
             TestCode(@"var i=0, j=1;", @"var i = 0, j = 1;");
             TestCode(@"var    i   =   0    ,   j  =  1;", @"var i = 0, j = 1;");
@@ -1229,12 +1229,12 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestLexcialDecl() {
+        public void LexcialDecl() {
             TestCode(@"i=1", @"i = 1");
         }
 
         [TestMethod, Priority(0)]
-        public void TestForIn() {
+        public void ForIn() {
             TestCode(
 @"for(    var    x     in    abc) {
 }",
@@ -1243,7 +1243,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestFor() {
+        public void For() {
             var options = new FormattingOptions() { SpaceAfterSemiColonInFor = true };
             TestCode(
 @"for (var i = 0;i < 10;i++) {
@@ -1262,7 +1262,7 @@ c: 42, d: 100}",
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpaceAfterComma() {
+        public void SpaceAfterComma() {
             var options = new FormattingOptions() { SpaceAfterComma = true };
             TestCode(
 @"
@@ -1293,7 +1293,7 @@ function x(a,b,c) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpaceAfterFunctionInAnonymousFunctions() {
+        public void SpaceAfterFunctionInAnonymousFunctions() {
             var options = new FormattingOptions() { SpaceAfterFunctionInAnonymousFunctions = true };
             TestCode(
 @"
@@ -1317,7 +1317,7 @@ x = function() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestNestedSwitch() {
+        public void NestedSwitch() {
             TestCode("switch (a){\r\n    case 1: x += 2;\r\n case   2  : \r\n     for (var i=0;i<10;i++)\r\ni  --;\r\n}\r\n",
             @"switch (a) {
     case 1: x += 2;
@@ -1329,7 +1329,7 @@ x = function() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestNestedIfs() {
+        public void NestedIfs() {
             TestCode(@"if(1)if(1)if(1)if(1) {
     x += 2
 }",
@@ -1345,7 +1345,7 @@ x = function() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestSwitch() {
+        public void Switch() {
             TestCode("switch (a){\r\ncase   1   :   x+=2 ;    break;\r\n    case 2:{\r\n    }\r\n}\r\n",
                      "switch (a) {\r\n    case 1: x += 2; break;\r\n    case 2: {\r\n    }\r\n}\r\n");
 
@@ -1416,7 +1416,7 @@ break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestNewLineBracesForFunctions() {
+        public void NewLineBracesForFunctions() {
             var options = new FormattingOptions() { OpenBracesOnNewLineForFunctions = true };
 
             TestCode(
@@ -1438,7 +1438,7 @@ break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestInsertTabs() {
+        public void InsertTabs() {
             var options = new FormattingOptions() { SpacesPerIndent = null };
             TestCode(
 @"switch (abc) {
@@ -1464,7 +1464,7 @@ break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestComments() {
+        public void Comments() {
             // comments in weird spots can result in some slightly odd 
             // insertions or missing insertions.  These aren't set in stone
             // necessarily but these test cases make sure we're not doing
@@ -1529,7 +1529,7 @@ break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSingleLineComments() {
+        public void SingleLineComments() {
             TestCode(
 @"var x = {'abc':42,
          'bar':100 // foo
@@ -1729,7 +1729,7 @@ writeToEngine(ep);
         }
 
         [TestMethod, Priority(0)]
-        public void TestInsertSpaces() {
+        public void InsertSpaces() {
             var options = new FormattingOptions() { SpacesPerIndent = 2 };
             TestCode(
 "switch (abc) {\r\n\tcase 42: break;\r\n}",
@@ -1758,7 +1758,7 @@ writeToEngine(ep);
         }
 
         [TestMethod, Priority(0)]
-        public void TestNewLineBracesForFlowControl() {
+        public void NewLineBracesForFlowControl() {
             var options = new FormattingOptions() { OpenBracesOnNewLineForControl = true };
             TestCode(
 @"switch (abc) {
@@ -1853,7 +1853,7 @@ writeToEngine(ep);
         }
 
         [TestMethod, Priority(0)]
-        public void TestNewLineBracesForFlowControl2() {
+        public void NewLineBracesForFlowControl2() {
             var options = new FormattingOptions() { OpenBracesOnNewLineForControl = false };
             TestCode(
             @"switch (abc)
@@ -1948,7 +1948,7 @@ writeToEngine(ep);
         }
 
         [TestMethod, Priority(0)]
-        public void TestIf() {
+        public void If() {
             // https://nodejstools.codeplex.com/workitem/1175
             TestCode(
 @"if (true){
@@ -1999,7 +1999,7 @@ else{
         }
 
         [TestMethod, Priority(0)]
-        public void TestNestedBlock() {
+        public void NestedBlock() {
             TestCode(
 @"do {
 if (true) {
@@ -2114,7 +2114,7 @@ case 42: break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpacesAroundBinaryOperator() {
+        public void SpacesAroundBinaryOperator() {
             TestCode("x+y", "x + y", new FormattingOptions() { SpaceBeforeAndAfterBinaryOperator = true });
             TestCode("x+y", "x+y", new FormattingOptions() { SpaceBeforeAndAfterBinaryOperator = false });
             TestCode("x + y", "x + y", new FormattingOptions() { SpaceBeforeAndAfterBinaryOperator = true });
@@ -2126,7 +2126,7 @@ case 42: break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSpaceAfterKeywordsInControlFlowStatements() {
+        public void SpaceAfterKeywordsInControlFlowStatements() {
             TestCode(
 @"if(true) {
 }",
@@ -2183,7 +2183,7 @@ case 42: break;
         }
 
         [TestMethod, Priority(0)]
-        public void TestSimple() {
+        public void Simple() {
             TestCode(
 @"do {
 x
@@ -2250,7 +2250,7 @@ throw null;
         }
 
         [TestMethod, Priority(0)]
-        public void TestFormatterNotReplacingAggressively() {
+        public void FormatterNotReplacingAggressively() {
             var code =
 @"function f() {
     function g() {

--- a/Nodejs/Tests/AnalysisTests/ParserOffsetTests.cs
+++ b/Nodejs/Tests/AnalysisTests/ParserOffsetTests.cs
@@ -27,7 +27,7 @@ namespace AnalysisTests {
     public class ParserOffsetTests {
 
         [TestMethod, Priority(0)]
-        public void TestArrayLiteral() {
+        public void ArrayLiteral() {
             TestOneSnippet(
                 "[1,2,3]",
                 new NodeInfo(typeof(Block), 0, 7),
@@ -40,7 +40,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestBinaryOperator() {
+        public void BinaryOperator() {
             TestOneSnippet(
                 "1 + 2",
                 new NodeInfo(typeof(Block), 0, 5),
@@ -60,7 +60,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestLoopBreakContinue() {
+        public void LoopBreakContinue() {
             TestOneSnippet(
                 @"for(var i = 0; i<10; i++) {
     break;
@@ -83,7 +83,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommaOperator() {
+        public void CommaOperator() {
             TestOneSnippet("1,2,3",
                 new NodeInfo(typeof(Block), 0, 5),
                 new NodeInfo(typeof(ExpressionStatement), 0, 5),
@@ -96,7 +96,7 @@ namespace AnalysisTests {
 
         
         [TestMethod, Priority(0)]
-        public void TestCallNode() {
+        public void CallNode() {
             TestOneSnippet("f(1,2,3)",
                 new NodeInfo(typeof(Block), 0, 8),
                 new NodeInfo(typeof(ExpressionStatement), 0, 8),
@@ -127,7 +127,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestConditional() {
+        public void Conditional() {
             TestOneSnippet("true ? 1 : 0",
                 new NodeInfo(typeof(Block), 0, 12),
                 new NodeInfo(typeof(ExpressionStatement), 0, 12),
@@ -140,7 +140,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestConstant() {
+        public void Constant() {
             TestOneSnippet("'abc'",
                 new NodeInfo(typeof(Block), 0, 5),
                 new NodeInfo(typeof(ExpressionStatement), 0, 5),
@@ -154,7 +154,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestConstStatement() {
+        public void ConstStatement() {
             TestOneSnippet("const x = 42;",
                 new NodeInfo(typeof(Block), 0, 13),
                 new NodeInfo(typeof(LexicalDeclaration), 0, 13),
@@ -164,7 +164,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestDebuggerStatement() {
+        public void DebuggerStatement() {
             TestOneSnippet("debugger;",
                 new NodeInfo(typeof(Block), 0, 9),
                 new NodeInfo(typeof(DebuggerNode), 0, 9)
@@ -172,7 +172,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestDoWhile() {
+        public void DoWhile() {
             TestOneSnippet(@"do {
 }while(true);",
                 new NodeInfo(typeof(Block), 0, 19),
@@ -183,7 +183,7 @@ namespace AnalysisTests {
         }
         
         [TestMethod, Priority(0)]
-        public void TestEmptyStatement() {
+        public void EmptyStatement() {
             TestOneSnippet(";",
                 new NodeInfo(typeof(Block), 0, 1),
                 new NodeInfo(typeof(EmptyStatement), 0, 1)
@@ -191,7 +191,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestForIn() {
+        public void ForIn() {
             TestOneSnippet(@"for(var x in abc) {
 }",
                 new NodeInfo(typeof(Block), 0, 22),
@@ -205,7 +205,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFor() {
+        public void For() {
             TestOneSnippet(@"for(var x = 0; x<100; x++) {
 }",
                 new NodeInfo(typeof(Block), 0, 31),
@@ -238,7 +238,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunction() {
+        public void Function() {
             TestOneSnippet(@"function f(a, b, c) {
 }",
                 new NodeInfo(typeof(Block), 0, 24),
@@ -251,7 +251,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestGetSet() {
+        public void GetSet() {
             TestOneSnippet(@"x = {get abc () { 42 }}",
                 new NodeInfo(typeof(Block), 0, 23),
                 new NodeInfo(typeof(ExpressionStatement), 0, 23),
@@ -282,7 +282,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestGrouping() {
+        public void Grouping() {
             TestOneSnippet(@"(x)",
                 new NodeInfo(typeof(Block), 0, 3),
                 new NodeInfo(typeof(ExpressionStatement), 0, 3),
@@ -292,7 +292,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestIf() {
+        public void If() {
             TestOneSnippet(@"if(true) {
 } else {
 }",
@@ -305,7 +305,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestLabeledStatement() {
+        public void LabeledStatement() {
             TestOneSnippet(@"myLabel:
 console.log('hi');",
                 new NodeInfo(typeof(Block), 0, 28),
@@ -319,7 +319,7 @@ console.log('hi');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestLexicalDeclaration() {
+        public void LexicalDeclaration() {
             TestOneSnippet(@"'use strict';
 let x = 42;",
                 new NodeInfo(typeof(Block), 0, 26),
@@ -332,7 +332,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestBogusLexicalDeclaration() {
+        public void BogusLexicalDeclaration() {
             TestOneSnippet(@"let x = 42;",
                 new NodeInfo(typeof(Block), 0, 11),
                 new NodeInfo(typeof(ExpressionStatement), 0, 3),
@@ -345,7 +345,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestLookup() {
+        public void Lookup() {
             TestOneSnippet(@"x",
                 new NodeInfo(typeof(Block), 0, 1),
                 new NodeInfo(typeof(ExpressionStatement), 0, 1),
@@ -359,7 +359,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestMember() {
+        public void Member() {
             TestOneSnippet(@"x.abc",
                 new NodeInfo(typeof(Block), 0, 5),
                 new NodeInfo(typeof(ExpressionStatement), 0, 5),
@@ -369,7 +369,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestObjectLiteral() {
+        public void ObjectLiteral() {
             TestOneSnippet(@"{abc:42, aaa:100}",
                 new NodeInfo(typeof(Block), 0, 17),
                 new NodeInfo(typeof(Block), 0, 17),
@@ -382,7 +382,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestRegexpLiteral() {
+        public void RegexpLiteral() {
             TestOneSnippet(@"/foo/",
                 new NodeInfo(typeof(Block), 0, 5),
                 new NodeInfo(typeof(ExpressionStatement), 0, 5),
@@ -391,7 +391,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestReturn() {
+        public void Return() {
             TestOneSnippet(@"function f() {
     return 42;
 }",
@@ -412,7 +412,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestSwitch() {
+        public void Switch() {
             TestOneSnippet(@"switch(abc) {
     case 42:
         break;
@@ -439,7 +439,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestThis() {
+        public void This() {
             TestOneSnippet(@"var x = this.foo;",
                 new NodeInfo(typeof(Block), 0, 17),
                 new NodeInfo(typeof(Var), 0, 17),
@@ -450,7 +450,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestThrow() {
+        public void Throw() {
             TestOneSnippet(@"throw 'error';",
                 new NodeInfo(typeof(Block), 0, 14),
                 new NodeInfo(typeof(ThrowNode), 0, 14),
@@ -459,7 +459,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestTryCatch() {
+        public void TryCatch() {
             TestOneSnippet(@"try {
     x
 } catch(arg) {
@@ -475,7 +475,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestTryFinally() {
+        public void TryFinally() {
             TestOneSnippet(@"try {
     x
 } finally {
@@ -490,7 +490,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestTryCatchFinally() {
+        public void TryCatchFinally() {
             TestOneSnippet(@"try {
     x
 }catch(arg) {
@@ -508,7 +508,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclaration() {
+        public void VariableDeclaration() {
             TestOneSnippet(@"var abc = 42, foo = 100;",
                 new NodeInfo(typeof(Block), 0, 24),
                 new NodeInfo(typeof(Var), 0, 24),
@@ -520,7 +520,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnaryOperator() {
+        public void UnaryOperator() {
             TestOneSnippet(@"+42",
                 new NodeInfo(typeof(Block), 0, 3),
                 new NodeInfo(typeof(ExpressionStatement), 0, 3),
@@ -530,7 +530,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestWhileNode() {
+        public void WhileNode() {
             TestOneSnippet(@"while(foo) { hi; }",
                 new NodeInfo(typeof(Block), 0, 18),
                 new NodeInfo(typeof(WhileNode), 0, 18),
@@ -542,7 +542,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestWithNode() {
+        public void WithNode() {
             TestOneSnippet(@"with(foo) { hi; }",
                 new NodeInfo(typeof(Block), 0, 17),
                 new NodeInfo(typeof(WithNode), 0, 17),
@@ -554,7 +554,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionExpression() {
+        public void FunctionExpression() {
             TestOneSnippet(@"x = function() { }",
                 new NodeInfo(typeof(Block), 0, 18),
                 new NodeInfo(typeof(ExpressionStatement), 0, 18),
@@ -567,7 +567,7 @@ let x = 42;",
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionExpressionWithName() {
+        public void FunctionExpressionWithName() {
             TestOneSnippet(@"x = function name() { }",
                 new NodeInfo(typeof(Block), 0, 23),
                 new NodeInfo(typeof(ExpressionStatement), 0, 23),

--- a/Nodejs/Tests/AnalysisTests/ParserTests.cs
+++ b/Nodejs/Tests/AnalysisTests/ParserTests.cs
@@ -26,7 +26,7 @@ namespace AnalysisTests {
     [TestClass]
     public class ParserTests {
         [TestMethod, Priority(0)]
-        public void TestCodeSettings() {
+        public void CodeSettings() {
             var settings1 = new CodeSettings();
             var settings2 = new CodeSettings() { AllowShebangLine = true, SourceMode = JavaScriptSourceMode.Expression, StrictMode = true };
             var settings3 = new CodeSettings() { KnownGlobalNamesList = "foo;bar" };
@@ -42,7 +42,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestSourceSpan() {
+        public void SourceSpan() {
             var span = new SourceSpan(
                 new SourceLocation(1, 1, 1),
                 new SourceLocation(100, 2, 100)
@@ -61,7 +61,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestFunctionRecovery() {
+        public void FunctionRecovery() {
             const string code = @"
 [1,2,
 function Y() {
@@ -105,7 +105,7 @@ function Y() {
         /// https://nodejstools.codeplex.com/workitem/1200
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestParseUnterminatedFunctionInList() {
+        public void ParseUnterminatedFunctionInList() {
             const string code = @"console.log(function(error, response) {";
 
             CheckAst(
@@ -135,7 +135,7 @@ function Y() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestParseExpression() {
+        public void ParseExpression() {
             const string code = @"
 42
 ";
@@ -197,7 +197,7 @@ foo(abc.'foo' else function)
         }
 
         [TestMethod, Priority(0)]
-        public void TestMemberKeyword() {
+        public void MemberKeyword() {
             const string code = @"
 foo.get
 ";
@@ -727,7 +727,7 @@ function foo(abc {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionStrictMode() {
+        public void FunctionStrictMode() {
             const string code = @"
 function abc() {
     'use strict';
@@ -748,7 +748,7 @@ function abc() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFunctionKeywordIdentifier() {
+        public void FunctionKeywordIdentifier() {
             const string code = @"
 function get() {
 }";
@@ -764,7 +764,7 @@ function get() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestGenerators() {
+        public void Generators() {
             string code = @"
 function *x() {
     yield 1;
@@ -836,7 +836,7 @@ function *x() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestYieldMember() {
+        public void YieldMember() {
             string code = @"
 function *x() {
     abc.yield;
@@ -3625,7 +3625,7 @@ _f
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnicodeIdentifier() {
+        public void UnicodeIdentifier() {
             const string identifiers = @"
 \u1234abc
 \u1234\u1235abc
@@ -3642,7 +3642,7 @@ abc\u1234
         }
 
         [TestMethod, Priority(0)]
-        public void TestBlock() {
+        public void Block() {
             const string code = @"
 { 1; 2 }";
             CheckAst(
@@ -3657,7 +3657,7 @@ abc\u1234
         }
 
         [TestMethod, Priority(0)]
-        public void TestDebugger() {
+        public void Debugger() {
             const string code = @"
 debugger;";
             CheckAst(
@@ -3669,7 +3669,7 @@ debugger;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestSwitch() {
+        public void Switch() {
             const string code = @"
 switch(abc) {
     case 0:
@@ -3709,7 +3709,7 @@ switch(abc) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestThrow() {
+        public void Throw() {
             const string code = @"
 throw ""abc"";
 throw;
@@ -3724,7 +3724,7 @@ throw;
         }
 
         [TestMethod, Priority(0)]
-        public void TestWith() {
+        public void With() {
             const string code = @"
 with(abc) {
     1;
@@ -3744,7 +3744,7 @@ with(abc) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestConditional() {
+        public void Conditional() {
             const string identifiers = @"
 1 ? 2 : 3
 ";
@@ -3763,7 +3763,7 @@ with(abc) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestVoid() {
+        public void Void() {
             const string identifiers = @"
 void 1
 ";
@@ -3781,7 +3781,7 @@ void 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestTypeOf() {
+        public void TypeOf() {
             const string identifiers = @"
 typeof 1
 ";
@@ -3799,7 +3799,7 @@ typeof 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnary() {
+        public void Unary() {
             const string identifiers = @"
 +1;
 -1;
@@ -3824,7 +3824,7 @@ delete abc;
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnaryPostFix() {
+        public void UnaryPostFix() {
             const string identifiers = @"
 abc++;
 abc--;
@@ -3839,7 +3839,7 @@ abc--;
         }
 
         [TestMethod, Priority(0)]
-        public void TestGrouping() {
+        public void Grouping() {
             const string identifiers = @"
 (1)
 ";
@@ -3852,7 +3852,7 @@ abc--;
         }
 
         [TestMethod, Priority(0)]
-        public void TestArrayLiteral() {
+        public void ArrayLiteral() {
             const string identifiers = @"
 [1,2,3];
 [1,2,3,]
@@ -3867,7 +3867,7 @@ abc--;
         }
 
         [TestMethod, Priority(0)]
-        public void TestObjectLiteral() {
+        public void ObjectLiteral() {
             // Expression statements can't start with { as it's ambiguous with block,
             // so we do an assignment here
             const string identifiers = @"
@@ -3939,7 +3939,7 @@ x = {set abc (value) { 42 }}
         }
 
         [TestMethod, Priority(0)]
-        public void TestPrecedence() {
+        public void Precedence() {
             const string code = @"
 1 + 2 * 3;
 1 + 2 / 3;
@@ -4081,7 +4081,7 @@ false
         ///     0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestNumericLiterals() {
+        public void NumericLiterals() {
             const string numbers = @"
 0
 1
@@ -4172,7 +4172,7 @@ false
         ///     u HexDigit HexDigit HexDigit HexDigit
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestStringLiterals() {
+        public void StringLiterals() {
             const string strings = @"
 ""hello""
 'hello'
@@ -4239,7 +4239,7 @@ lo""
         ///     RegularExpressionFlags IdentifierPart
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestRegexLiterals() {
+        public void RegexLiterals() {
             // TODO: More test cases
             const string regexs = @"
 /abc/;
@@ -4261,7 +4261,7 @@ lo""
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclaration() {
+        public void VariableDeclaration() {
             const string code = @"
 var i = 0, j = 1;
 ";
@@ -4277,7 +4277,7 @@ var i = 0, j = 1;
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclarationKeyword() {
+        public void VariableDeclarationKeyword() {
             const string code = @"
 var get = 0;";
             CheckAst(
@@ -4291,7 +4291,7 @@ var get = 0;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclarationError() {
+        public void VariableDeclarationError() {
             const string code = @"
 var function = 0;";
             CheckAst(
@@ -4308,7 +4308,7 @@ var function = 0;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestVariableDeclarationError2() {
+        public void VariableDeclarationError2() {
             const string code = @"
 var 42 = 0;";
             CheckAst(
@@ -4325,7 +4325,7 @@ var 42 = 0;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestEmptyStatement() {
+        public void EmptyStatement() {
             const string code = @"
 ;
 ";
@@ -4338,7 +4338,7 @@ var 42 = 0;";
         }
 
         [TestMethod, Priority(0)]
-        public void TestIfStatement() {
+        public void IfStatement() {
             const string code = @"
 if(true) {
     1
@@ -4369,7 +4369,7 @@ if(true) {
 
 
         [TestMethod, Priority(0)]
-        public void TestForStatement() {
+        public void ForStatement() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { }
 ";
@@ -4387,7 +4387,7 @@ for(var i = 0; i<4; i++) { }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForStatementLexical() {
+        public void ForStatementLexical() {
             const string ForCode = @"
 for(const i = 0; false; ) { }
 ";
@@ -4405,7 +4405,7 @@ for(const i = 0; false; ) { }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForNoVarStatement() {
+        public void ForNoVarStatement() {
             const string ForCode = @"
 for(i = 0; i<4; i++) { }
 ";
@@ -4429,7 +4429,7 @@ for(i = 0; i<4; i++) { }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForInStatement() {
+        public void ForInStatement() {
             const string ForCode = @"
 for(var i in []) { }
 for(i in []) { }
@@ -4452,7 +4452,7 @@ for(i in []) { }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForContinueStatement() {
+        public void ForContinueStatement() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { continue; }
 ";
@@ -4472,7 +4472,7 @@ for(var i = 0; i<4; i++) { continue; }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForBreakStatement() {
+        public void ForBreakStatement() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { break; }
 ";
@@ -4492,7 +4492,7 @@ for(var i = 0; i<4; i++) { break; }
         }
 
         [TestMethod, Priority(0)]
-        public void TestForContinueLabelStatement() {
+        public void ForContinueLabelStatement() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { continue myLabel; }
 myLabel:
@@ -4517,7 +4517,7 @@ myLabel:
         }
 
         [TestMethod, Priority(0)]
-        public void TestForContinueLabelStatement2() {
+        public void ForContinueLabelStatement2() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { 
 myLabel:
@@ -4543,7 +4543,7 @@ continue myLabel;
         }
 
         [TestMethod, Priority(0)]
-        public void TestForContinueLabelStatement3() {
+        public void ForContinueLabelStatement3() {
             const string ForCode = @"
 for(var j = 0; j<4; j++) {
     myLabel:
@@ -4580,7 +4580,7 @@ for(var j = 0; j<4; j++) {
         }
 
         [TestMethod, Priority(0)]
-        public void TestForBreakLabelStatement() {
+        public void ForBreakLabelStatement() {
             const string ForCode = @"
 for(var i = 0; i<4; i++) { break myLabel; }
 myLabel:
@@ -4640,7 +4640,7 @@ while(i<0) { 2; }
         }
 
         [TestMethod, Priority(0)]
-        public void TestUseStrictDirective() {
+        public void UseStrictDirective() {
             const string code = @"'use strict';
 42";
 

--- a/Nodejs/Tests/AnalysisTests/RequireTests.cs
+++ b/Nodejs/Tests/AnalysisTests/RequireTests.cs
@@ -38,7 +38,7 @@ namespace AnalysisTests {
         /// https://nodejstools.codeplex.com/workitem/1234
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestRequireTrailingSlash() {
+        public void RequireTrailingSlash() {
             var entries = Analysis.Analyze(
                 new AnalysisFile("mod.js", @"var x = require('mymod').value;"),
                 new AnalysisFile("node_modules\\mymod\\mymod.js", @"module.exports = require('./mymod/')"),
@@ -53,7 +53,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireAssignedExports() {
+        public void RequireAssignedExports() {
             var entries = Analysis.Analyze(
                 new AnalysisFile("mod.js", @"var x = require('mymod').value;"),
                 AnalysisFile.PackageJson("node_modules\\mymod\\package.json", "./lib/mymod"),
@@ -68,7 +68,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireDirectoryFileOverload() {
+        public void RequireDirectoryFileOverload() {
             var entries = Analysis.Analyze(
                 new AnalysisFile("mod.js", @"var x = require('mymod').value;"),
                 new AnalysisFile("node_modules\\mymod\\index.js", @"module.exports = require('./realindex.js');"),
@@ -82,7 +82,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireMultiAssign() {
+        public void RequireMultiAssign() {
             var entries = Analysis.Analyze(
                 new AnalysisFile("server.js", @"var mymod = require('mymod')"),
                 new AnalysisFile("node_modules\\mymod\\index.js", @"module.exports = require('./lib/');"),
@@ -110,7 +110,7 @@ var mymod = module.exports = exports = new MyMod")
         // assigned exports.
 
         [TestMethod, Priority(0)]
-        public void TestRequireSimple() {
+        public void RequireSimple() {
             var mod1 = @"exports.foo = 42;";
             var mod2 = @"x = require('./one.js').foo";
 
@@ -132,7 +132,7 @@ var mymod = module.exports = exports = new MyMod")
         }
 
         [TestMethod, Priority(0)]
-        public void TestBadRequire() {
+        public void BadRequire() {
             // foo.js
             //      require('./rec1')
             // rec1\
@@ -164,7 +164,7 @@ var mymod = module.exports = exports = new MyMod")
         /// without the leading .
         /// </summary>
         [TestMethod, Priority(0)]
-        public void TestRequireNonRelativePackageJson() {
+        public void RequireNonRelativePackageJson() {
             var analyzer = new JsAnalyzer();
             var mod = @"var x = require('./rec1')";
             var myindex = @"exports.abc = 100;";
@@ -187,7 +187,7 @@ var mymod = module.exports = exports = new MyMod")
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireNodeModules() {
+        public void RequireNodeModules() {
             var mod1 = @"exports.foo = 42;";
             var mod2 = @"x = require('one.js').foo";
 
@@ -209,7 +209,7 @@ var mymod = module.exports = exports = new MyMod")
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireBuiltin() {
+        public void RequireBuiltin() {
             string code = @"
 var http = require('http');
 ";
@@ -222,7 +222,7 @@ var http = require('http');
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequireBinaryOp() {
+        public void RequireBinaryOp() {
             string code = @"
 var http = require('ht' + 'tp');
 ";
@@ -235,7 +235,7 @@ var http = require('ht' + 'tp');
         }
 
         [TestMethod, Priority(0)]
-        public void TestRequire() {
+        public void Require() {
             var testCases = new[] {
                 new { File="server.js", Line = 4, Type = "mymod.", Expected = "mymod_export" },
                 new { File="server.js", Line = 8, Type = "mymod2.", Expected = "mymod_export" },

--- a/Nodejs/Tests/AnalysisTests/ScannerTests.cs
+++ b/Nodejs/Tests/AnalysisTests/ScannerTests.cs
@@ -26,7 +26,7 @@ namespace AnalysisTests {
     [TestClass]
     public class ScannerTests {
         [TestMethod, Priority(0)]
-        public void TestPartialScanning() {
+        public void PartialScanning() {
             var code1 = "/* hello world ";
             var code2 = "   goodbye */";
             CollectingErrorSink errorSink = new CollectingErrorSink(true);
@@ -51,7 +51,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestOperators() {
+        public void Operators() {
             var code = @"x %= 1
 x &= 1
 x *= 1
@@ -130,7 +130,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestNumericLiteral() {
+        public void NumericLiteral() {
             var code = @".123";
 
             VerifyTokens(
@@ -143,7 +143,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestIllegalEscape() {
+        public void IllegalEscape() {
             var code = "\\while";
 
             VerifyTokens(
@@ -158,7 +158,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestIllegalEscapeRead() {
+        public void IllegalEscapeRead() {
             var code = "\\while";
 
             VerifyTokens(
@@ -173,7 +173,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestLineTerminators() {
+        public void LineTerminators() {
             var code = "\u2028 \u2029";
 
             VerifyTokens(
@@ -186,7 +186,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnicodeIdentifiers() {
+        public void UnicodeIdentifiers() {
             var code = "\u0257abc";
 
             VerifyTokens(
@@ -197,7 +197,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnicodeWhiteSpace() {
+        public void UnicodeWhiteSpace() {
             var code = "\u00a0\u00a0";
 
             VerifyTokens(
@@ -208,7 +208,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnicodeIllegalCharacter() {
+        public void UnicodeIllegalCharacter() {
             var code = "`";
 
             VerifyTokens(
@@ -222,7 +222,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestRegularExpressionLiteral() {
+        public void RegularExpressionLiteral() {
             var code = @"x = /foo/";
 
             VerifyTokens(
@@ -236,7 +236,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestBadNumericLiteral() {
+        public void BadNumericLiteral() {
             var code = @"1Z";
 
             VerifyTokens(
@@ -261,7 +261,7 @@ x /= 1
         }
         
         [TestMethod, Priority(0)]
-        public void TestOctalStringLiterals() {
+        public void OctalStringLiterals() {
             var code = @"'\10'";
 
             VerifyTokens(
@@ -319,7 +319,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestUnterminatedString() {
+        public void UnterminatedString() {
             var code = @"'abc
 ";
 
@@ -344,7 +344,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestHexEscape() {
+        public void HexEscape() {
             var code = "'\\xAA'";
 
             VerifyTokens(
@@ -356,7 +356,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestHexEscape2() {
+        public void HexEscape2() {
             var code = "'\\xaa'";
 
             VerifyTokens(
@@ -368,7 +368,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestInvalidHexEscape() {
+        public void InvalidHexEscape() {
             var code = "'\\xZZ'";
 
             VerifyTokens(
@@ -401,7 +401,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestInvalidUnicodeEscape() {
+        public void InvalidUnicodeEscape() {
             var code = "'\\uZZZZ'";
 
             VerifyTokens(
@@ -454,7 +454,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0)]
-        public void TestIllegalCharacter() {
+        public void IllegalCharacter() {
             var code = "\0\0";
 
             VerifyTokens(
@@ -468,7 +468,7 @@ x /= 1
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestMultilineComment() {
+        public void MultilineComment() {
             var code = @"/*
 hello world
 */";
@@ -481,7 +481,7 @@ hello world
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestMultilineCommentUnterminated() {
+        public void MultilineCommentUnterminated() {
             var code = @"/*
 hello world
 ";
@@ -494,7 +494,7 @@ hello world
         }
 
         [TestMethod, Priority(0)]
-        public void TestPositions() {
+        public void Positions() {
             var code = "one\n\ntwo";
 
             VerifyTokens(

--- a/Nodejs/Tests/AnalysisTests/VisibilityTests.cs
+++ b/Nodejs/Tests/AnalysisTests/VisibilityTests.cs
@@ -72,7 +72,7 @@ namespace AnalysisTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestVisible() {
+        public void Visible() {
             // make sure the order of adding modules doesn't matter...
             var analysis = Analysis.Analyze(
                 new AnalysisFile("app.js", "Object.app = 100\r\nabc = Object.quox"),

--- a/Nodejs/Tests/Core.UI/BasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/BasicProjectTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestAddExistingFolder() {
+        public void AddExistingFolder() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\AddExistingFolder.sln");
                 
@@ -265,7 +265,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestAddExistingFolderProject() {
+        public void AddExistingFolderProject() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\AddExistingFolder.sln");
 
@@ -289,7 +289,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestAddExistingFolderDebugging() {
+        public void AddExistingFolderDebugging() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\AddExistingFolder.sln");
 
@@ -512,7 +512,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestAutomationProperties() {
+        public void AutomationProperties() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\HelloWorld.sln");
 
@@ -581,7 +581,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestAutomationProject() {
+        public void AutomationProject() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\HelloWorld.sln");
 
@@ -622,7 +622,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestProjectItemAutomation() {
+        public void ProjectItemAutomation() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\HelloWorld.sln");
 
@@ -644,7 +644,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestRelativePaths() {
+        public void RelativePaths() {
             // link to outside file should show up as top-level item
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodejsProjectData\RelativePaths.sln");

--- a/Nodejs/Tests/Core.UI/DebuggerUITests.cs
+++ b/Nodejs/Tests/Core.UI/DebuggerUITests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Nodejs.Tests.UI {
     public class DebuggerUITests : NodejsProjectTest {
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Debugging UI")]
         [HostType("VSTestHost")]
-        public void TestWaitOnExit() {
+        public void WaitOnExit() {
             foreach (var debug in new[] { false, true }) {
                 foreach (var exitCode in new[] { 0, 1 }) {
                     foreach (var waitOnAbnormal in new[] { true, false }) {
@@ -108,7 +108,7 @@ process.exit(" + exitCode + ");"),
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Debugging UI"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoDebugging() {
+        public void NoDebugging() {
             var project = Project("NoDebugging",
                 Compile("server"),
                 Property(CommonConstants.StartupFile, "server.js"),

--- a/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestExcludedErrors() {
+        public void ExcludedErrors() {
             var project = Project("TestExcludedErrors",
                 Compile("server", "function f(a, b, c) { }\r\n\r\n"),
                 Compile("excluded", "aa bb", isExcluded: true)
@@ -101,7 +101,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestDebuggerPort() {
+        public void DebuggerPort() {
             var filename = Path.Combine(TestData.GetTempPath(), Path.GetRandomFileName());
             Console.WriteLine("Temp file is: {0}", filename);
             var code = String.Format(@"
@@ -134,7 +134,7 @@ while(true) {{
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestEnvironmentVariables() {
+        public void EnvironmentVariables() {
             var filename = Path.Combine(TestData.GetTempPath(), Path.GetRandomFileName());
             Console.WriteLine("Temp file is: {0}", filename);
             var code = String.Format(@"
@@ -167,7 +167,7 @@ while(true) {{
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestEnvironmentVariablesNoDebugging() {
+        public void EnvironmentVariablesNoDebugging() {
             var filename = Path.Combine(TestData.GetTempPath(), Path.GetRandomFileName());
             Console.WriteLine("Temp file is: {0}", filename);
             var code = String.Format(@"
@@ -197,7 +197,7 @@ require('fs').writeFileSync('{0}', process.env.fob + process.env.bar + process.e
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestProjectProperties() {
+        public void ProjectProperties() {
             var filename = Path.Combine(TestData.GetTempPath(), Path.GetRandomFileName());
 
             var project = Project("ProjectProperties",
@@ -251,7 +251,7 @@ require('fs').writeFileSync('{0}', process.env.fob + process.env.bar + process.e
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestClientServerIntelliSenseModes() {
+        public void ClientServerIntelliSenseModes() {
             string
                 solutionLabel = "Solution 'ClientServerCode' (1 project)",
                 projectLabel = "ClientServerCode",

--- a/Nodejs/Tests/Core.UI/NpmUITests.cs
+++ b/Nodejs/Tests/Core.UI/NpmUITests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Nodejs.Tests.UI {
     public class NpmUITests : NodejsProjectTest {
         [TestMethod, Priority(0), TestCategory("Npm UI")]
         [HostType("VSTestHost")]
-        public void TestNpmUIInitialization() {
+        public void NpmUIInitialization() {
             using (var app = new VisualStudioApp()) {
                 // Initialize call is required because NTVS does not autoload its package
                 // We may not be on UI thread, but Dev11 and Dev12 know how to sort that out.
@@ -58,7 +58,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Npm UI")]
         [HostType("VSTestHost")]
-        public void TestNpmUIArrowKeyBehavior() {
+        public void NpmUIArrowKeyBehavior() {
             using (var app = new VisualStudioApp()) {
                 app.ServiceProvider.GetUIThread().Invoke(() => {
                     NpmPackageInstallWindow npmWindow = OpenNpmWindowAndWaitForReady();
@@ -109,7 +109,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Npm UI")]
         [HostType("VSTestHost")]
-        public void TestNpmUITabKeyBehavior() {
+        public void NpmUITabKeyBehavior() {
             using (var app = new VisualStudioApp()) {
                 app.ServiceProvider.GetUIThread().Invoke(() => {
                     NpmPackageInstallWindow npmWindow = OpenNpmWindowAndWaitForReady();

--- a/Nodejs/Tests/Core.UI/ProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/ProjectTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Nodejs.Tests.UI {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestSnippetsDisabled() {
+        public void SnippetsDisabled() {
             using (var app = new VisualStudioApp()) {
                 Window window;
                 var openFile = OpenProjectItem(app, "server.js", out window);
@@ -80,7 +80,7 @@ http.createServer(function (req, res) {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoAutoFormattingEnter() {
+        public void NoAutoFormattingEnter() {
             using (var app = new VisualStudioApp()) {
                 Window window;
                 var openFile = OpenProjectItem(app, "server.js", out window);
@@ -105,7 +105,7 @@ http.createServer(function (req, res) {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoAutoFormattingCloseFunction() {
+        public void NoAutoFormattingCloseFunction() {
             using (var app = new VisualStudioApp()) {
                 Window window;
                 var openFile = OpenProjectItem(app, "server.js", out window);
@@ -131,7 +131,7 @@ http.createServer(function (req, res) {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoAutoFormattingPaste() {
+        public void NoAutoFormattingPaste() {
             using (var app = new VisualStudioApp()) {
                 Window window;
                 var openFile = OpenProjectItem(app, "server.js", out window);
@@ -157,7 +157,7 @@ http.createServer(function (req, res) {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoReferences() {
+        public void NoReferences() {
             Window window;
             using (var app = new VisualStudioApp()) {
                 var openFile = OpenProjectItem(app, "server.js", out window);
@@ -424,7 +424,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNewProject() {
+        public void NewProject() {
             using (var app = new VisualStudioApp()) {
                 using (var newProjDialog = app.FileNewProject()) {
                     newProjDialog.FocusLanguageNode("JavaScript");
@@ -456,7 +456,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNewAzureProject() {
+        public void NewAzureProject() {
             using (var app = new VisualStudioApp()) {
                 using (var newProjDialog = app.FileNewProject()) {
                     newProjDialog.FocusLanguageNode("JavaScript");
@@ -487,7 +487,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestAutomationProject() {
+        public void AutomationProject() {
             using (var app = new VisualStudioApp()) {
                 var project = app.OpenProject(@"TestData\NodeAppWithModule\NodeAppWithModule.sln");
 
@@ -599,7 +599,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestProjectProperties() {
+        public void ProjectProperties() {
             for (int mode = 0; mode < 2; mode++) {
                 using (var app = new VisualStudioApp()) {
                     var testFile = Path.Combine(Path.GetTempPath(), "nodejstest.txt");
@@ -628,7 +628,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestBrowserLaunch() {
+        public void BrowserLaunch() {
             for (int mode = 0; mode < 2; mode++) {
                 var startingProcesses = System.Diagnostics.Process.GetProcessesByName("iexplore").Select(x => x.Id).ToSet();
 
@@ -778,7 +778,7 @@ sd.StringDecoder
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestLongPathCheck() {
+        public void LongPathCheck() {
             string[] expectedLongPaths = {
                 @"node_modules\azure\node_modules\azure-common\node_modules\xml2js\node_modules\sax\test\trailing-attribute-no-value.js",
                 @"node_modules\azure\node_modules\azure-common\node_modules\xml2js\node_modules\sax\test\xmlns-xml-default-prefix-attribute.js",

--- a/Nodejs/Tests/Core.UI/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core.UI/ReplWindowTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestErrorNewLine() {
+        public void ErrorNewLine() {
             Test((app, window) => {
                 Keyboard.Type("abc\r");
                 window.WaitForText("> abc", "ReferenceError: abc is not defined", "> ");
@@ -49,7 +49,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestColorOutput() {
+        public void ColorOutput() {
             Test((app, window) => {
                 Keyboard.Type("[1,2,3]\r");
                 window.WaitForText("> [1,2,3]", "[ 1, 2, 3 ]", "> ");
@@ -81,7 +81,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestStdErrIsRed() {
+        public void StdErrIsRed() {
             Test((app, window) => {
                 window.ReplWindow.Evaluator.ExecuteText("setTimeout(function () { not_a_fn(); }, 0);\r").Wait();
 
@@ -108,7 +108,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestCompletion() {
+        public void Completion() {
             Test((app, window) => {
                 Keyboard.Type("''.");
                 using (var session = window.WaitForSession<ICompletionSession>()) {
@@ -119,7 +119,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestNoSpecialCommandCompletion() {
+        public void NoSpecialCommandCompletion() {
             Test((app, window) => {
                 Keyboard.Type(".");
                 window.AssertNoIntellisenseSession();

--- a/Nodejs/Tests/Core.UI/SnippetsTests.cs
+++ b/Nodejs/Tests/Core.UI/SnippetsTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestInsertSnippet() {
+        public void InsertSnippet() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder()) {
                     foreach (var snippet in BasicSnippets) {
@@ -147,7 +147,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestSurroundWithSnippet() {
+        public void SurroundWithSnippet() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder()) {
                     foreach (var snippet in BasicSnippets) {
@@ -161,7 +161,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestSurroundWithMultiline() {
+        public void SurroundWithMultiline() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder()) {
                     foreach (var snippet in BasicSnippets) {
@@ -198,7 +198,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestSelected() {
+        public void Selected() {
             var snippet = new Snippet(
                 "if",
                 "if (true) {\r\n    $body$\r\n}",
@@ -218,7 +218,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestBasicSnippetsTab() {
+        public void BasicSnippetsTab() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder()) {
                     foreach (var snippet in BasicSnippets) {
@@ -263,7 +263,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestSelectedIndented() {
+        public void SelectedIndented() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder()) {
                     var server = solution.OpenItem("SnippetsTest", "indented.js");
@@ -288,7 +288,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestIndentSize() {
+        public void IndentSize() {
             var snippet = new Snippet(
                 "tryf",
                 "try {\r\n  $body$\r\n} catch (e) {\r\n  \r\n} finally {\r\n  \r\n};",
@@ -304,7 +304,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestTabIndentation() {
+        public void TabIndentation() {
             var snippet = new Snippet(
                 "forprops",
                 "for (var property in object) {\r\n\tif (object.hasOwnProperty(property)) {\r\n\t\t$body$\r\n\t}\r\n};",
@@ -320,7 +320,7 @@ namespace Microsoft.Nodejs.Tests.UI {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestBraceOnNewLine() {
+        public void BraceOnNewLine() {
             using (var solution = BasicProject.Generate().ToVs()) {
                 using (new SnippetTestOptionHolder(
                     insertTabs: false,

--- a/Nodejs/Tests/Core/CommentBlockTests.cs
+++ b/Nodejs/Tests/Core/CommentBlockTests.cs
@@ -24,7 +24,7 @@ namespace NodejsTests {
     [TestClass]
     public class CommentBlockTests {
         [TestMethod, Priority(0)]
-        public void TestCommentCurrentLine() {
+        public void CommentCurrentLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');
 console.log('Goodbye');"));
@@ -47,7 +47,7 @@ console.log('Goodbye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnCommentCurrentLine() {
+        public void UnCommentCurrentLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"//console.log('Hello');
 //console.log('Goodbye');"));
@@ -70,7 +70,7 @@ console.log('Goodbye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestComment() {
+        public void Comment() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');
 console.log('Goodbye');"));
@@ -88,7 +88,7 @@ console.log('Goodbye');"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentEmptyLine() {
+        public void CommentEmptyLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');
 
@@ -108,7 +108,7 @@ console.log('Goodbye');"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentWhiteSpaceLine() {
+        public void CommentWhiteSpaceLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');
    
@@ -128,7 +128,7 @@ console.log('Goodbye');"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentIndented() {
+        public void CommentIndented() {
             var view = new MockTextView(
                 new MockTextBuffer(@"function f(){
     console.log('Hello');
@@ -155,7 +155,7 @@ console.log('Goodbye');"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentIndentedBlankLine() {
+        public void CommentIndentedBlankLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"function f(){
     console.log('Hello');
@@ -184,7 +184,7 @@ console.log('Goodbye');"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentBlankLine() {
+        public void CommentBlankLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('hi');
 
@@ -201,7 +201,7 @@ console.log('bye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentIndentedWhiteSpaceLine() {
+        public void CommentIndentedWhiteSpaceLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"function f(){
     console.log('Hello');
@@ -230,7 +230,7 @@ console.log('bye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestUnCommentIndented() {
+        public void UnCommentIndented() {
             var view = new MockTextView(
                 new MockTextBuffer(@"function f(){
     //console.log('Hello');
@@ -257,7 +257,7 @@ console.log('bye');",
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestUnComment() {
+        public void UnComment() {
             var view = new MockTextView(
                 new MockTextBuffer(@"//console.log('Hello');
 //console.log('Goodbye');"));
@@ -275,7 +275,7 @@ console.log('Goodbye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentStartOfLastLine() {
+        public void CommentStartOfLastLine() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');
 console.log('Goodbye');"));
@@ -293,7 +293,7 @@ console.log('Goodbye');",
         }
 
         [TestMethod, Priority(0)]
-        public void TestCommentAfterCodeIsNotUncommented() {
+        public void CommentAfterCodeIsNotUncommented() {
             var view = new MockTextView(
                 new MockTextBuffer(@"console.log('Hello');//comment that should stay a comment;
 //console.log('Still here');//another comment that should stay a comment;

--- a/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
+++ b/Nodejs/Tests/Core/Debugger/DebuggerTests.cs
@@ -133,7 +133,7 @@ namespace NodejsTests.Debugger {
         #region BreakAll Tests
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("AppVeyorIgnore")]
-        public void TestBreakAll() {
+        public void BreakAll() {
             // Load process (running)
             NodeThread thread = null;
             using (var process = DebugProcess(
@@ -855,7 +855,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpoints() {
+        public void Breakpoints() {
             TestDebuggerSteps(
                 "BreakpointTest.js",
                 new[] {
@@ -867,7 +867,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpoints2() {
+        public void Breakpoints2() {
             TestDebuggerSteps(
                 "BreakpointTest2.js",
                 new[] {
@@ -882,7 +882,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpoints3() {
+        public void Breakpoints3() {
             TestDebuggerSteps(
                 "BreakpointTest3.js",
                 new[] {
@@ -895,7 +895,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointsConditionals() {
+        public void BreakpointsConditionals() {
             TestDebuggerSteps(
                 "BreakpointTest2.js",
                 new[] {
@@ -926,7 +926,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointEnable() {
+        public void BreakpointEnable() {
             TestDebuggerSteps(
                 "BreakpointTest2.js",
                 new[] {
@@ -942,7 +942,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointRemove() {
+        public void BreakpointRemove() {
             TestDebuggerSteps(
                 "BreakpointTest2.js",
                 new[] {
@@ -956,7 +956,7 @@ namespace NodejsTests.Debugger {
         }
 
         //[TestMethod, Priority(0)]
-        //public void TestBreakpointFailed() {
+        //public void BreakpointFailed() {
         //    var process =
         //        DebugProcess(
         //            DebuggerTestPath + "BreakpointTest.js",
@@ -984,7 +984,7 @@ namespace NodejsTests.Debugger {
         //}
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointsBreakOn() {
+        public void BreakpointsBreakOn() {
             // BreakOnKind.Always
             TestDebuggerSteps(
                 "BreakpointBreakOn.js",
@@ -1163,7 +1163,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointsHitCount() {
+        public void BreakpointsHitCount() {
             TestDebuggerSteps(
                 "BreakpointBreakOn.js",
                 new[] {
@@ -1182,7 +1182,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointInvalidLineFixup() {
+        public void BreakpointInvalidLineFixup() {
             TestDebuggerSteps(
                 "FixupBreakpointOnComment.js",
                 new[] {
@@ -1398,22 +1398,22 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointPredicatedEntrypointNoFixup() {
+        public void BreakpointPredicatedEntrypointNoFixup() {
             TestBreakpointPredicatedEntrypoint("BreakpointTest.js", targetBreakpoint: 0, expectedHit: 0);
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointPredicatedEntrypointBlankLineFixup() {
+        public void BreakpointPredicatedEntrypointBlankLineFixup() {
             TestBreakpointPredicatedEntrypoint("FixupBreakpointOnBlankLine.js", targetBreakpoint: 0, expectedHit: 2);
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestBreakpointPredicatedEntrypointCommentFixup() {
+        public void BreakpointPredicatedEntrypointCommentFixup() {
             TestBreakpointPredicatedEntrypoint("FixupBreakpointOnComment.js", targetBreakpoint: 0, expectedHit: 1);
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("AppVeyorIgnore")]
-        public void TestDuplicateFileName() {
+        public void DuplicateFileName() {
             TestDebuggerSteps(
                 "DuppedFilename.js",
                 new[] {
@@ -1437,7 +1437,7 @@ namespace NodejsTests.Debugger {
         #region Exception Tests
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestExceptions() {
+        public void Exceptions() {
             // Well-known, handled
             // Implicit break always
             //TestExceptions(
@@ -1548,7 +1548,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestExceptionsTypes() {
+        public void ExceptionsTypes() {
             TestExceptions(
                 DebuggerTestPath + @"ExceptionTypes.js",
                 ExceptionHitTreatment.BreakAlways,
@@ -1571,7 +1571,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestComplexExceptions() {
+        public void ComplexExceptions() {
             TestExceptions(
                 DebuggerTestPath + @"ComplexExceptions.js",
                 ExceptionHitTreatment.BreakAlways,
@@ -1593,7 +1593,7 @@ namespace NodejsTests.Debugger {
         /// by default.
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestRequireExceptions() {
+        public void RequireExceptions() {
             TestExceptions(
                 DebuggerTestPath + @"RequireExceptions.js",
                 null,
@@ -1608,7 +1608,7 @@ namespace NodejsTests.Debugger {
         /// Test handling of exceptions in evaluated code
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestExceptionInEvaluatedCode() {
+        public void ExceptionInEvaluatedCode() {
             TestDebuggerSteps(
                 "ExceptionInEvaluatedCode.js",
                 new[] {
@@ -1675,7 +1675,7 @@ namespace NodejsTests.Debugger {
         #region Module Load Tests
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestModuleLoad() {
+        public void ModuleLoad() {
             TestModuleLoad(
                 "NoRequires.js",
                 "NoRequires.js"
@@ -1722,7 +1722,7 @@ namespace NodejsTests.Debugger {
         #region Exit Code Tests
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestExitNormal() {
+        public void ExitNormal() {
             TestDebuggerSteps(
                 "ExitNormal.js",
                 new[] {
@@ -1733,7 +1733,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestExitException() {
+        public void ExitException() {
             TestDebuggerSteps(
                 "ExitException.js",
                 new[] {
@@ -1747,7 +1747,7 @@ namespace NodejsTests.Debugger {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("AppVeyorIgnore")]
-        public void TestExitExplicit() {
+        public void ExitExplicit() {
             TestDebuggerSteps(
                 "ExitExplicit.js",
                 new[] {
@@ -1762,7 +1762,7 @@ namespace NodejsTests.Debugger {
         #region Argument Tests
 
         [TestMethod, Priority(0), TestCategory("Debugging"), TestCategory("Ignore")]
-        public void TestScriptArguments() {
+        public void ScriptArguments() {
             TestDebuggerSteps(
                 "PassedArgs.js",
                 new[] {

--- a/Nodejs/Tests/Core/ReferenceCodeTests.cs
+++ b/Nodejs/Tests/Core/ReferenceCodeTests.cs
@@ -49,7 +49,7 @@ path = new function() {
 ";
 
         [TestMethod, Priority(0)]
-        public void TestPathRelative() {
+        public void PathRelative() {
             string tempPath = Path.GetTempPath().Replace('\\', '/');
             string tempPathNoFirstSlash = tempPath.Substring(0, 2) + tempPath.Substring(3);
             string tempPathNoDrive = tempPath.Substring(2);
@@ -70,17 +70,17 @@ path = new function() {
         }
 
         [TestMethod, Priority(0)]
-        public void TestPathNormalize() {
+        public void PathNormalize() {
             TestReferenceFunction("t('/foo/../bar', '/bar');", "path", "normalize");
         }
 
         [TestMethod, Priority(0)]
-        public void TestPathResolve() {
+        public void PathResolve() {
             TestReferenceFunction("t('foo/bar', '/tmp/file/', '..', 'a/../subfile')", "path", "resolve");
         }
 
         [TestMethod, Priority(0)]
-        public void TestPathJoin() {
+        public void PathJoin() {
             TestReferenceFunction("t('/foo', 'bar')", "path", "join");
             TestReferenceFunction("t('/foo', '/bar')", "path", "join");
             TestReferenceFunction("t('foo', '/bar')", "path", "join");

--- a/Nodejs/Tests/Core/ReplWindowTests.cs
+++ b/Nodejs/Tests/Core/ReplWindowTests.cs
@@ -44,7 +44,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestNumber() {
+        public void Number() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -59,7 +59,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestRequire() {
+        public void Require() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -70,7 +70,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestFunctionDefinition() {
+        public void FunctionDefinition() {
             var whitespaces = new[] { "", "\r\n", "   ", "\r\n    " };
             using (var eval = ProjectlessEvaluator()) {
                 foreach (var whitespace in whitespaces) {
@@ -90,7 +90,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestConsoleLog() {
+        public void ConsoleLog() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -101,7 +101,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestConsoleWarn() {
+        public void ConsoleWarn() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -112,7 +112,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestConsoleError() {
+        public void ConsoleError() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -123,7 +123,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore"), TestCategory("Ignore")]
-        public void TestConsoleDir() {
+        public void ConsoleDir() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -201,7 +201,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestException() {
+        public void Exception() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -214,7 +214,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestExceptionNull() {
+        public void ExceptionNull() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -227,7 +227,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestExceptionUndefined() {
+        public void ExceptionUndefined() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -240,7 +240,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestProcessExit() {
+        public void ProcessExit() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -258,7 +258,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestReset() {
+        public void Reset() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -285,7 +285,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestSaveNoFile() {
+        public void SaveNoFile() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -303,7 +303,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestSaveBadFile() {
+        public void SaveBadFile() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -321,7 +321,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestSave() {
+        public void Save() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval, NodejsConstants.JavaScript);
                 window.ClearScreen();
@@ -347,7 +347,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestBadSave() {
+        public void BadSave() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -415,7 +415,7 @@ undefined";
                                                   };
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestPartialInputs() {
+        public void PartialInputs() {
             using (var eval = ProjectlessEvaluator()) {
                 foreach (var partialInput in _partialInputs) {
                     Assert.AreEqual(false, eval.CanExecuteText(partialInput), "Partial input successfully parsed: " + partialInput);
@@ -427,7 +427,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore"), TestCategory("Ignore")]
-        public void TestVarI() {
+        public void VarI() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -446,7 +446,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestObjectLiteral() {
+        public void ObjectLiteral() {
             using (var eval = ProjectlessEvaluator()) {
                 var window = new MockReplWindow(eval);
                 window.ClearScreen();
@@ -460,7 +460,7 @@ undefined";
         /// https://nodejstools.codeplex.com/workitem/279
         /// </summary>
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestRequireInProject() {
+        public void RequireInProject() {
             string testDir;
             do {
                 testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -515,7 +515,7 @@ undefined";
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore"), TestCategory("Ignore")]
-        public void TestNpmReplRedirector() {
+        public void NpmReplRedirector() {
             using (var eval = ProjectlessEvaluator()) {
                 var mockWindow = new MockReplWindow(eval) {
                     ShowAnsiCodes = true

--- a/Nodejs/Tests/Core/SourceMapTests.cs
+++ b/Nodejs/Tests/Core/SourceMapTests.cs
@@ -57,7 +57,7 @@ namespace NodejsTests {
         private const string _sample = @"{'version':3,'file':'test.js','sourceRoot':'','sources':['test.ts'],'names':['Greeter','Greeter.constructor','Greeter.greet'],'mappings':'AAAA;IACIA,iBAAYA,QAAuBA;QAAvBC,aAAeA,GAARA,QAAQA;AAAQA,IAAIA,CAACA;IACxCD,0BAAAA;QACIE,OAAOA,MAAMA,GAAGA,IAAIA,CAACA,QAAQA,GAAGA,OAAOA;IAC3CA,CAACA;IACLF,eAACA;AAADA,CAACA,IAAA;AAAA,CAAC'}";
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestBadMappings() {
+        public void BadMappings() {
             // empty segment
             AssertUtil.Throws<InvalidOperationException>(
                 () => new SourceMap(new StringReader("{version:3, mappings:','}"))
@@ -81,7 +81,7 @@ namespace NodejsTests {
 
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestMappingLine() {
+        public void MappingLine() {
             var map = new SourceMap(new StringReader(_sample));
             var testCases = new[] { 
                 new { Line = 0, Name = "Greeter", Filename = "test.ts" },
@@ -109,7 +109,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestMappingLineAndColumn() {
+        public void MappingLineAndColumn() {
             var map = new SourceMap(new StringReader(_sample));
             var testCases = new[] { 
                 new { InLine = 0, InColumn = 0, ExpectedLine = 0, ExpectedColumn = 0, Name = "Greeter", Filename = "test.ts" },
@@ -142,7 +142,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestVersion() {
+        public void Version() {
             try {
                 new SourceMap(new StringReader("{}"));
                 Assert.Fail("Exception not thrown on empty map");
@@ -164,14 +164,14 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestNames() {
+        public void Names() {
             var map = new SourceMap(new StringReader("{version:3, names:['foo']}"));
             Assert.AreEqual(map.Names[0], "foo");
         }
 
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestSources() {
+        public void Sources() {
             var map = new SourceMap(new StringReader("{version:3, sources:['test.ts']}"));
             Assert.AreEqual(map.Sources[0], "test.ts");
 
@@ -180,13 +180,13 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestFile() {
+        public void File() {
             var map = new SourceMap(new StringReader("{version:3, file:'test.js'}"));
             Assert.AreEqual(map.File, "test.js");
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestInvalidJson() {
+        public void InvalidJson() {
             try {
                 var map = new SourceMap(new StringReader("{'test.js\\'}"));
                 Assert.Fail("Argument exception not raised");
@@ -195,14 +195,14 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestMapToOriginal() {
+        public void MapToOriginal() {
             var mapper = new SourceMapper();
             var mapInfo = mapper.MapToOriginal(TestData.GetPath(@"TestData\DebuggerProject\TypeScriptTest.js"), 1, 0);
             Assert.AreEqual("TypeScriptTest.ts", mapInfo.FileName);
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestMapToJavaScript() {
+        public void MapToJavaScript() {
             var mapper = new SourceMapper();
             string fileName;
             int lineNo, columnNo;
@@ -211,7 +211,7 @@ namespace NodejsTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Debugging")]
-        public void TestGetOriginalFileNameWithStackFrame() {
+        public void GetOriginalFileNameWithStackFrame() {
             string javaScriptFileName = TestData.GetPath(@"TestData\TypeScriptMultfile\all.js");
             var sourceMapper = new SourceMapper();            
             int? line = 24, column = 9;

--- a/Nodejs/Tests/Core/TemplateTests.cs
+++ b/Nodejs/Tests/Core/TemplateTests.cs
@@ -26,7 +26,7 @@ namespace NodejsTests {
     [TestClass]
     public class TemplateTests {
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestPackageJsonTemplateEncoding() {
+        public void PackageJsonTemplateEncoding() {
             var projectTemplates = Path.Combine(TestData.BinarySourceLocation, "ProjectTemplates", "JavaScript", "Node.js", "1033");
             Assert.IsTrue(Directory.Exists(projectTemplates), "Project templates are not available");
 

--- a/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/FileSystemPackageJsonTests.cs
@@ -22,7 +22,7 @@ namespace NpmTests {
     [TestClass]
     public class FileSystemPackageJsonTests : AbstractPackageJsonTests {
         [TestMethod, Priority(0)]
-        public void TestReadFromFile() {
+        public void ReadFromFile() {
             using (var manager = new TemporaryFileManager()) {
                 var dir = manager.GetNewTempDirectory();
                 var path = Path.Combine(dir.FullName, "package.json");
@@ -32,7 +32,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadFromDirectory() {
+        public void ReadFromDirectory() {
             using (var manager = new TemporaryFileManager()) {
                 var dir = manager.GetNewTempDirectory();
                 FilesystemPackageJsonTestHelpers.CreatePackageJson(Path.Combine(dir.FullName, "package.json"), PkgSimple);

--- a/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
+++ b/Nodejs/Tests/NpmTests/InstallUninstallPackageTests.cs
@@ -23,7 +23,7 @@ namespace NpmTests {
     [TestClass]
     public class InstallUninstallPackageTests : AbstractPackageJsonTests {
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestAddPackageToSimplePackageJsonThenUninstall() {
+        public void AddPackageToSimplePackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
@@ -76,7 +76,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestAddPackageNoPackageJsonThenUninstall() {
+        public void AddPackageNoPackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 File.Delete(Path.Combine(rootDir, "package.json"));
@@ -130,7 +130,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestAddPackageNoSavePackageJsonThenUninstall() {
+        public void AddPackageNoSavePackageJsonThenUninstall() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);

--- a/Nodejs/Tests/NpmTests/MaxPathTests.cs
+++ b/Nodejs/Tests/NpmTests/MaxPathTests.cs
@@ -25,7 +25,7 @@ namespace NpmTests {
     public class MaxPathTests : AbstractPackageJsonTests {
 
         [TestMethod, Priority(0)]
-        public void TestAngularFullstackScaffoldedProject() {
+        public void AngularFullstackScaffoldedProject() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackageDir(manager);
                 var controller = NpmControllerFactory.Create(rootDir, string.Empty);
@@ -45,7 +45,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0), TestCategory("AppVeyorIgnore")]
-        public void TestInstallUninstallMaxPathGlobalModule() {
+        public void InstallUninstallMaxPathGlobalModule() {
             var controller = NpmControllerFactory.Create(string.Empty, string.Empty);
 
             using (var commander = controller.CreateNpmCommander()) {

--- a/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
+++ b/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
@@ -41,7 +41,7 @@ namespace NpmTests {
 }";
 
         [TestMethod, Priority(0)]
-        public void TestReadRootPackageNoDependencies() {
+        public void ReadRootPackageNoDependencies() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSimple);
                 var pkg = RootPackageFactory.Create(rootDir);
@@ -62,7 +62,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadRootPackageOneDependency() {
+        public void ReadRootPackageOneDependency() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleDependency);
                 RunNpmInstall(rootDir);
@@ -107,7 +107,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadRootPackageMissingDependency() {
+        public void ReadRootPackageMissingDependency() {
             using (var manager = new TemporaryFileManager()) {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleDependency);
 
@@ -151,7 +151,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadRootDependencyRecursive() {
+        public void ReadRootDependencyRecursive() {
             using (var manager = new TemporaryFileManager()) {
 
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleRecursiveDependency);

--- a/Nodejs/Tests/NpmTests/NpmSearchTests.cs
+++ b/Nodejs/Tests/NpmTests/NpmSearchTests.cs
@@ -490,7 +490,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFilterString() {
+        public void FilterString() {
             const string filterString = "express";
             var results = GetFilteredPackageList(filterString);
             Assert.IsTrue(results.Count > 0, string.Format("Should be some filter results for '{0}'.", filterString));
@@ -512,7 +512,7 @@ namespace NpmTests {
 
         [Ignore]
         [TestMethod, Priority(0)]
-        public void TestFilterStringWithHyphens() {
+        public void FilterStringWithHyphens() {
             const string
                 filterStringWithHyphenMiddle = "grunt-contrib",
                 filterStringWithHyphenSuffix = "amazing-",
@@ -553,12 +553,12 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFilterRegex() {
+        public void FilterRegex() {
             TestFilterRegex("/^express$");
         }
 
         [TestMethod, Priority(0)]
-        public void TestFilterRegexTrailingSlash() {
+        public void FilterRegexTrailingSlash() {
             TestFilterRegex("/^express$/");
         }
     }

--- a/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
@@ -513,7 +513,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadAllDependencies() {
+        public void ReadAllDependenciesTest() {
             CheckDependencies(
                 ReadAllDependencies(),
                 UrlDependencies.Concat(VersionRangeDependencies)

--- a/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
@@ -513,7 +513,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void ReadAllDependencies() {
+        public void TestReadAllDependencies() {
             CheckDependencies(
                 ReadAllDependencies(),
                 UrlDependencies.Concat(VersionRangeDependencies)

--- a/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonDependencyTests.cs
@@ -345,17 +345,17 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyDependenciesNotNull() {
+        public void ReadEmptyDependenciesNotNull() {
             CheckEmptyDependenciesNotNull(LoadFrom(PkgSimple).Dependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyDevDependenciesNotNull() {
+        public void ReadEmptyDevDependenciesNotNull() {
             CheckEmptyDependenciesNotNull(LoadFrom(PkgSimple).DevDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyOptionalDependenciesNotNull() {
+        public void ReadEmptyOptionalDependenciesNotNull() {
             CheckEmptyDependenciesNotNull(LoadFrom(PkgSimple).OptionalDependencies);
         }
 
@@ -467,27 +467,27 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadDependenciesWithVersionRange() {
+        public void ReadDependenciesWithVersionRange() {
             CheckDependencies(ReadDependencies(), VersionRangeDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadDependenciesWithUrls() {
+        public void ReadDependenciesWithUrls() {
             CheckDependencies(ReadDependencies(), UrlDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadDevDependenciesWithVersionRange() {
+        public void ReadDevDependenciesWithVersionRange() {
             CheckDependencies(ReadDevDependencies(), DevVersionRangeDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadDevDependenciesWithUrls() {
+        public void ReadDevDependenciesWithUrls() {
             CheckDependencies(ReadDevDependencies(), DevUrlDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadBundledDependencies() {
+        public void ReadBundledDependencies() {
             CheckStringArrayContents(
                 LoadFrom(PkgAllTheDependencies).BundledDependencies,
                 16,
@@ -495,7 +495,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadBundleDependencies() {
+        public void ReadBundleDependencies() {
             CheckStringArrayContents(
                 LoadFrom(PkgBundleDependencies).BundledDependencies,
                 16,
@@ -503,17 +503,17 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadOptionalDependenciesWithVersionRange() {
+        public void ReadOptionalDependenciesWithVersionRange() {
             CheckDependencies(ReadOptionalDependencies(), OptionalVersionRangeDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadOptionalDependenciesWithUrls() {
+        public void ReadOptionalDependenciesWithUrls() {
             CheckDependencies(ReadOptionalDependencies(), OptionalUrlDependencies);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadAllDependencies() {
+        public void ReadAllDependencies() {
             CheckDependencies(
                 ReadAllDependencies(),
                 UrlDependencies.Concat(VersionRangeDependencies)

--- a/Nodejs/Tests/NpmTests/PackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/PackageJsonTests.cs
@@ -194,19 +194,19 @@ namespace NpmTests {
 }";
 
         [TestMethod, Priority(0)]
-        public void TestReadNoNameNull() {
+        public void ReadNoNameNull() {
             var pkg = LoadFrom(PkgEmpty);
             Assert.IsNull(pkg.Name, "Name should be null.");
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadNoVersionIsZeroed() {
+        public void ReadNoVersionIsZeroed() {
             var pkg = LoadFrom(PkgEmpty);
             Assert.AreEqual(new SemverVersion(), pkg.Version, "Empty version mismatch.");
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadNameAndVersion() {
+        public void ReadNameAndVersion() {
             var pkgJson = LoadFrom(PkgSimple);
 
             dynamic json = JsonConvert.DeserializeObject(PkgSimple);
@@ -218,13 +218,13 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadNoDescriptionNull() {
+        public void ReadNoDescriptionNull() {
             var pkg = LoadFrom(PkgEmpty);
             Assert.IsNull(pkg.Description, "Description should be null.");
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadDescription() {
+        public void ReadDescription() {
             var pkg = LoadFrom(PkgLargeCompliant);
             Assert.AreEqual(
                 "Sample package for CommonJS. This package demonstrates the required elements of a CommonJS package.",
@@ -233,12 +233,12 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyKeywordsCountZero() {
+        public void ReadEmptyKeywordsCountZero() {
             CheckEmptyArray(LoadFrom(PkgEmpty).Keywords);
         }
 
         [TestMethod, Priority(0)]
-        public void TestEnumerationOverKeywords() {
+        public void EnumerationOverKeywords() {
             CheckStringArrayContents(
                 LoadFrom(PkgLargeCompliant).Keywords,
                 2,
@@ -246,13 +246,13 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadNoHomepageEmpty() {
+        public void ReadNoHomepageEmpty() {
             var pkg = LoadFrom(PkgSimple);
             Assert.AreEqual(0, pkg.Homepages.Count, "Homepage should be empty.");
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadHomepageCompliant() {
+        public void ReadHomepageCompliant() {
             var pkg = LoadFrom(PkgLargeCompliant);
             CheckStringArrayContents(
                 pkg.Homepages,
@@ -261,7 +261,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadHomepageNonCompliant() {
+        public void ReadHomepageNonCompliant() {
             var pkg = LoadFrom(PkgLargeNonCompliant);
             CheckStringArrayContents(
                 pkg.Homepages,
@@ -270,12 +270,12 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyFilesEmpty() {
+        public void ReadEmptyFilesEmpty() {
             CheckEmptyArray(LoadFrom(PkgSimple).Files);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadFiles() {
+        public void ReadFiles() {
             CheckStringArrayContents(
                 LoadFrom(PkgLargeCompliant).Files,
                 3,
@@ -283,12 +283,12 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyManEmpty() {
+        public void ReadEmptyManEmpty() {
             CheckEmptyArray(LoadFrom(PkgSimple).Man);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadSingleMan() {
+        public void ReadSingleMan() {
             CheckStringArrayContents(
                 LoadFrom(PkgLargeNonCompliant).Man,
                 1,
@@ -296,7 +296,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadMultiMan() {
+        public void ReadMultiMan() {
             CheckStringArrayContents(
                 LoadFrom(PkgLargeCompliant).Man,
                 2,
@@ -304,12 +304,12 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadEmptyAuthor() {
+        public void ReadEmptyAuthor() {
             Assert.IsNull(LoadFrom(PkgSimple).Author);
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadMisspelledAuthor() {
+        public void ReadMisspelledAuthor() {
             Assert.AreEqual(
                 @"{
   ""misspelledname"": ""Firstname Lastname""
@@ -319,7 +319,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadSingleAuthorField() {
+        public void ReadSingleAuthorField() {
             Assert.AreEqual(
                 "Firstname Lastname",
                 LoadFrom(PkgSingleAuthorField).Author.Name
@@ -327,7 +327,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadAuthorCompliant() {
+        public void ReadAuthorCompliant() {
             var compliantAuthor = LoadFrom(PkgLargeCompliant).Author;
             Assert.AreEqual("Firstname Lastname", compliantAuthor.Name);
             Assert.AreEqual("firstname@lastname.com", compliantAuthor.Email);
@@ -335,7 +335,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestReadAuthorNonCompliant() {
+        public void ReadAuthorNonCompliant() {
             var nonCompliantAuthor = LoadFrom(PkgLargeNonCompliant).Author;
             Assert.AreEqual("Firstname Lastname", nonCompliantAuthor.Name);
             Assert.AreEqual("http://firstnamelastname.com", nonCompliantAuthor.Url);

--- a/Nodejs/Tests/NpmTests/ProblematicPackageJsonTests.cs
+++ b/Nodejs/Tests/NpmTests/ProblematicPackageJsonTests.cs
@@ -29,7 +29,7 @@ namespace NpmTests {
     public class ProblematicPackageJsonTests : AbstractPackageJsonTests {
 
         [TestMethod, Priority(0)]
-        public void TestFreshPackageJsonParseFromResource() {
+        public void FreshPackageJsonParseFromResource() {
             var pkg = LoadFromResource("NpmTests.TestData.fresh_package.json");
             Assert.IsNotNull(pkg, "Fresh package should not be null.");
         }
@@ -43,7 +43,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestFreshPackageParseFromFile() {
+        public void FreshPackageParseFromFile() {
             TestParseFromFile("fresh_package.json");
         }
 
@@ -53,99 +53,99 @@ namespace NpmTests {
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseDoubleColon() {
+        public void ParseDoubleColon() {
             TestFreshPackage("doublecolon");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseDoubleComma() {
+        public void ParseDoubleComma() {
             TestFreshPackage("doublecomma");
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseDuplicateProperty() {
+        public void ParseDuplicateProperty() {
             TestFreshPackage("duplicateproperty");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseLeadingBrace() {
+        public void ParseLeadingBrace() {
             TestFreshPackage("leadingbrace");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseLeadingLetter() {
+        public void ParseLeadingLetter() {
             TestFreshPackage("leadingletter");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseLeadingSquareBrace() {
+        public void ParseLeadingSquareBrace() {
             TestFreshPackage("leadingsquarebrace");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingColon() {
+        public void ParseMissingColon() {
             TestFreshPackage("missingcolon");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingComma() {
+        public void ParseMissingComma() {
             TestFreshPackage("missingcomma");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingLeadingBrace() {
+        public void ParseMissingLeadingBrace() {
             TestFreshPackage("missingleadingbrace");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingLeadingListBrace() {
+        public void ParseMissingLeadingListBrace() {
             TestFreshPackage("missingleadinglistbrace");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingLeadingPropNameQuote() {
+        public void ParseMissingLeadingPropNameQuote() {
             TestFreshPackage("missingleadingpropnamequote");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseMissingOnePropNameQuote() {
+        public void ParseMissingOnePropNameQuote() {
             TestFreshPackage("missingonepropnamequote");
         }
 
         [TestMethod, Priority(0)]
-        public void TestParseMissingPropNameQuotes() {
+        public void ParseMissingPropNameQuotes() {
             TestFreshPackage("missingpropnamequotes");
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestParseMissingTrailingBrace() {
+        public void ParseMissingTrailingBrace() {
             TestFreshPackage("missingtrailingbrace");
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestParseMissingTrailingListBrace() {
+        public void ParseMissingTrailingListBrace() {
             TestFreshPackage("missingtrailinglistbrace");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(PackageJsonException))]
-        public void TestParseUnescapedQuote() {
+        public void ParseUnescapedQuote() {
             TestFreshPackage("unescapedquote");
         }
 
         [TestMethod, Priority(0)]
-        public void TestParseCppStyleComment_WorkItem563() {
+        public void ParseCppStyleComment_WorkItem563() {
             var buff = new StringBuilder(@"{
   ""name"": ""angular-app-server"",
   ""description"": ""Back end server to support our angular app"",
@@ -182,7 +182,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestParseFromEveryCharValue() {
+        public void ParseFromEveryCharValue() {
             var buff = new StringBuilder();
             var ch = (char)0;
             do {

--- a/Nodejs/Tests/NpmTests/SemverVersionTests.cs
+++ b/Nodejs/Tests/NpmTests/SemverVersionTests.cs
@@ -26,7 +26,7 @@ namespace NpmTests {
     [TestClass]
     public class SemverVersionTests {
         [TestMethod, Priority(0)]
-        public void TestBasicMajorMinorPatchVersion() {
+        public void BasicMajorMinorPatchVersion() {
             SemverVersionTestHelper.AssertVersionsEqual(
                 1,
                 2,
@@ -38,52 +38,52 @@ namespace NpmTests {
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow negative major version.")]
-        public void TestNegativeMajorVersionFails() {
+        public void NegativeMajorVersionFails() {
             SemverVersion.Parse("-1.2.3");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow negative minor version.")]
-        public void TestNegativeMinorVersionFails() {
+        public void NegativeMinorVersionFails() {
             SemverVersion.Parse("1.-2.3");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow negative patch version.")]
-        public void TestNegativePatchVersionFails() {
+        public void NegativePatchVersionFails() {
             SemverVersion.Parse("1.2.-3");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow non-numeric major version.")]
-        public void TestNonNumericMajorVersionFails() {
+        public void NonNumericMajorVersionFails() {
             SemverVersion.Parse("a.2.3");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow non-numeric minor version.")]
-        public void TestNonNumericMinorVersionFails() {
+        public void NonNumericMinorVersionFails() {
             SemverVersion.Parse("1.b.3");
         }
 
         [TestMethod, Priority(0)]
         [ExpectedException(typeof(SemverVersionFormatException), "Should not allow non-numeric patch version.")]
-        public void TestNonNumericPatchVersionFails() {
+        public void NonNumericPatchVersionFails() {
             SemverVersion.Parse("1.2.c");
         }
 
         [TestMethod, Priority(0)]
-        public void TestAlphaPreRelease() {
+        public void AlphaPreRelease() {
             SemverVersionTestHelper.AssertVersionsEqual(1, 2, 3, "alpha", null, SemverVersion.Parse("1.2.3-alpha"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestNumericPreRelease() {
+        public void NumericPreRelease() {
             SemverVersionTestHelper.AssertVersionsEqual(1, 2, 3, "4.5.6", null, SemverVersion.Parse("1.2.3-4.5.6"));
         }
 
         [TestMethod, Priority(0)]
-        public void TestPreReleaseHyphenatedIdentifier() {
+        public void PreReleaseHyphenatedIdentifier() {
             SemverVersionTestHelper.AssertVersionsEqual(
                 1,
                 2,
@@ -94,7 +94,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestPreReleaseHyphenatedIdentifierWithoutVersion()
+        public void PreReleaseHyphenatedIdentifierWithoutVersion()
         {
             // This version code is crazy, and for that reason it fail when
             // regional settings is set to Turkish.
@@ -108,7 +108,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestPreReleaseAndBuildMetadata() {
+        public void PreReleaseAndBuildMetadata() {
             // 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85
             SemverVersionTestHelper.AssertVersionsEqual(1, 0, 0, "alpha", "001", SemverVersion.Parse("1.0.0-alpha+001"));
             SemverVersionTestHelper.AssertVersionsEqual(
@@ -121,7 +121,7 @@ namespace NpmTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestBuildMetadataOnly() {
+        public void BuildMetadataOnly() {
             SemverVersionTestHelper.AssertVersionsEqual(
                 1,
                 0,

--- a/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
+++ b/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
@@ -259,7 +259,7 @@ namespace ProfilingUITests {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestStartAnalysisDebugMenu() {
+        public void StartAnalysisDebugMenu() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -294,7 +294,7 @@ namespace ProfilingUITests {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestStartAnalysisDebugMenuNoProject() {
+        public void StartAnalysisDebugMenuNoProject() {
             using (new JustMyCodeSetting(false))
             using (var app = new NodejsVisualStudioApp()) {
                 bool ok = true;
@@ -385,7 +385,7 @@ namespace ProfilingUITests {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestMultipleSessions() {
+        public void MultipleSessions() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -458,7 +458,7 @@ namespace ProfilingUITests {
         /// </summary>
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestMultipleSessions2() {
+        public void MultipleSessions2() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -726,7 +726,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestSaveDirtySession() {
+        public void SaveDirtySession() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -766,7 +766,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestDeleteReport() {
+        public void DeleteReport() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -792,7 +792,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestCompareReports() {
+        public void CompareReports() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -860,7 +860,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestRemoveReport() {
+        public void RemoveReport() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -886,7 +886,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestOpenReport() {
+        public void OpenReport() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -912,7 +912,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestOpenReportCtxMenu() {
+        public void OpenReportCtxMenu() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -937,7 +937,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestTargetPropertiesForProject() {
+        public void TargetPropertiesForProject() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -968,7 +968,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestTargetPropertiesForExecutable() {
+        public void TargetPropertiesForExecutable() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -1012,7 +1012,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestStopProfiling() {
+        public void StopProfiling() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -1047,7 +1047,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core")]
         [HostType("VSTestHost")]
-        public void TestTwoProfilesAtTheSameTime() {
+        public void TwoProfilesAtTheSameTime() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -1260,7 +1260,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestJustMyCode() {
+        public void JustMyCode() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(true))
@@ -1288,7 +1288,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestJustMyCodeOff() {
+        public void JustMyCodeOff() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -1315,7 +1315,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestProjectProperties() {
+        public void ProjectProperties() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))
@@ -1349,7 +1349,7 @@ namespace ProfilingUITests {
 
         [TestMethod, Priority(0), TestCategory("Core"), TestCategory("Ignore")]
         [HostType("VSTestHost")]
-        public void TestBrowserLaunch() {
+        public void BrowserLaunch() {
             EnvDTE.Project project;
             INodeProfiling profiling;
             using (new JustMyCodeSetting(false))

--- a/Nodejs/Tests/Profiling/LogParserTests.cs
+++ b/Nodejs/Tests/Profiling/LogParserTests.cs
@@ -78,7 +78,7 @@ namespace ProfilerTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestFilenameParsing() {
+        public void FilenameParsing() {
             AssertExpectedFileInfo(
                 " net.js:931",
                 "net",

--- a/Nodejs/Tests/TestAdapterTests/TestExecutorTests.cs
+++ b/Nodejs/Tests/TestAdapterTests/TestExecutorTests.cs
@@ -37,7 +37,7 @@ namespace TestAdapterTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestRun() {
+        public void Run() {
             
             var executor = new TestExecutor();
             var recorder = new MockTestExecutionRecorder();
@@ -57,7 +57,7 @@ namespace TestAdapterTests {
         }
 
         [TestMethod, Priority(0), TestCategory("Ignore")]
-        public void TestRunAll() {
+        public void RunAll() {
             
             var executor = new TestExecutor();
             var recorder = new MockTestExecutionRecorder();
@@ -76,7 +76,7 @@ namespace TestAdapterTests {
         }
 
         [TestMethod, Priority(0)]
-        public void TestCancel() {
+        public void Cancel() {
             
             var executor = new TestExecutor();
             var recorder = new MockTestExecutionRecorder();


### PR DESCRIPTION
About half of our tests use the prefix `Test` for their method names. Test methods are already marked as tests using the `TestMethod` attribute. Also naming the test methods `Test*` makes finding tests in the test explorer more difficult

Quick find and replace to eliminate the `Test` prefixes. This gives all of our test methods a consistent naming convetion.