### PR TITLE
Fix Interactive window .npm commands sometimes failing in VS 2015 update 3

### DIFF
--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -108,7 +108,7 @@ namespace Microsoft.NodejsTools.Repl {
                 }
 
                 // Otherwise, fall back to using fullname
-                string projectDirectory = Path.GetDirectoryName(dteProject.FullName);
+                string projectDirectory = string.IsNullOrEmpty(dteProject.FullName) ? null : Path.GetDirectoryName(dteProject.FullName);
                 if (!string.IsNullOrEmpty(projectDirectory)) {
                     projectNameToDirectoryDictionary.Add(projectName, Tuple.Create(projectDirectory, hierarchy));
                 }


### PR DESCRIPTION
##### Bug
If `dteProject.FullName` is empty when we execute an `.npm` command in the interactive window, an exception is thrown by `Path.GetDirectoryName(dteProject.FullName)` and we end up not doing anything. I believe this is caused by the typescript virtual project or something similar showing up in the list of projects that we iterate through.

##### fix
Check if `dteProject.FullName` is empty or null before calling `GetDirectoryName`