### PR TITLE
Quick Fix for Include in Project

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -76,7 +76,7 @@ namespace Microsoft.NodejsTools.Project {
 #endif
 
         internal override int IncludeInProject(bool includeChildren) {
-            if (!Parent.ItemNode.IsExcluded) {
+            if (!ItemNode.IsExcluded) {
                 return 0;
             }
 


### PR DESCRIPTION
**Bug**
Cannot include child node if parent node is excluded. The expected behavior is to recursivly include the entire parent path.

**Fix**
Gate using Child Node's include state instead of parent node's

closes #905