### PR TITLE
Fix link in Node.js Tools 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NTVS supports **editing**, **Intellisense**, **profiling**, **npm**, **TypeScrip
 * [**Microsoft/nodejs-guidelines**](https://github.com/Microsoft/nodejs-guidelines) includes other tips for working with Node.js.
 
 ## Releases
-* **[Node.js Tools 1.1](https://aka.ms/ntvslatest)** - Stable NTVS release (available for Visual Studio 2012, 2013, and 2015)
+* **[Node.js Tools 1.1](https://github.com/Microsoft/nodejstools/releases/tag/v1.1)** - Stable NTVS release (available for Visual Studio 2012, 2013, and 2015)
 * **[Node.js Tools 1.2 Alpha](https://github.com/Microsoft/nodejstools/releases/tag/v1.2.Alpha)** - Preview build with better ES6 Support and other improvements (available for Visual Studio 2015 and VS 15)
 * **[Dev Builds](https://github.com/Microsoft/nodejstools/releases)** - Includes the most recent changes and bugfixes (available for Visual Studio 2015 and VS 15)
 


### PR DESCRIPTION
`https://aka.ms/ntvslatest` redirect on Node.js 1.2 Alpha