### PR TITLE
Fix for Issue #974. Double clicking on Mocha tests opens external editor.

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -20,8 +20,8 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
                         test: t.fullTitle(),
                         suite: suite.fullTitle(),
                         file: testFile,
-                        line: 0,
-                        column: 0
+                        line: 1,
+                        column: 1
                     });
                 });
             }


### PR DESCRIPTION
Issue #974

##### Bug

Double clicking in Mocha test causes JavaScript file to open in external editor.

##### Fix

Jumping to line: 0, column: 0 seems to cause this. Changed default to line: 1, column: 1.