### PR TITLE
Synchronize Node.js <-> TS settings

### DIFF
--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -33,7 +33,8 @@ namespace Microsoft.NodejsTools
         public const string NodejsNpmCmdSetString = "9F4B31B4-09AC-4937-A2E7-F4BC02BB7DBA";
         public const string NodejsProjectFactoryString = "3AF33F2E-1136-4D97-BBB7-1795711AC8B8";
         public const string NodejsBaseProjectFactoryString = "9092AA53-FB77-4645-B42D-1CCCA6BD08BD";
-        public const string TypeScriptLanguageInfoString = "87bdf188-e6e8-4fcf-a82a-9b8506e01847";
+        public const string TypeScriptLanguageInfoString = "4a0dddb5-7a95-4fbf-97cc-616d07737a77";
+        public const string TypeScriptDebuggerLanguageInfoString = "87bdf188-e6e8-4fcf-a82a-9b8506e01847";
         public const string JadeEditorFactoryString = "6CB69EF8-1329-4DC0-84B4-FA134EA59BE3";
         public const string DefaultLanguageServiceString = "{8239BEC4-EE87-11D0-8C98-00C04FC2AB22}";
 
@@ -60,7 +61,8 @@ namespace Microsoft.NodejsTools
         public static readonly Guid NodejsEditorFactory = new Guid(NodejsEditorFactoryString);
         public static readonly Guid NodejsDebugLanguage = new Guid(NodejsDebugLanguageString);
         public static readonly Guid NodejsNpmCmdSet = new Guid(NodejsNpmCmdSetString);
-        public static readonly Guid TypeScriptDebugLanguage = new Guid(TypeScriptLanguageInfoString);
+        public static readonly Guid TypeScriptLanguageInfo = new Guid(TypeScriptLanguageInfoString);
+        public static readonly Guid TypeScriptDebugLanguage = new Guid(TypeScriptDebuggerLanguageInfoString);
         
         public static readonly Guid ScriptDebugLanguage = new Guid(ScriptDebugLanguageString);
 

--- a/Nodejs/Product/Nodejs/LanguagePreferences.cs
+++ b/Nodejs/Product/Nodejs/LanguagePreferences.cs
@@ -14,14 +14,15 @@
 //
 //*********************************************************//
 
+using System;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.NodejsTools {
-    class LanguagePreferences : IVsTextManagerEvents2 {
-        LANGPREFERENCES _preferences;
+    class LanguagePreferences : IVsTextManagerEvents4 {
+        internal LANGPREFERENCES3 _preferences;
 
-        public LanguagePreferences(LANGPREFERENCES preferences) {
+        public LanguagePreferences(LANGPREFERENCES3 preferences) {
             _preferences = preferences;
         }
 
@@ -47,12 +48,18 @@ namespace Microsoft.NodejsTools {
             return VSConstants.S_OK;
         }
 
-        public int OnUserPreferencesChanged2(VIEWPREFERENCES2[] viewPrefs, FRAMEPREFERENCES2[] framePrefs, LANGPREFERENCES2[] langPrefs, FONTCOLORPREFERENCES2[] colorPrefs) {
-            if (langPrefs != null && langPrefs.Length > 0 && langPrefs[0].guidLang == this._preferences.guidLang) {
-                _preferences.IndentStyle = langPrefs[0].IndentStyle;
-                _preferences.fAutoListMembers = langPrefs[0].fAutoListMembers;
-                _preferences.fAutoListParams = langPrefs[0].fAutoListParams;
-                _preferences.fHideAdvancedAutoListMembers = langPrefs[0].fHideAdvancedAutoListMembers;
+        public int OnUserPreferencesChanged4(VIEWPREFERENCES3[] pViewPrefs, LANGPREFERENCES3[] pLangPrefs, FONTCOLORPREFERENCES2[] pColorPrefs) {
+            IVsTextManager4 textMgr = (IVsTextManager4)NodejsPackage.Instance.GetService(typeof(SVsTextManager));
+
+           if (pLangPrefs != null && pLangPrefs.Length > 0 && pLangPrefs[0].guidLang == _preferences.guidLang) {
+                _preferences.IndentStyle = pLangPrefs[0].IndentStyle;
+                _preferences.fAutoListMembers = pLangPrefs[0].fAutoListMembers;
+                _preferences.fAutoListParams = pLangPrefs[0].fAutoListParams;
+                _preferences.fHideAdvancedAutoListMembers = pLangPrefs[0].fHideAdvancedAutoListMembers;
+
+                // Synchronize settings back to TS language service
+                pLangPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
+                textMgr.SetUserPreferences4(null, pLangPrefs, null);
             }
             return VSConstants.S_OK;
         }

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -161,12 +161,8 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '11.0'">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -116,6 +116,12 @@
     <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
+    <Reference Include="microsoft.visualstudio.textmanager.interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
@@ -156,7 +162,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="'$(VSTarget)' != '11.0'">
       <EmbedInteropTypes>true</EmbedInteropTypes>
@@ -321,6 +327,10 @@
     </Compile>
     <Compile Include="NpmUI\PackageCatalogEntryViewModel.cs" />
     <Compile Include="Options\AnalysisLevel.cs" />
+    <Compile Include="Options\NodejsFormattingDialogPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Options\TypeScriptRegistrySwitches.cs" />
     <Compile Include="Options\TypingsInfoBar.cs" />
     <Compile Include="Options\NodejsDiagnosticsOptionsPage.cs">
       <SubType>Component</SubType>

--- a/Nodejs/Product/Nodejs/Options/NodejsDialogPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsDialogPage.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NodejsTools.Options {
             _category = category;
         }
 
-        internal void SaveBool(string name, bool value) {
+        internal virtual void SaveBool(string name, bool value) {
             SaveString(name, value.ToString());
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.NodejsTools.Options {
             return null;
         }
 
-        internal bool? LoadBool(string name) {
+        internal virtual bool? LoadBool(string name) {
             string res = LoadString(name);
             if (res == null) {
                 return null;

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingBracesOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingBracesOptionsPage.cs
@@ -14,12 +14,11 @@
 //
 //*********************************************************//
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NodejsTools.Options {
     [ComVisible(true)]
-    public class NodejsFormattingBracesOptionsPage : NodejsDialogPage {
+    public class NodejsFormattingBracesOptionsPage : NodejsFormattingDialogPage {
         private NodejsFormattingBracesOptionsControl _window;
 
         public NodejsFormattingBracesOptionsPage()
@@ -51,8 +50,8 @@ namespace Microsoft.NodejsTools.Options {
             BraceOnNewLineForFunctions = BraceOnNewLineForControlBlocks = false;
         }
 
-        private const string BraceOnNewLineForFunctionsSetting = "BraceOnNewLineForFunctions";
-        private const string BraceOnNewLineForControlBlocksSetting = "BraceOnNewLineForControlBlocks";
+        private const string BraceOnNewLineForFunctionsSetting = TypeScriptRegistrySwitches.PlaceOpenBraceOnNewLineForFunctions;
+        private const string BraceOnNewLineForControlBlocksSetting = TypeScriptRegistrySwitches.PlaceOpenBraceOnNewLineForControlBlocks;
 
         public override void LoadSettingsFromStorage(){
             // Load settings from storage.

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.NodejsTools.Options {
     public class NodejsFormattingDialogPage : NodejsDialogPage {
-        ISettingsManager _settingsManager;
+        private readonly ISettingsManager _settingsManager;
         private const string TypeScriptBaseName = "TextEditor.TypeScript.Specific.";
 
         public NodejsFormattingDialogPage(string category) : base(category) {

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
@@ -1,0 +1,60 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.NodejsTools.Options {
+    public class NodejsFormattingDialogPage : NodejsDialogPage {
+        ISettingsManager _settingsManager;
+        private const string TypeScriptBaseName = "TextEditor.TypeScript.Specific.";
+
+        public NodejsFormattingDialogPage(string category) : base(category) {
+            uint handle;
+            string registryRoot;
+            var registry = NodejsPackage.Instance.GetService(typeof(SLocalRegistry)) as ILocalRegistry4;
+            var regKey = registry.GetLocalRegistryRootEx((uint)__VsLocalRegistryType.RegType_UserSettings, out handle, out registryRoot);
+            _settingsManager = (ISettingsManager)NodejsPackage.Instance.GetService(typeof(SVsSettingsPersistenceManager));
+        }
+
+        internal override void SaveBool(string name, bool value) {
+            var keyName = GetKeyName(name);
+            var registryValue = value ? 1 : 0;
+            _settingsManager.SetValueAsync(keyName, registryValue, isMachineLocal: false);
+        }
+
+        internal override bool? LoadBool(string name) {
+            var value = _settingsManager.GetValueOrDefault<int?>(GetKeyName(name));
+            if (value == null) {
+                return null;
+            } else {
+                return value != 0;
+            }
+        }
+
+        private static string GetKeyName(string name) {
+            if (name.EndsWith("_TEMP")) {
+                name = name.Remove(name.Length - 5);
+            }
+            return TypeScriptBaseName + name;
+        }
+
+        [Guid("9B164E40-C3A2-4363-9BC5-EB4039DEF653")]
+        private class SVsSettingsPersistenceManager { }
+    }
+}

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingGeneralOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingGeneralOptionsPage.cs
@@ -14,12 +14,11 @@
 //
 //*********************************************************//
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NodejsTools.Options {
     [ComVisible(true)]
-    public class NodejsFormattingGeneralOptionsPage : NodejsDialogPage {
+    public class NodejsFormattingGeneralOptionsPage : NodejsFormattingDialogPage {
         private NodejsFormattingGeneralOptionsControl _window;
 
         public NodejsFormattingGeneralOptionsPage()
@@ -51,10 +50,10 @@ namespace Microsoft.NodejsTools.Options {
             FormatOnEnter = FormatOnSemiColon = FormatOnCloseBrace = FormatOnPaste = true;
         }
 
-        private const string FormatOnEnterSetting = "FormatOnEnter";
-        private const string FormatOnSemiColonSetting = "FormatOnSemiColon";
-        private const string FormatOnCloseBraceSetting = "FormatOnCloseBrace";
-        private const string FormatOnPasteSetting = "FormatOnPaste";
+        private const string FormatOnEnterSetting = TypeScriptRegistrySwitches.FormatCompletedLineOnEnter;
+        private const string FormatOnSemiColonSetting = TypeScriptRegistrySwitches.FormatCompletedStatementOnSemicolon;
+        private const string FormatOnCloseBraceSetting = TypeScriptRegistrySwitches.FormatCompletedBlockOnRightCurlyBrace;
+        private const string FormatOnPasteSetting = TypeScriptRegistrySwitches.FormatOnPaste;
 
         public override void LoadSettingsFromStorage(){
             // Load settings from storage.

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingSpacingOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingSpacingOptionsPage.cs
@@ -14,12 +14,11 @@
 //
 //*********************************************************//
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NodejsTools.Options {
     [ComVisible(true)]
-    public class NodejsFormattingSpacingOptionsPage : NodejsDialogPage {
+    public class NodejsFormattingSpacingOptionsPage : NodejsFormattingDialogPage {
         private NodejsFormattingSpacingOptionsControl _window;
 
         public NodejsFormattingSpacingOptionsPage()
@@ -54,12 +53,12 @@ namespace Microsoft.NodejsTools.Options {
             SpaceAfterOpeningAndBeforeClosingNonEmptyParens = false;
         }
 
-        private const string SpaceAfterCommaSetting = "SpaceAfterComma";
-        private const string SpaceAfterSemicolonInForSetting = "SpaceAfterSemicolonInFor";
-        private const string SpaceBeforeAndAfterBinaryOperatorSetting = "SpaceBeforeAndAfterBinaryOperator";
-        private const string SpaceAfterKeywordsInControlFlowSetting = "SpaceAfterKeywordsInControlFlow";
-        private const string SpaceAfterFunctionKeywordForAnonymousFunctionsSetting = "SpaceAfterFunctionKeywordForAnonymousFunctions";
-        private const string SpaceAfterOpeningAndBeforeClosingNonEmptyParensSetting = "SpaceAfterOpeningAndBeforeClosingNonEmptyParens";
+        private const string SpaceAfterCommaSetting = TypeScriptRegistrySwitches.InsertSpaceAfterCommaDelimiter;
+        private const string SpaceAfterSemicolonInForSetting = TypeScriptRegistrySwitches.InsertSpaceAfterSemicolonInForStatements;
+        private const string SpaceBeforeAndAfterBinaryOperatorSetting = TypeScriptRegistrySwitches.InsertSpaceBeforeAndAfterBinaryOperators;
+        private const string SpaceAfterKeywordsInControlFlowSetting = TypeScriptRegistrySwitches.InsertSpaceAfterKeywordsInControlFlowStatements;
+        private const string SpaceAfterFunctionKeywordForAnonymousFunctionsSetting = TypeScriptRegistrySwitches.InsertSpaceAfterFunctionKeywordForAnonymousFunctions;
+        private const string SpaceAfterOpeningAndBeforeClosingNonEmptyParensSetting = TypeScriptRegistrySwitches.InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis;
 
         public override void LoadSettingsFromStorage() {
             // Load settings from storage.

--- a/Nodejs/Product/Nodejs/Options/TypeScriptRegistrySwitches.cs
+++ b/Nodejs/Product/Nodejs/Options/TypeScriptRegistrySwitches.cs
@@ -1,0 +1,66 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+namespace Microsoft.NodejsTools.Options {
+    /// <summary>
+    /// Copied from  TypeScript\VS\LanguageService\TypeScriptLanguageService\ToolsOptions\Constants.cs
+    /// </summary>
+    public static class TypeScriptRegistrySwitches {
+        public const string TypeScriptLanguageServiceSubKey = "TypeScriptLanguageService";
+
+        public const string TerminateProcessOnException = "TerminateProcessOnException";
+        public const string SimulateCrashOnCompletionRequest = "SimulateCrashOnCompletionRequest";
+        public const string EnableDevMode = "EnableDevMode";
+        public const string CustomTypeScriptServicesFileLocation = "CustomTypeScriptServicesFileLocation";
+        public const string CustomDefaultLibraryLocation = "CustomDefaultLibraryLocation";
+        public const string CustomDefaultES6LibraryLocation = "CustomDefaultES6LibraryLocation";
+
+        public const string FormatCompletedLineOnEnter = "FormatCompletedLineOnEnter_TEMP"; // TODO: Remove "TEMP" when option is supported
+        public const string FormatCompletedStatementOnSemicolon = "FormatCompletedStatementOnSemicolon";
+        public const string FormatCompletedBlockOnRightCurlyBrace = "FormatCompletedBlockOnRightCurlyBrace";
+        public const string FormatOnPaste = "FormatOnPaste_TEMP"; // TODO: Remove "TEMP" when option is supported
+
+        public const string PlaceOpenBraceOnNewLineForFunctions = "PlaceOpenBraceOnNewLineForFunctions";
+        public const string PlaceOpenBraceOnNewLineForControlBlocks = "PlaceOpenBraceOnNewLineForControlBlocks";
+
+        public const string InsertSpaceAfterCommaDelimiter = "InsertSpaceAfterCommaDelimiter";
+        public const string InsertSpaceAfterSemicolonInForStatements = "InsertSpaceAfterSemicolonInForStatements";
+        public const string InsertSpaceBeforeAndAfterBinaryOperators = "InsertSpaceBeforeAndAfterBinaryOperators";
+        public const string InsertSpaceAfterKeywordsInControlFlowStatements = "InsertSpaceAfterKeywordsInControlFlowStatements";
+        public const string InsertSpaceAfterFunctionKeywordForAnonymousFunctions = "InsertSpaceAfterFunctionKeywordForAnonymousFunctions";
+        public const string InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis = "InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis";
+
+        public const string ShowVirtualProjectsInSolutionExplorerWhenNoSolution = "ShowVirtualProjectsInSolutionExplorerWhenNoSolution";
+        public const string ShowVirtualProjectsInSolutionExplorerWhenSolutionOpen = "ShowVirtualProjectsInSolutionExplorerWhenSolutionOpen";
+
+        public const string AutomaticallyCompileTypeScriptFilesWhenSavedWhenNoSolution = "AutomaticallyCompileTypeScriptFilesWhenSavedWhenNoSolution";
+        public const string UseAMDCodeGenerationForModulesThatAreNotPartOfAProject = "UseAMDCodeGenerationForModulesThatAreNotPartOfAProject";
+        public const string UseCommonJSCodeGenerationForModulesThatAreNotPartOfAProject = "UseCommonJSCodeGenerationForModulesThatAreNotPartOfAProject";
+        public const string UseSystemCodeGenerationForModulesThatAreNotPartOfAProject = "UseSystemCodeGenerationForModulesThatAreNotPartOfAProject";
+        public const string UseUMDCodeGenerationForModulesThatAreNotPartOfAProject = "UseUMDCodeGenerationForModulesThatAreNotPartOfAProject";
+        public const string UseES2015CodeGenerationForModulesThatAreNotPartOfAProject = "UseES2015CodeGenerationForModulesThatAreNotPartOfAProject";
+
+        public const string UseTypeScriptExperimental = "UseTypeScriptExperimental";
+
+        public const string UseJsxReactForFilesThatAreNotPartOfAProject = "UseJsxReactForFilesThatAreNotPartOfAProject";
+        public const string UseJsxPreserveForFilesThatAreNotPartOfAProject = "UseJsxPreserveForFilesThatAreNotPartOfAProject";
+
+        public const string ECMAScriptForFilesThatAreNotPartOfAProject = "ECMAScriptForFilesThatAreNotPartOfAProject";
+        public const string ShowGruntGulpDialogForAspNet = "ShowGruntGulpDialogForAspNet";
+
+        public const string CompletionChars = "CompletionChars";
+    }
+}


### PR DESCRIPTION
Synchronize Node.js <-> TS settings so that Node.js options are applied to Salsa. In particular this change:

* on startup, populate Node.js options with TS -> Node.js editor settings (general, scrollbars, and tabs)
* on Node.js editor settings changed, populate TS options
* use TS properties as backing for Node.js formatting settings

limitations:
* On TS options changed, will not sync back to Node.js
* On TS + Node.js options changed, will use Node.js options