### PR TITLE
Fix Repl window null deref when main NTVS package has not been loaded yet

### DIFF
--- a/Common/Product/SharedProject/CommonPackage.cs
+++ b/Common/Product/SharedProject/CommonPackage.cs
@@ -130,6 +130,7 @@ namespace Microsoft.VisualStudioTools {
         /// <returns></returns>
         public static IWpfTextView GetActiveTextView(System.IServiceProvider serviceProvider) {
             if (serviceProvider == null) {
+                Debug.Assert(false, "No service provider");
                 return null;
             }
 
@@ -179,6 +180,7 @@ namespace Microsoft.VisualStudioTools {
 
         internal static CommonProjectNode GetStartupProject(System.IServiceProvider serviceProvider) {
             if (serviceProvider == null) {
+                Debug.Assert(false, "No service provider");
                 return null;
             }
             var buildMgr = (IVsSolutionBuildManager)serviceProvider.GetService(typeof(IVsSolutionBuildManager));

--- a/Common/Product/SharedProject/CommonPackage.cs
+++ b/Common/Product/SharedProject/CommonPackage.cs
@@ -129,6 +129,10 @@ namespace Microsoft.VisualStudioTools {
         /// </summary>
         /// <returns></returns>
         public static IWpfTextView GetActiveTextView(System.IServiceProvider serviceProvider) {
+            if (serviceProvider == null) {
+                return null;
+            }
+
             var monitorSelection = (IVsMonitorSelection)serviceProvider.GetService(typeof(SVsShellMonitorSelection));
             if (monitorSelection == null) {
                 return null;
@@ -174,6 +178,9 @@ namespace Microsoft.VisualStudioTools {
         }
 
         internal static CommonProjectNode GetStartupProject(System.IServiceProvider serviceProvider) {
+            if (serviceProvider == null) {
+                return null;
+            }
             var buildMgr = (IVsSolutionBuildManager)serviceProvider.GetService(typeof(IVsSolutionBuildManager));
             IVsHierarchy hierarchy;
             if (buildMgr != null && ErrorHandler.Succeeded(buildMgr.get_StartupProject(out hierarchy)) && hierarchy != null) {


### PR DESCRIPTION
#917

**Bug**
If the Repl window is used before the main NTVS package has been loaded, `NodeJsPacakge.Instance` will be null. This causes a null deref problem in some call paths (see #917)

**Fix**
Add a few null checks to these call paths.

closes #917