### PR TITLE
Fix argument exception on project reload in test container discoverer

### DIFF
--- a/Common/Product/TestAdapter/VsProjectExtensions.cs
+++ b/Common/Product/TestAdapter/VsProjectExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter {
         public static bool TryGetProjectPath(this IVsProject project, out string path) {
             ValidateArg.NotNull(project, "project");
 
-            return ErrorHandler.Succeeded(project.GetMkDocument(VSConstants.VSITEMID_ROOT, out path));
+            return ErrorHandler.Succeeded(project.GetMkDocument(VSConstants.VSITEMID_ROOT, out path)) && !string.IsNullOrEmpty(path);
         }
 
         private static string GetAggregateProjectTypeGuids(this IVsProject project) {

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -387,6 +387,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
                 string path;
                 if (e.Project.TryGetProjectPath(out path) &&
+                    !string.IsNullOrEmpty(path) &&
                     !_knownProjects.ContainsKey(path)) {
                     var dteProject = ((IVsHierarchy)e.Project).GetProject();
 

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -387,7 +387,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
                 string path;
                 if (e.Project.TryGetProjectPath(out path) &&
-                    !string.IsNullOrEmpty(path) &&
                     !_knownProjects.ContainsKey(path)) {
                     var dteProject = ((IVsHierarchy)e.Project).GetProject();
 
@@ -429,7 +428,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 ProjectInfo projectInfo;
                 string projectPath;
                 if (e.Project.TryGetProjectPath(out projectPath) &&
-                    !string.IsNullOrEmpty(projectPath) &&
                     _knownProjects.TryGetValue(projectPath, out projectInfo)) {
                     _knownProjects.Remove(projectPath);
 
@@ -551,7 +549,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
             string projectPath;
             if (project != null &&
                 project.TryGetProjectPath(out projectPath) &&
-                !string.IsNullOrEmpty(projectPath) &&
                 _knownProjects.TryGetValue(projectPath, out projectInfo) &&
                 projectInfo != null &&
                 projectInfo.HasRequestedContainers) {


### PR DESCRIPTION
**Bug**
- Unload project with test explorer open
- reload project with test explorer open

See exception in `TestContainerDiscoverer::OnProjectLoaded` in some cases. This is because `TryGetProjectPath` can return true even if the path it returns is null.

**Fix**
I fixed similar problems before with #856 and #888, so instead of adding yet another `string.IsNullOrEmpty` check, this change updates `TryGetProjectPath` to instead return false if the result path is `null` or empty. 