### PR TITLE
#998 Fix slight clipping of IntelliSense selection area on some resolutions

### DIFF
--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.Designer.cs
@@ -28,14 +28,15 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NodejsIntellisenseOptionsControl));
             this.outerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.advancedOptionsLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this._nodejsES5IntelliSenseOptionsControl = new Microsoft.NodejsTools.Options.NodeLsIntellisenseOptionsControl();
-            this._salsaLsIntellisenseOptionsControl = new Microsoft.NodejsTools.Options.SalsaLsIntellisenseOptionsControl();
             this.intelliSenseModeLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this._intelliSenseModeDropdown = new System.Windows.Forms.ComboBox();
             this.intelliSenseModeLabel = new System.Windows.Forms.Label();
             this._analysisPreviewFeedbackLinkLabel = new System.Windows.Forms.LinkLabel();
             this._es5DeprecatedWarning = new System.Windows.Forms.Label();
             this.horizontalDivider = new System.Windows.Forms.Label();
+            this._nodejsES5IntelliSenseOptionsControl = new Microsoft.NodejsTools.Options.NodeLsIntellisenseOptionsControl();
+            this._salsaLsIntellisenseOptionsControl = new Microsoft.NodejsTools.Options.SalsaLsIntellisenseOptionsControl();
+            this._es6BottomPadding = new System.Windows.Forms.Label();
             toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.outerLayoutPanel.SuspendLayout();
             this.advancedOptionsLayoutPanel.SuspendLayout();
@@ -57,16 +58,6 @@
             this.advancedOptionsLayoutPanel.Controls.Add(this._salsaLsIntellisenseOptionsControl, 0, 0);
             this.advancedOptionsLayoutPanel.Name = "advancedOptionsLayoutPanel";
             // 
-            // _nodejsES5IntelliSenseOptionsControl
-            // 
-            resources.ApplyResources(this._nodejsES5IntelliSenseOptionsControl, "_nodejsES5IntelliSenseOptionsControl");
-            this._nodejsES5IntelliSenseOptionsControl.Name = "_nodejsES5IntelliSenseOptionsControl";
-            // 
-            // _salsaLsIntellisenseOptionsControl
-            // 
-            resources.ApplyResources(this._salsaLsIntellisenseOptionsControl, "_salsaLsIntellisenseOptionsControl");
-            this._salsaLsIntellisenseOptionsControl.Name = "_salsaLsIntellisenseOptionsControl";
-            // 
             // intelliSenseModeLayoutPanel
             // 
             resources.ApplyResources(this.intelliSenseModeLayoutPanel, "intelliSenseModeLayoutPanel");
@@ -74,6 +65,7 @@
             this.intelliSenseModeLayoutPanel.Controls.Add(this.intelliSenseModeLabel, 0, 0);
             this.intelliSenseModeLayoutPanel.Controls.Add(this._analysisPreviewFeedbackLinkLabel, 1, 2);
             this.intelliSenseModeLayoutPanel.Controls.Add(this._es5DeprecatedWarning, 1, 1);
+            this.intelliSenseModeLayoutPanel.Controls.Add(this._es6BottomPadding, 1, 3);
             this.intelliSenseModeLayoutPanel.Name = "intelliSenseModeLayoutPanel";
             // 
             // _intelliSenseModeDropdown
@@ -108,6 +100,22 @@
             this.horizontalDivider.ForeColor = System.Drawing.SystemColors.Control;
             this.horizontalDivider.Name = "horizontalDivider";
             // 
+            // _nodejsES5IntelliSenseOptionsControl
+            // 
+            resources.ApplyResources(this._nodejsES5IntelliSenseOptionsControl, "_nodejsES5IntelliSenseOptionsControl");
+            this._nodejsES5IntelliSenseOptionsControl.Name = "_nodejsES5IntelliSenseOptionsControl";
+            // 
+            // _salsaLsIntellisenseOptionsControl
+            // 
+            resources.ApplyResources(this._salsaLsIntellisenseOptionsControl, "_salsaLsIntellisenseOptionsControl");
+            this._salsaLsIntellisenseOptionsControl.Name = "_salsaLsIntellisenseOptionsControl";
+            // 
+            // _es6BottomPadding
+            // 
+            resources.ApplyResources(this._es6BottomPadding, "_es6BottomPadding");
+            this._es6BottomPadding.ForeColor = System.Drawing.SystemColors.Control;
+            this._es6BottomPadding.Name = "_es6BottomPadding";
+            // 
             // NodejsIntellisenseOptionsControl
             // 
             resources.ApplyResources(this, "$this");
@@ -137,5 +145,6 @@
         private System.Windows.Forms.ComboBox _intelliSenseModeDropdown;
         private System.Windows.Forms.LinkLabel _analysisPreviewFeedbackLinkLabel;
         private System.Windows.Forms.Label _es5DeprecatedWarning;
+        private System.Windows.Forms.Label _es6BottomPadding;
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
@@ -69,6 +69,11 @@ namespace Microsoft.NodejsTools.Options {
             bool isES6PreviewIntelliSense = _intelliSenseModeDropdown.SelectedItem == _ecmaScript6;
             _nodejsES5IntelliSenseOptionsControl.Visible = !isES6PreviewIntelliSense;
             _es5DeprecatedWarning.Visible = !isES6PreviewIntelliSense;
+
+            // Enables us to auto-size the IntelliSense selection area without reflowing the entire page
+            _es6BottomPadding.Visible = isES6PreviewIntelliSense;
+
+            // IntelliSense Options are controlled by the built-in language service in DEV15+
 #if DEV14
             _salsaLsIntellisenseOptionsControl.Visible = isES6PreviewIntelliSense;
 #else

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.resx
@@ -217,7 +217,7 @@
     <value>Top</value>
   </data>
   <data name="advancedOptionsLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 115</value>
+    <value>12, 140</value>
   </data>
   <data name="advancedOptionsLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>12, 12, 12, 0</value>
@@ -245,6 +245,9 @@
   </data>
   <data name="advancedOptionsLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_nodejsES5IntelliSenseOptionsControl" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_salsaLsIntellisenseOptionsControl" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="intelliSenseModeLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="intelliSenseModeLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -372,6 +375,30 @@
   <data name="&gt;&gt;_es5DeprecatedWarning.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="_es6BottomPadding.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_es6BottomPadding.Location" type="System.Drawing.Point, System.Drawing">
+    <value>192, 89</value>
+  </data>
+  <data name="_es6BottomPadding.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="_es6BottomPadding.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;_es6BottomPadding.Name" xml:space="preserve">
+    <value>_es6BottomPadding</value>
+  </data>
+  <data name="&gt;&gt;_es6BottomPadding.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_es6BottomPadding.Parent" xml:space="preserve">
+    <value>intelliSenseModeLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;_es6BottomPadding.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="intelliSenseModeLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -382,10 +409,10 @@
     <value>12, 0, 12, 12</value>
   </data>
   <data name="intelliSenseModeLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="intelliSenseModeLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>711, 89</value>
+    <value>711, 114</value>
   </data>
   <data name="intelliSenseModeLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -403,7 +430,7 @@
     <value>1</value>
   </data>
   <data name="intelliSenseModeLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_intelliSenseModeDropdown" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="intelliSenseModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_analysisPreviewFeedbackLinkLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_es5DeprecatedWarning" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_intelliSenseModeDropdown" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="intelliSenseModeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_analysisPreviewFeedbackLinkLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_es5DeprecatedWarning" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_es6BottomPadding" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="horizontalDivider.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -412,7 +439,7 @@
     <value>NoControl</value>
   </data>
   <data name="horizontalDivider.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 101</value>
+    <value>12, 126</value>
   </data>
   <data name="horizontalDivider.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>12, 0, 12, 0</value>
@@ -454,7 +481,7 @@
     <value>3</value>
   </data>
   <data name="outerLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>735, 720</value>
+    <value>735, 745</value>
   </data>
   <data name="outerLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -496,7 +523,7 @@
     <value>6, 6, 0, 6</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>735, 720</value>
+    <value>735, 745</value>
   </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>


### PR DESCRIPTION
Issue #998 

##### Bug
Options page was getting clipped under certain resolutions

##### Fix
Add a conditionally visible empty row below "Learn more link" that enables us to auto-size the IntelliSense selection area without reflowing the entire page