### PR TITLE
Let JavaScript test frameworks use 0-based line and column numbers

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -21,16 +21,14 @@ var find_tests = function (testFileList, discoverResultFile) {
             return;
         }
         for (var test in testCases) {
-            var line = 1; // line 0 doesn't exist in editor
-            var column = 1;
+            var line = 0;
+            var column = 0;
             if (debug !== undefined) {
                 try {
                     var funcDetails = debug.findFunctionSourceLocation(testCases[test]);
                     if (funcDetails != undefined) {
-                        //v8 is 0 based line numbers, editor is 1 based
-                        line = parseInt(funcDetails.line) + 1;
-                        //v8 is 0 based column numbers, editor is 1 based
-                        column = parseInt(funcDetails.column) + 1;
+                        line = funcDetails.line; // 0 based
+                        column = funcDetails.column; // 0 based
                     }
                 } catch (e) {
                     //If we take an exception mapping the source line, simply fallback to unknown source map 

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -84,7 +84,9 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
             List<DiscoveredTest> discoveredTests = (List<DiscoveredTest>)JsonConvert.DeserializeObject(testInfo, typeof(List<DiscoveredTest>));
             if (discoveredTests != null) {
                 foreach (DiscoveredTest discoveredTest in discoveredTests) {
-                    NodejsTestInfo test = new NodejsTestInfo(discoveredTest.File, discoveredTest.Test, Name, discoveredTest.Line, discoveredTest.Column);
+                    var line = discoveredTest.Line + 1;
+                    var column = discoveredTest.Column + 1;
+                    NodejsTestInfo test = new NodejsTestInfo(discoveredTest.File, discoveredTest.Test, Name, line, column);
                     testCases.Add(test);
                 }
             }


### PR DESCRIPTION
##### Bug

v8 debugger and TypeScript use 0-based line/column numbers, but Visual Studio uses 1-based. It was easy to forget to add 1 when passing test locations back to Visual Studio.

##### Fix

Do the translation inside Visual Studio where the 1-based line and column numbers are actually used.