### PR TITLE
Fix hang when sending debug commands after Node program runs to completion

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
@@ -58,6 +58,8 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                 _connection.SendMessage(command.ToString());
                 cancellationToken.ThrowIfCancellationRequested();
 
+                cancellationToken.Register(() => promise.TrySetCanceled(), false);
+
                 JObject response = await promise.Task.ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/Nodejs/Product/Nodejs/Debugger/Extensions.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Extensions.cs
@@ -15,163 +15,11 @@
 //*********************************************************//
 
 using System;
-using System.Diagnostics;
-using System.IO;
-using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.NodejsTools.Debugger {
     static class Extensions {
-        /// <summary>
-        /// Reads a string from the socket which is encoded as:
-        ///     U, byte count, bytes 
-        ///     A, byte count, ASCII
-        ///     
-        /// Which supports either UTF-8 or ASCII strings.
-        /// </summary>
-        internal static string ReadString(this Socket socket) {
-            byte[] cmd_buffer = new byte[4];
-            if (socket.Receive(cmd_buffer, 1, SocketFlags.None) == 1) {
-                if (cmd_buffer[0] == 'N') {
-                    // null string
-                    return null;
-                }
-                bool isUnicode = cmd_buffer[0] == 'U';
-
-                if (socket.Receive(cmd_buffer) == 4) {
-                    int filenameLen = BitConverter.ToInt32(cmd_buffer, 0);
-                    byte[] buffer = new byte[filenameLen];
-                    int bytesRead = 0;
-                    while (bytesRead != filenameLen) {
-                        bytesRead += socket.Receive(buffer, bytesRead, filenameLen - bytesRead, SocketFlags.None);
-                    } 
-
-                    if (isUnicode) {
-                        return Encoding.UTF8.GetString(buffer);
-                    } else {
-                        char[] chars = new char[buffer.Length];
-                        for (int i = 0; i < buffer.Length; i++) {
-                            chars[i] = (char)buffer[i];
-                        }
-                        return new string(chars);
-                    }
-                } else {
-                    Debug.Assert(false, "Failed to read length");
-                }
-            } else {
-                Debug.Assert(false, "Failed to read unicode/ascii byte");
-            }
-            return null;
-        }
-
-        internal static int ReadInt(this Socket socket) {
-            byte[] cmd_buffer = new byte[4];
-            if (socket.Receive(cmd_buffer) == 4) {
-                return BitConverter.ToInt32(cmd_buffer, 0);
-            }
-            throw new SocketException();
-        }
-
-        /// <summary>
-        /// Replaces \uxxxx with the actual unicode char for a prettier display in local variables.
-        /// </summary>
-        public static string FixupEscapedUnicodeChars(this string text) {
-            StringBuilder buf = null;
-            int i = 0;
-            int l = text.Length;
-            int val;
-            while (i < l) {
-                char ch = text[i++];
-                if (ch == '\\') {
-                    if (buf == null) {
-                        buf = new StringBuilder(text.Length);
-                        buf.Append(text, 0, i - 1);
-                    }
-
-                    if (i >= l) {
-                        return text;
-                    }
-                    ch = text[i++];
-
-                    if (ch == 'u' || ch == 'U') {
-                        int len = (ch == 'u') ? 4 : 8;
-                        int max = 16;
-                        if (TryParseInt(text, i, len, max, out val)) {
-                            buf.Append((char)val);
-                            i += len;
-                        } else {
-                            return text;
-                        }
-                    } else {
-                        buf.Append("\\");
-                        buf.Append(ch);
-                    }
-                } else if (buf != null) {
-                    buf.Append(ch);
-                }
-            }
-
-            if (buf != null) {
-                return buf.ToString();
-            }
-            return text;
-        }
-
-
-        private static bool TryParseInt(string text, int start, int length, int b, out int value) {
-            value = 0;
-            if (start + length > text.Length) {
-                return false;
-            }
-            for (int i = start, end = start + length; i < end; i++) {
-                int onechar;
-                if (HexValue(text[i], out onechar) && onechar < b) {
-                    value = value * b + onechar;
-                } else {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private static bool HexValue(char ch, out int value) {
-            switch (ch) {
-                case '0':
-                case '\x660': value = 0; break;
-                case '1':
-                case '\x661': value = 1; break;
-                case '2':
-                case '\x662': value = 2; break;
-                case '3':
-                case '\x663': value = 3; break;
-                case '4':
-                case '\x664': value = 4; break;
-                case '5':
-                case '\x665': value = 5; break;
-                case '6':
-                case '\x666': value = 6; break;
-                case '7':
-                case '\x667': value = 7; break;
-                case '8':
-                case '\x668': value = 8; break;
-                case '9':
-                case '\x669': value = 9; break;
-                default:
-                    if (ch >= 'a' && ch <= 'z') {
-                        value = ch - 'a' + 10;
-                    } else if (ch >= 'A' && ch <= 'Z') {
-                        value = ch - 'A' + 10;
-                    } else {
-                        value = -1;
-                        return false;
-                    }
-                    break;
-            }
-            return true;
-        }
-
         internal static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout, CancellationToken token = default(CancellationToken)) {
             var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
             linkedTokenSource.CancelAfter(timeout);
@@ -182,18 +30,12 @@ namespace Microsoft.NodejsTools.Debugger {
             return await task.ConfigureAwait(false);
         }
 
-        internal static async Task<string> ReadLineBlockAsync(this StreamReader streamReader, int length) {
-            var buffer = new char[length];
-
-            int count = await streamReader.ReadBlockAsync(buffer, 0, length).ConfigureAwait(false);
-            if (count == 0) {
-                var errorMessage = string.Format("Unable to read {0} bytes from stream.", length);
-                throw new InvalidDataException(errorMessage);
-            }
-
-            // Get UTF-8 string
-            byte[] bytes = streamReader.CurrentEncoding.GetBytes(buffer, 0, count);
-            return Encoding.UTF8.GetString(bytes);
+        internal static async Task WaitAsync(this Task task, TimeSpan timeout, CancellationToken token = default(CancellationToken)) {
+            // Same logic as above but for a regular Task without a return value.
+            var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            linkedTokenSource.CancelAfter(timeout);
+            await task.ContinueWith(t => { }, linkedTokenSource.Token).ConfigureAwait(false);
+            await task.ConfigureAwait(false);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/NodeBreakpointBinding.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeBreakpointBinding.cs
@@ -100,8 +100,8 @@ namespace Microsoft.NodejsTools.Debugger {
 
         public bool Unbound { get; set; }
 
-        public async Task Remove() {
-            await Process.RemoveBreakpointAsync(this).ConfigureAwait(false);
+        public Task Remove() {
+            return Process.RemoveBreakpointAsync(this).WaitAsync(System.TimeSpan.FromSeconds(2));
         }
 
         public uint GetHitCount() {


### PR DESCRIPTION
Issue #935

##### Bug
Run a node program to completion. We pause on the last line before exiting. Node is still running at this point. Running a debug command at this point (such as pause or remove breakpoint) can freeze VS since we never receive responses back from the Node debugger.

##### Fix
This change has two fixes:

* Add an explicit timeout when removing breakpoints. We have an identical timeout when adding breakpoints so it probably makes sense to add this.
* On our low level send calls, register the cancellation token to cancel the promise.

A better fix would be just to never send requests to node after we run to the last line, but it is not clear how we can detect this without a wrapper. The debug protocol does not seem to emit any events about this and Node is still running.

Also deleted a bunch of unused NodejsTools extension functions while I was in the file.

closes #935