### PR TITLE
Fixed "ReferenceError: dbg is not defined" error when 'dbg' global va…

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -1,7 +1,15 @@
 var fs = require('fs');
 var path = require('path');
+var vm = require('vm');
 
 var find_tests = function (testFileList, discoverResultFile) {
+    var debug;
+    try {
+        debug = vm.runInDebugContext('Debug');
+    } catch (ex) {
+        console.error("NTVS_ERROR:", ex);
+    }
+
     var testList = [];
     testFileList.split(';').forEach(function (testFile) {
         var testCases;
@@ -13,16 +21,16 @@ var find_tests = function (testFileList, discoverResultFile) {
             return;
         }
         for (var test in testCases) {
-            var line = 0;
-            var column = 0;
-            if (dbg != undefined) {
+            var line = 1; // line 0 doesn't exist in editor
+            var column = 1;
+            if (debug !== undefined) {
                 try {
-                    var funcDetails = dbg.Debug.findFunctionSourceLocation(testCases[test]);
+                    var funcDetails = debug.findFunctionSourceLocation(testCases[test]);
                     if (funcDetails != undefined) {
                         //v8 is 0 based line numbers, editor is 1 based
                         line = parseInt(funcDetails.line) + 1;
-                        //v8 and editor are both 1 based column numbers, no adjustment necessary
-                        column = parseInt(funcDetails.column);
+                        //v8 is 0 based column numbers, editor is 1 based
+                        column = parseInt(funcDetails.column) + 1;
                     }
                 } catch (e) {
                     //If we take an exception mapping the source line, simply fallback to unknown source map 

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -122,7 +122,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
 
         private string EvaluateJavaScript(string nodeExePath, string testFile, string discoverResultFile, IMessageLogger logger, string workingDirectory) {
             workingDirectory = workingDirectory.TrimEnd(new char['\\']);
-            string arguments = "--expose_debug_as=dbg " + WrapWithQuotes(_findTestsScriptFile)
+            string arguments = WrapWithQuotes(_findTestsScriptFile)
                 + " " + Name +
                 " " + WrapWithQuotes(testFile) +
                 " " + WrapWithQuotes(discoverResultFile) +


### PR DESCRIPTION
Issue #977

##### Bug

1) If the 'dbg' global variable is not defined, the find_tests function throws "ReferenceError: dbg is not defined" rather than falling back to using default line and column numbers.

2) The default line and column numbers are 0 rather than 1. This would cause issues when the test was opened/navigated to (open .js file in external editor, see #974).

3) The function is returning 0 based column numbers rather than 1 based as the editor expects.

4) Requiring Node to be started with the "--expose_debug_as=dbg" pollutes the global namespace and makes it a little more tricky to test. The debug context can be alternatively accessed via the following:
var debug = vm.runInDebugContext('Debug');

##### Fix

Changed to use vm.runInDebugContext('Debug') rather than 'dbg' global variable.
Return 1 based column and line numbers.
No need to start Node process with "--expose_debug_as=dbg" .