### PR TITLE
Create vsix extension files during Build

### DIFF
--- a/Nodejs/Product/InteractiveWindow/InteractiveWindow.csproj
+++ b/Nodejs/Product/InteractiveWindow/InteractiveWindow.csproj
@@ -180,6 +180,9 @@
   <PropertyGroup>
     <DelaySign>true</DelaySign>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <CreateVsixContainer>True</CreateVsixContainer>
+  </PropertyGroup>
   <Import Project="$(BuildRoot)\Common\Product\ReplWindow\ReplWindow.proj" />
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -12,12 +12,12 @@
        Id specifications are minimums; any SKU equal or 'higher' will accept
        them. -->
   <Installation>
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />

--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -1,34 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8">
-    <Name>Node.js Tools - Interactive Window</Name>
-    <Author>Microsoft</Author>
-    <Version>1.2</Version>
-    <Description xml:space="preserve">Node.js Tools - Interactive Window</Description>
-    <MoreInfoUrl>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfoUrl>
+﻿<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8" Version="1.2" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Node.js Tools - Interactive Window</DisplayName>
+    <Description xml:space="preserve">Node.js Tools - Interactive Window.</Description>
+    <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>
     <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=785972</GettingStartedGuide>
-    <Locale>1033</Locale>
-    <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>
     <PreviewImage>NodeJS_200x.png</PreviewImage>
-    <SystemComponent>false</SystemComponent>
-    <SupportedProducts>
-      <VisualStudio Version="11.0">
-        <Edition>Pro</Edition>
-        <Edition>VWDExpress</Edition>
-      </VisualStudio>
-    </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" />
-  </Identifier>
-  <References>
-    <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
-      <Name>Visual Studio MPF</Name>
-    </Reference>
-  </References>
-  <Content>
-    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
-    <MefComponent>|%CurrentProject%|</MefComponent>
-    <Assembly AssemblyName="|%CurrentProject%;_GetAssemblyName|">|%CurrentProject%|</Assembly>
-  </Content>
-
-</Vsix>
+  </Metadata>
+  <!-- Version="11.0" specifies the minimum (not the maximum) version, and the
+       Id specifications are minimums; any SKU equal or 'higher' will accept
+       them. -->
+  <Installation>
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+  </Installation>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" />
+  </Assets>
+</PackageManifest>

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1706,6 +1706,9 @@
     <RegisterOutputPackage>true</RegisterOutputPackage>
     <RegisterWithCodebase>true</RegisterWithCodebase>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <CreateVsixContainer>True</CreateVsixContainer>
+  </PropertyGroup>
   <Import Project="$(BuildRoot)\Common\Product\SharedProject\SharedProject.proj" />
   <Import Project="..\ProjectAfter.settings" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -11,9 +11,13 @@
   <!-- Version="11.0" specifies the minimum (not the maximum) version, and the
        Id specifications are minimums; any SKU equal or 'higher' will accept
        them. -->
-  <Installation InstalledByMsi="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
-    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="11.0" />
+  <Installation>
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="4.5" />

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -12,12 +12,12 @@
        Id specifications are minimums; any SKU equal or 'higher' will accept
        them. -->
   <Installation>
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" Version="4.5" />

--- a/Nodejs/Product/Profiling/Profiling.csproj
+++ b/Nodejs/Product/Profiling/Profiling.csproj
@@ -231,6 +231,9 @@
     <RegisterOutputPackage>true</RegisterOutputPackage>
     <RegisterWithCodebase>true</RegisterWithCodebase>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <CreateVsixContainer>True</CreateVsixContainer>
+  </PropertyGroup>
   <Import Project="..\ProjectAfter.settings" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -1,34 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="B515653F-FB69-4B64-9D3F-F1FCF8421DD0">
-    <Name>Node.js Tools - Profiling</Name>
-    <Author>Microsoft</Author>
-    <Version>1.2</Version>
+﻿<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="B515653F-FB69-4B64-9D3F-F1FCF8421DD0" Version="1.2" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Node.js Tools - Profiling</DisplayName>
     <Description xml:space="preserve">Provides support for profiling Node.js projects</Description>
-    <MoreInfoUrl>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfoUrl>
+    <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>
     <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=785972</GettingStartedGuide>
-    <Locale>1033</Locale>
-    <InstalledByMsi>true</InstalledByMsi>
     <Icon>NodeJS.ico</Icon>
     <PreviewImage>NodeJS_200x.png</PreviewImage>
-    <SupportedProducts>
-      <VisualStudio Version="11.0">
-        <Edition>Ultimate</Edition>
-        <Edition>Premium</Edition>
-        <Edition>Pro</Edition>
-      </VisualStudio>
-    </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" />
-  </Identifier>
-  <References>
-    <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
-      <Name>Visual Studio MPF</Name>
-    </Reference>
-    <Reference Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" MinVersion="1.2" MaxVersion="1.2">
-      <Name>Node.js Tools for Visual Studio</Name>
-    </Reference>
-  </References>
-  <Content>
-    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
-  </Content>
-</Vsix>
+  </Metadata>
+  <!-- Version="11.0" specifies the minimum (not the maximum) version, and the
+       Id specifications are minimums; any SKU equal or 'higher' will accept
+       them. -->
+  <Installation>
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+  </Installation>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />
+  </Assets>
+</PackageManifest>

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -12,12 +12,12 @@
        Id specifications are minimums; any SKU equal or 'higher' will accept
        them. -->
   <Installation>
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[14.0.25123,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
   </Installation>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />


### PR DESCRIPTION
This change creates proper vsix files for the 3 NTVS extensions: Nodejs, Profiling, and Interactive Window.

The change also upgraded Profile and Interactive to version 2 of the VSIX manifest files.

This gets us closer to supporting automatic extension updating, the lightweight install experience ( #821 ), and other good stuff.