### PR TITLE
Reorder TryDeactivateSymLinkWatcher in call to prevent leak/crash

### DIFF
--- a/Common/Product/SharedProject/CommonFolderNode.cs
+++ b/Common/Product/SharedProject/CommonFolderNode.cs
@@ -232,10 +232,10 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         public override void Remove(bool removeFromStorage) {
-            base.Remove(removeFromStorage);
-
             // if we were a symlink folder, we need to stop watching now.
             ProjectMgr.TryDeactivateSymLinkWatcher(this);
+
+            base.Remove(removeFromStorage);
         }
 
         public override void Close() {

--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -1567,7 +1567,6 @@ namespace Microsoft.VisualStudioTools.Project {
             firstChild = null;
             lastChild = null;
             nextSibling = null;
-            itemNode = null;
         }
 
         /// <summary>


### PR DESCRIPTION
This is the same fix as #967, reordering function calls to make sure we deactive the symlinkwatcher before destroying the FolderNode. The current order results in an error when deleting folders from a project.

