### PR TITLE
Add support for Tape test framework

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1311,6 +1311,9 @@
     <None Include="Theme\Microsoft.NodejsTools.theme.v12.0.pkgdef" />
     <None Include="Theme\Microsoft.NodejsTools.theme.v14.0.pkgdef" />
     <None Include="Theme\Microsoft.NodejsTools.theme.v15.0.pkgdef" />
+    <Content Include="TestFrameworks\Tape\tape.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="VSTemplateStore.pkgdef">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -875,6 +875,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <ZipItem Include="Templates\Files\TapeUnitTest\UnitTest.js" />
+    <ZipItem Include="Templates\Files\TapeUnitTest\UnitTest.vstemplate" />
+    <ZipItem Include="Templates\Files\TypeScriptTapeUnitTest\UnitTest.vstemplate" />
+    <ZipItem Include="Templates\Files\TypeScriptTapeUnitTest\UnitTest.ts" />
     <Content Include="Templates\VS_Nodejs.item.vstman">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -1698,7 +1702,6 @@
     <ZipProject Include="ProjectTemplates\TypeScriptAzureNodejsWorkerRole\startup.ts" />
     <ZipProject Include="ProjectTemplates\TypeScriptAzureWebRole\server.ts" />
   </ItemGroup>
-  <ItemGroup />
   <PropertyGroup>
     <!--
     To specify a different registry root to register your package, uncomment the TargetRegistryRoot

--- a/Nodejs/Product/Nodejs/Templates/Files/TapeUnitTest/UnitTest.js
+++ b/Nodejs/Product/Nodejs/Templates/Files/TapeUnitTest/UnitTest.js
@@ -1,0 +1,12 @@
+﻿var test = require("tape");
+
+test("Test A", function (t) {
+    t.plan(1);
+    t.ok(true, "This shouldn't fail");
+});
+
+test("Test B", function (t) {
+    t.plan(2);
+    t.ok(true, "This shouldn't fail");
+    t.equal(1, 2, "This should fail");
+});

--- a/Nodejs/Product/Nodejs/Templates/Files/TapeUnitTest/UnitTest.vstemplate
+++ b/Nodejs/Product/Nodejs/Templates/Files/TapeUnitTest/UnitTest.vstemplate
@@ -1,0 +1,18 @@
+﻿<VSTemplate Version="2.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="3055" />
+    <Description Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="3056" />
+    <Icon Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="403" />
+    <ProjectType>Node.js</ProjectType>
+    <DefaultName>UnitTest.js</DefaultName>
+    <SortOrder>340</SortOrder>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectItem SubType="Code" TargetFileName="$fileinputname$.$fileinputextension$" ReplaceParameters="true">UnitTest.js</ProjectItem>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.NodejsTools.ProjectWizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.NodejsTools.ProjectWizard.UnitTestFileWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>Tape</WizardData>
+</VSTemplate>

--- a/Nodejs/Product/Nodejs/Templates/Files/TypeScriptMochaUnitTest/UnitTest.ts
+++ b/Nodejs/Product/Nodejs/Templates/Files/TypeScriptMochaUnitTest/UnitTest.ts
@@ -7,6 +7,6 @@ describe("Test Suite 1", () => {
 
     it("Test B", () => {
         assert.ok(1 === 1, "This shouldn't fail");
-        assert.ok(false, "This should fail ts");
+        assert.ok(false, "This should fail");
     });
 });

--- a/Nodejs/Product/Nodejs/Templates/Files/TypeScriptTapeUnitTest/UnitTest.ts
+++ b/Nodejs/Product/Nodejs/Templates/Files/TypeScriptTapeUnitTest/UnitTest.ts
@@ -1,0 +1,12 @@
+﻿import test = require("tape");
+
+test("Test A", function (t) {
+    t.plan(1);
+    t.ok(true, "This shouldn't fail");
+});
+
+test("Test B", function (t) {
+    t.plan(2);
+    t.ok(true, "This shouldn't fail");
+    t.equal(1, 2, "This should fail");
+});

--- a/Nodejs/Product/Nodejs/Templates/Files/TypeScriptTapeUnitTest/UnitTest.vstemplate
+++ b/Nodejs/Product/Nodejs/Templates/Files/TypeScriptTapeUnitTest/UnitTest.vstemplate
@@ -1,0 +1,18 @@
+﻿<VSTemplate Version="2.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="3057" />
+    <Description Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="3058" />
+    <Icon Package="{2ffe45c4-5c73-493c-b187-f2e955ff875e}" ID="3" />
+    <ProjectType>Node.js</ProjectType>
+    <DefaultName>UnitTest.ts</DefaultName>
+    <SortOrder>350</SortOrder>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectItem SubType="Code" TargetFileName="$fileinputname$.$fileinputextension$" ReplaceParameters="true">UnitTest.ts</ProjectItem>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.NodejsTools.ProjectWizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.NodejsTools.ProjectWizard.UnitTestFileWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>Tape</WizardData>
+</VSTemplate>

--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -1,0 +1,75 @@
+var fs = require('fs');
+var path = require('path');
+
+function find_tests(testFileList, discoverResultFile, projectFolder) {
+    var test = findTape(projectFolder);
+    if (test === null) {
+        console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
+        return;
+    }
+    
+    var harness = test.getHarness({ exit: false });
+    var tests = harness["_tests"];
+
+    var count = 0;
+    var testList = [];
+    testFileList.split(';').forEach(function (testFile) {
+
+        var testCases;
+        process.chdir(path.dirname(testFile));
+        try {
+            testCases = require(testFile);
+        } catch (ex) {
+            console.error("NTVS_ERROR:", ex, "in", testFile);
+            return;
+        }
+
+        for (; count < tests.length; count++) {
+            var t = tests[count];
+            t._skip = true; // Don't run tests.
+            testList.push({
+                test: t.name,
+                suite: '',
+                file: testFile,
+                line: 1,
+                column: 1
+            });
+        }
+    });
+
+    var fd = fs.openSync(discoverResultFile, 'w');
+    fs.writeSync(fd, JSON.stringify(testList));
+    fs.closeSync(fd);
+};
+module.exports.find_tests = find_tests;
+
+function run_tests(testName, testFile, workingFolder, projectFolder) {
+    var testCases;
+    process.chdir(path.dirname(testFile));
+    try {
+        testCases = require(testFile);
+    } catch (ex) {
+        console.error("NTVS_ERROR:", ex, "in", testFile);
+        return;
+    }
+
+    try {
+        var test = findTape(projectFolder);
+        if (test === null) {
+            console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
+            return;
+        }
+
+        var harness = test.getHarness();
+        harness.only(testName);
+    } catch (ex) {
+        console.error("NTVS_ERROR:", ex);
+        return;
+    }
+}
+module.exports.run_tests = run_tests;
+
+function findTape(projectFolder) {
+    var tapePath = path.join(projectFolder, 'node_modules', 'tape');
+    return require(tapePath);
+}

--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -31,8 +31,8 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
                 test: t.name,
                 suite: '',
                 file: testFile,
-                line: 1,
-                column: 1
+                line: 0,
+                column: 0
             });
         }
     });

--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -5,7 +5,9 @@ var path = require('path');
 
 function find_tests(testFileList, discoverResultFile, projectFolder) {
     var test = findTape(projectFolder);
-    if (test === null) return;
+    if (test === null) {
+        return;
+    }
     
     var harness = test.getHarness({ exit: false });
     var tests = harness["_tests"];
@@ -37,16 +39,20 @@ module.exports.find_tests = find_tests;
 
 function run_tests(testName, testFile, workingFolder, projectFolder) {
     var testCases = loadTestCases(testFile);
-    if (testCases === null) return;
+    if (testCases === null) {
+        return;
+    }
 
     var test = findTape(projectFolder);
-    if (test === null) return;
+    if (test === null) {
+        return;
+    }
 
     try {
         var harness = test.getHarness();
         harness.only(testName);
-    } catch (ex) {
-        console.error("NTVS_ERROR:", ex);
+    } catch (e) {
+        logError("Error running test:", testName, "in", testFile, e);
         return;
     }
 }
@@ -57,7 +63,8 @@ function loadTestCases(testFile) {
         process.chdir(path.dirname(testFile));
         return require(testFile);
     } catch (e) {
-        console.error("NTVS_ERROR:", e, "in", testFile);
+        // we would like continue discover other files, so swallow, log and continue;
+        logError("Test discovery error:", e, "in", testFile);
         return null;
     }
 }
@@ -67,7 +74,13 @@ function findTape(projectFolder) {
         var tapePath = path.join(projectFolder, 'node_modules', 'tape');
         return require(tapePath);
     } catch (e) {
-        console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
+        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install tape\" via the Node.js interactive window.");
         return null;
     }
+}
+
+function logError() {
+    var errorArgs = Array.prototype.slice.call(arguments);
+    errorArgs.unshift("NTVS_ERROR:");
+    console.error.apply(console, errorArgs);
 }

--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -74,7 +74,7 @@ function findTape(projectFolder) {
         var tapePath = path.join(projectFolder, 'node_modules', 'tape');
         return require(tapePath);
     } catch (e) {
-        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install tape\" via the Node.js interactive window.");
+        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Tape can be installed locally with the npm manager via solution explorer or with \".npm install tape\" via the Node.js interactive window.");
         return null;
     }
 }

--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -1,12 +1,11 @@
+"use strict";
+
 var fs = require('fs');
 var path = require('path');
 
 function find_tests(testFileList, discoverResultFile, projectFolder) {
     var test = findTape(projectFolder);
-    if (test === null) {
-        console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
-        return;
-    }
+    if (test === null) return;
     
     var harness = test.getHarness({ exit: false });
     var tests = harness["_tests"];
@@ -14,19 +13,12 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
     var count = 0;
     var testList = [];
     testFileList.split(';').forEach(function (testFile) {
-
-        var testCases;
-        process.chdir(path.dirname(testFile));
-        try {
-            testCases = require(testFile);
-        } catch (ex) {
-            console.error("NTVS_ERROR:", ex, "in", testFile);
-            return;
-        }
+        var testCases = loadTestCases(testFile);
+        if (testCases === null) return; // continue to next testFile
 
         for (; count < tests.length; count++) {
             var t = tests[count];
-            t._skip = true; // Don't run tests.
+            t._skip = true; // don't run tests
             testList.push({
                 test: t.name,
                 suite: '',
@@ -44,22 +36,13 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
 module.exports.find_tests = find_tests;
 
 function run_tests(testName, testFile, workingFolder, projectFolder) {
-    var testCases;
-    process.chdir(path.dirname(testFile));
-    try {
-        testCases = require(testFile);
-    } catch (ex) {
-        console.error("NTVS_ERROR:", ex, "in", testFile);
-        return;
-    }
+    var testCases = loadTestCases(testFile);
+    if (testCases === null) return;
+
+    var test = findTape(projectFolder);
+    if (test === null) return;
 
     try {
-        var test = findTape(projectFolder);
-        if (test === null) {
-            console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
-            return;
-        }
-
         var harness = test.getHarness();
         harness.only(testName);
     } catch (ex) {
@@ -69,7 +52,22 @@ function run_tests(testName, testFile, workingFolder, projectFolder) {
 }
 module.exports.run_tests = run_tests;
 
+function loadTestCases(testFile) {
+    try {
+        process.chdir(path.dirname(testFile));
+        return require(testFile);
+    } catch (e) {
+        console.error("NTVS_ERROR:", e, "in", testFile);
+        return null;
+    }
+}
+
 function findTape(projectFolder) {
-    var tapePath = path.join(projectFolder, 'node_modules', 'tape');
-    return require(tapePath);
+    try {
+        var tapePath = path.join(projectFolder, 'node_modules', 'tape');
+        return require(tapePath);
+    } catch (e) {
+        console.error("NTVS_ERROR:", "Couldn't find 'tape' module relative to", projectFolder);
+        return null;
+    }
 }

--- a/Nodejs/Product/Nodejs/VSPackage.resx
+++ b/Nodejs/Product/Nodejs/VSPackage.resx
@@ -282,6 +282,18 @@
   <data name="3054" xml:space="preserve">
     <value>Dockerfile</value>
   </data>
+  <data name="3055" xml:space="preserve">
+    <value>JavaScript Tape UnitTest file</value>
+  </data>
+  <data name="3056" xml:space="preserve">
+    <value>A JavaScript Tape UnitTest file</value>
+  </data>
+  <data name="3057" xml:space="preserve">
+    <value>TypeScript Tape UnitTest file</value>
+  </data>
+  <data name="3058" xml:space="preserve">
+    <value>A TypeScript Tape UnitTest file</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>_BUILDROOT_\Nodejs\Product\Icons\SystemRegisteredICO\NodeJS.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Nodejs/Setup/NodejsTools/NodejsTools.wxs
+++ b/Nodejs/Setup/NodejsTools/NodejsTools.wxs
@@ -15,6 +15,7 @@
             <Directory Id="Dir_$(var.key)TestFrameworks" Name="TestFrameworks">
                 <Directory Id="Dir_$(var.key)TestFrameworksExportRunner" Name="ExportRunner" />
                 <Directory Id="Dir_$(var.key)TestFrameworksMocha" Name="Mocha" />
+                <Directory Id="Dir_$(var.key)TestFrameworksTape" Name="Tape" />
             </Directory>
             <Directory Id="Dir_$(var.key)InstallLocationScripts" Name="Scripts">
                 <Directory Id="Dir_$(var.key)InstallLocationScriptsTypings" Name="Typings">

--- a/Nodejs/Setup/NodejsTools/NodejsToolsFiles.proj
+++ b/Nodejs/Setup/NodejsTools/NodejsToolsFiles.proj
@@ -164,7 +164,11 @@
         <File Include="TestFrameworks\mocha\mocha.js">
             <InstallDirectory>TestFrameworksMocha</InstallDirectory>
         </File>
-
+        
+        <File Include="TestFrameworks\tape\tape.js">
+            <InstallDirectory>TestFrameworksTape</InstallDirectory>
+        </File>
+        
         <!-- Remote Debug files -->
         <File Include="License.html;
                        Debugger\RemoteDebug\RemoteDebug.js;

--- a/Nodejs/Setup/NodejsTools/NodejsToolsFiles.proj
+++ b/Nodejs/Setup/NodejsTools/NodejsToolsFiles.proj
@@ -57,8 +57,10 @@
         </File>
 
         <ItemTemplate Include="ItemTemplates\JavaScript\UnitTest.zip;
+                               ItemTemplates\JavaScript\TapeUnitTest.zip;
                                ItemTemplates\JavaScript\MochaUnitTest.zip;
                                ItemTemplates\JavaScript\TypeScriptUnitTest.zip;
+                               ItemTemplates\JavaScript\TypeScriptTapeUnitTest.zip;
                                ItemTemplates\JavaScript\TypeScriptMochaUnitTest.zip;
                                ItemTemplates\JavaScript\DockerfileTemplate.zip"/>
                                


### PR DESCRIPTION
Issue #986

##### Fix

This pull adds support for the Tape JavaScript test framework.

There are unit tests for this in a separate project:
https://github.com/jcansdale/TestFrameworksNTVS

It would be nice to integrate these at some point (they are in a .njsproj project). I don't know where it would make sense to put them? The test framework support is useful on its own though, so I've submitted this pull request without the tests.