### PR TITLE
Remove empty email field from template package.json

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureNodejsApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureNodejsApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureStarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteAzureStarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteNodejsWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteNodejsWebApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteStarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AddWebSiteStarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
@@ -7,8 +7,7 @@
   },
   "description": "$projectname$",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "~4.9.0",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "worker.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureStarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureStarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
@@ -7,8 +7,7 @@
   },
   "description": "$projectname$",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "~4.9.0",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/ExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/ExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressWebRole/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressWebRole/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "server.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureStarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureStarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptStarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptStarterExpressApp/package.json
@@ -4,8 +4,7 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   },
   "dependencies": {
     "express": "3.4.4",

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/package.json
@@ -4,7 +4,6 @@
   "description": "$projectname$",
   "main": "app.js",
   "author": {
-    "name": "$username$",
-    "email": ""
+    "name": "$username$"
   }
 }


### PR DESCRIPTION
**Bug**
Our templates currently generate invalid `package.json` (according to the VS `package.json` schema checker) because the `email` field of `author` is always empty. This has been annoying me for a while.

**Fix**
Just remove the email field from the template entirely since it is optional.