### PR TITLE
Restore gating for Pre Update 2 for NTVS 1.2

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -62,4 +62,17 @@
       </DirectorySearch>
     </Property>
   </Fragment>
+
+  <Fragment>
+    <Property Id="VS_IS_2015_PRE_UPDATE_2" Secure="yes">
+      <RegistrySearch Id="VSPrereleaseInstallDir" Root="HKLM" Key="Software\Microsoft\VisualStudio\$(var.VSTargetVersion)\Setup\VS" Name="ProductDir" Type="directory">
+        <DirectorySearch Id="VSPrereleaseInstallDir_Common7_IDE" Path="Common7\IDE" Depth="1">
+          <?if "$(var.VSTargetVersion)"="14.0" ?>
+          <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.25122.0"/>
+          <?endif ?>
+        </DirectorySearch>
+      </RegistrySearch>
+    </Property>
+  </Fragment>
+
 </Wix>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -23,7 +23,7 @@
 
         <!-- Conditions for install -->
         <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/> 
-        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 </Condition> 
+        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 OR Installed </Condition> 
         
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -22,6 +22,9 @@
         <Property Id="ARPPRODUCTICON">AddRemoveProgramsIcon</Property>
 
         <!-- Conditions for install -->
+        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/> 
+        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 </Condition> 
+        
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>
 

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -23,7 +23,7 @@
 
         <!-- Conditions for install -->
         <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/> 
-        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 OR Installed </Condition> 
+        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 </Condition> 
         
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -21,5 +21,5 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
-     <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String> 
+    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
 </WixLocalization>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -21,4 +21,5 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
+     <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String> 
 </WixLocalization>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
@@ -21,5 +21,5 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
-    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String> 
+    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
 </WixLocalization>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings15.0.wxl
@@ -21,4 +21,5 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
+    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please update to Visual Studio 2015 Update 2.</String> 
 </WixLocalization>


### PR DESCRIPTION
Adds back in gating removed by #1005. This change instead uses the PTVS gating logic.

Tested on RTM machine and on saw gating, plus tested on update 2 machine and saw that it was not gated.

closes #1003