### PR TITLE
Fixing some NodeJsProjectNode refCount Issues

### DIFF
--- a/Common/Product/SharedProject/Automation/OAProject.cs
+++ b/Common/Product/SharedProject/Automation/OAProject.cs
@@ -61,6 +61,10 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
             }
         }
 
+        public void Dispose() {
+            configurationManager = null;
+        }
+
         /// <summary>
         /// Microsoft Internal Use Only.  Gets the file name of the project.
         /// </summary>

--- a/Common/Product/SharedProject/CommonProjectNode.cs
+++ b/Common/Product/SharedProject/CommonProjectNode.cs
@@ -155,8 +155,12 @@ namespace Microsoft.VisualStudioTools.Project {
                 if (IntPtr.Zero == unknownPtr) {
                     return null;
                 }
-                IVsHierarchy hier = Marshal.GetObjectForIUnknown(unknownPtr) as IVsHierarchy;
-                return hier;
+                try {
+                    IVsHierarchy hier = Marshal.GetObjectForIUnknown(unknownPtr) as IVsHierarchy;
+                    return hier;
+                } finally {
+                    Marshal.Release(unknownPtr);
+                }
             }
         }
 


### PR DESCRIPTION
Port of Microsoft/PTVS#1262 to try to address core memory leak issues:

* Marshal incrementing refcount and not decrementing it in two places.
* Automation object dispose.

In my testing, this did not actually fix the leak but does fix a few real issues with the current code. #881 still helps out with this.