### PR TITLE
Revert "IntelliSense InfoBar typings folder link should open built-in VS browser"

### DIFF
--- a/Nodejs/Product/Nodejs/Options/TypingsInfoBar.cs
+++ b/Nodejs/Product/Nodejs/Options/TypingsInfoBar.cs
@@ -22,7 +22,6 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudioTools;
 
 namespace Microsoft.NodejsTools.Options {
     public class TypingsInfoBar : IVsInfoBarUIEvents {
@@ -115,7 +114,7 @@ namespace Microsoft.NodejsTools.Options {
 
                 menuCommandService.GlobalInvoke(optionsCommand, intelliSenseOptionsGuidString);
             } else if (actionItem.Equals(_typingsFolderHyperlink)) {
-                CommonPackage.OpenVsWebBrowser(_provider, "http://go.microsoft.com/fwlink/?LinkID=808345");
+                Process.Start("http://go.microsoft.com/fwlink/?LinkID=808345");
             }
         }
 


### PR DESCRIPTION
Reverts Microsoft/nodejstools#1008

Turns out the built-in browser doesn't support relative links, so the experience is pretty poor unless we host our docs elsewhere. 