### PR TITLE
Mocha path

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -90,7 +90,7 @@ function detectMocha(projectFolder) {
           }
         }
 
-        var mochaPath = path.join(node_modulesFolder, 'node_modulesFolder', 'mocha');
+        var mochaPath = path.join(node_modulesFolder, 'node_modules', 'mocha');
         var Mocha = new require(mochaPath);
         return Mocha;
     } catch (ex) {

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -80,7 +80,17 @@ function logError() {
 
 function detectMocha(projectFolder) {
     try {
-        var mochaPath = path.join(projectFolder, 'node_modules', 'mocha');
+        // use mocha.json's path value for node modules path if it is specified
+        var node_modulesFolder = projectFolder;
+        var mochaJsonPath = path.join(node_modulesFolder, 'test', 'mocha.json');
+        if (fs.existsSync(mochaJsonPath)) {
+          var opt = require(mochaJsonPath);
+          if (opt && opt.path) {
+            node_modulesFolder = opt.path;
+          }
+        }
+
+        var mochaPath = path.join(node_modulesFolder, 'node_modulesFolder', 'mocha');
         var Mocha = new require(mochaPath);
         return Mocha;
     } catch (ex) {

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -86,7 +86,7 @@ function detectMocha(projectFolder) {
         if (fs.existsSync(mochaJsonPath)) {
           var opt = require(mochaJsonPath);
           if (opt && opt.path) {
-            node_modulesFolder = opt.path;
+            node_modulesFolder = path.resolve(projectFolder, opt.path);
           }
         }
 


### PR DESCRIPTION
-supports configuring node_modules location when running mocha tests. Right now, it looks for it under project home directory. This one checks it from mocha.json with 'path' as key and if it is specified, will use that value, if not, will the project home directory.