### PR TITLE
Fixes for Debugger when attaching to exited process

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
@@ -295,8 +295,8 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                 }
             } catch (SocketException) {
             } catch (IOException) {
-            } catch (InvalidOperationException) {
             } catch (ObjectDisposedException) {
+            } catch (InvalidOperationException) {
             } catch (DecoderFallbackException ex) {
                 LiveLogger.WriteLine(string.Format("Error decoding response body: {0}", ex), typeof(DebuggerConnection));
             } catch (JsonReaderException ex) {

--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
@@ -186,6 +186,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                 }
             } catch (SocketException) {
             } catch (ObjectDisposedException) {
+            } catch (InvalidOperationException) {
             } catch (IOException) {
             } catch (Exception e) {
                 LiveLogger.WriteLine(string.Format("Failed to write message {0}.", e), typeof(DebuggerConnection));
@@ -294,6 +295,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                 }
             } catch (SocketException) {
             } catch (IOException) {
+            } catch (InvalidOperationException) {
             } catch (ObjectDisposedException) {
             } catch (DecoderFallbackException ex) {
                 LiveLogger.WriteLine(string.Format("Error decoding response body: {0}", ex), typeof(DebuggerConnection));

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -950,8 +950,11 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
 
             uint attributes;
             var riidEvent = new Guid(iidEvent);
-
-            EngineUtils.RequireOk(eventObject.GetAttributes(out attributes));
+            var attributesResult = eventObject.GetAttributes(out attributes);
+            if (attributesResult == VSConstants.RPC_E_DISCONNECTED) {
+                return;
+            }
+            EngineUtils.RequireOk(attributesResult);
 
             if ((attributes & (uint)enum_EVENTATTRIBUTES.EVENT_STOPPING) != 0 && thread == null) {
                 Debug.Fail("A thread must be provided for a stopping event");
@@ -959,7 +962,11 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
             }
 
             try {
-                EngineUtils.RequireOk(events.Event(this, null, program, thread, eventObject, ref riidEvent, attributes));
+                var eventResult = events.Event(this, null, program, thread, eventObject, ref riidEvent, attributes);
+                if (eventResult == VSConstants.RPC_E_DISCONNECTED) {
+                    return;
+                }
+                EngineUtils.RequireOk(eventResult);
             } catch (InvalidCastException) {
                 // COM object has gone away
             }

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
@@ -113,6 +113,9 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                 } catch (IOException ex) {
                     LiveLogger.WriteLine("IOException connecting to remote debugger");
                     exception = ex;
+                } catch (InvalidOperationException ex) {
+                    LiveLogger.WriteLine("InvalidOperationException connecting to remote debugger");
+                    exception = ex;
                 } catch (SocketException ex) {
                     LiveLogger.WriteLine("SocketException connecting to remote debugger");
                     exception = ex;

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -248,7 +248,8 @@ namespace Microsoft.NodejsTools.Debugger {
         internal bool IsRunning() {
             var backtraceCommand = new BacktraceCommand(CommandId, _resultFactory, fromFrame: 0, toFrame: 1);
             var tokenSource = new CancellationTokenSource(_timeout);
-            if (TrySendRequestAsync(backtraceCommand, tokenSource.Token).GetAwaiter().GetResult()) {
+            var task = TrySendRequestAsync(backtraceCommand, tokenSource.Token);
+            if (task.Wait(_timeout) && task.Result) {
                 return backtraceCommand.Running;
             }
             return false;


### PR DESCRIPTION
#912 

**Bug**
We can currently crash or hang when attaching to a node process that exits quickly.

**Fixes**
This change adds a few fixes:

* In `Send`, don't treat RPC failure hresults as true failures that should throw exceptions.
* Fix infinite hang by timing out correctly.
* Handle  `InvalidOperationException` when trying to access `TcpClient.Stream`

closes #912