### PR TITLE
Check for null in `AD7Enginer::OnDocumentSaved`

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -1239,7 +1239,8 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
             }
 
             DebuggerClient.RunWithRequestExceptionsHandled(async () => {
-                if (!await Process.UpdateModuleSourceAsync(module).ConfigureAwait(false)) {
+                var currentProcess = Process;
+                if (currentProcess == null || !await currentProcess.UpdateModuleSourceAsync(module).ConfigureAwait(false)) {
                     var statusBar = (IVsStatusbar)ServiceProvider.GlobalProvider.GetService(typeof(SVsStatusbar));
                     statusBar.SetText(SR.GetString(SR.DebuggerModuleUpdateFailed));
                 }


### PR DESCRIPTION
Looking into #911

I can't repo the the original problem, but suspect that the null dereference error is coming from `_process` being null when this lambda is invoked.