### PR TITLE
Fix potential leak/null reference when switching projects

### DIFF
--- a/Common/Product/SharedProject/CommonFolderNode.cs
+++ b/Common/Product/SharedProject/CommonFolderNode.cs
@@ -239,10 +239,10 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         public override void Close() {
-            base.Close();
-
             // make sure this thing isn't hanging around...
             ProjectMgr.TryDeactivateSymLinkWatcher(this);
+
+            base.Close();
         }
 
         /// <summary>


### PR DESCRIPTION
**Bug**
We can end up hitting a null dereference or leaking a node when switching projects for a project with a symlink watcher. This happens on `CommonProjectNode` because we null out the `ItemNode` before destroying the symlink watcher.

**Fix**
Reorder the operations. We should destory the symlink watcher and then null out the nodes.