### PR TITLE
Limit Depth of created dependecy nodes

### DIFF
--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -22,13 +22,18 @@ using System.Linq;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NodeModules : AbstractNodeModules {
-        private Dictionary<string, ModuleInfo> _allModules;
         private static readonly string[] _ignoredDirectories = { @"\.bin", @"\.staging" };
 
-        public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0) {
-            var modulesBase = Path.Combine(parent.Path, NodejsConstants.NodeModulesFolder);
+        private readonly Dictionary<string, ModuleInfo> _allModules;
 
+        public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0, int maxDepth = 1) {
             _allModules = allModulesToDepth ?? new Dictionary<string, ModuleInfo>();
+
+            //if (depth >= maxDepth) {
+          //      return;
+          //  }
+
+            var modulesBase = Path.Combine(parent.Path, NodejsConstants.NodeModulesFolder);
 
             // This is the first time NodeModules is being created.
             // Iterate through directories to add everything that's known to be top-level.

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -29,9 +29,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0, int maxDepth = 1) {
             _allModules = allModulesToDepth ?? new Dictionary<string, ModuleInfo>();
 
-            //if (depth >= maxDepth) {
-          //      return;
-          //  }
+            if (depth >= maxDepth) {
+                return;
+            }
 
             var modulesBase = Path.Combine(parent.Path, NodejsConstants.NodeModulesFolder);
 

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -25,7 +25,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             string fullPathToRootDirectory,
             bool showMissingDevOptionalSubPackages,
             Dictionary<string, ModuleInfo> allModules = null,
-            int depth = 0) {
+            int depth = 0,
+            int maxDepth = 1) {
             Path = fullPathToRootDirectory;
             var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
             try {
@@ -45,7 +46,7 @@ The following error was reported:
             }
 
             try {
-                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth);
+                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth, maxDepth);
             }  catch (PathTooLongException) {
                 // otherwise we fail to create it completely...
             }


### PR DESCRIPTION
**Bug**
Right now, we end up parsing the entire node dependency tree and creating objects to represent every dependency in it. This uses a lot of memory and a lot of time during boot. Here's a simple, new Express 4 app for example:

![image](https://cloud.githubusercontent.com/assets/12821956/15343228/e86a4aaa-1c4f-11e6-83d7-d64be45438a7.png)


The plus side of this extra computation is that we allow users to explore the entire module dependency tree in VS directly.

**Fix**
All these operations are negatively impacting user experience, especially when loading projects with lots of dependencies (such as the eslint source.) I also am not convinced that browsing the dependencies of your dependencies is actually useful.

This fix limits the depth to which we create dependency nodes to 1 (only root dependencies are shown). Memory usage and boot time are much improved:

![image](https://cloud.githubusercontent.com/assets/12821956/15343247/119c4a0e-1c50-11e6-9d1b-7e2df5dae05c.png)


The change does remove some existing behavior, so if anyone feels strongly about this, we can discuss this further. The alternative is something like #869.