### PR TITLE
Use readonly members for debugger record types

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/BreakpointBindingEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/BreakpointBindingEventArgs.cs
@@ -17,25 +17,13 @@
 using System;
 
 namespace Microsoft.NodejsTools.Debugger {
-    class BreakpointBindingEventArgs : EventArgs {
-        private readonly NodeBreakpoint _breakpoint;
-        private readonly NodeBreakpointBinding _breakpointBinding;
+    sealed class BreakpointBindingEventArgs : EventArgs {
+        public readonly NodeBreakpoint Breakpoint;
+        public readonly NodeBreakpointBinding BreakpointBinding;
 
         public BreakpointBindingEventArgs(NodeBreakpoint breakpoint, NodeBreakpointBinding breakpointBinding) {
-            _breakpoint = breakpoint;
-            _breakpointBinding = breakpointBinding;
-        }
-
-        public NodeBreakpoint Breakpoint {
-            get {
-                return _breakpoint;
-            }
-        }
-
-        public NodeBreakpointBinding BreakpointBinding {
-            get {
-                return _breakpointBinding;
-            }
+            Breakpoint = breakpoint;
+            BreakpointBinding = breakpointBinding;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/BreakpointHitEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/BreakpointHitEventArgs.cs
@@ -17,25 +17,13 @@
 using System;
 
 namespace Microsoft.NodejsTools.Debugger {
-    class BreakpointHitEventArgs : EventArgs {
-        private readonly NodeBreakpointBinding _breakpointBinding;
-        private readonly NodeThread _thread;
+    sealed class BreakpointHitEventArgs : EventArgs {
+        public readonly NodeBreakpointBinding BreakpointBinding;
+        public readonly NodeThread Thread;
 
         public BreakpointHitEventArgs(NodeBreakpointBinding breakpoint, NodeThread thread) {
-            _breakpointBinding = breakpoint;
-            _thread = thread;
-        }
-
-        public NodeBreakpointBinding BreakpointBinding {
-            get {
-                return _breakpointBinding;
-            }
-        }
-
-        public NodeThread Thread {
-            get {
-                return _thread;
-            }
+            BreakpointBinding = breakpoint;
+            Thread = thread;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/ExceptionRaisedEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/ExceptionRaisedEventArgs.cs
@@ -18,32 +18,14 @@ using System;
 
 namespace Microsoft.NodejsTools.Debugger {
     class ExceptionRaisedEventArgs : EventArgs {
-        private readonly NodeException _exception;
-        private readonly NodeThread _thread;
-        private readonly bool _isUnhandled;
+        public readonly NodeThread Thread;
+        public readonly NodeException Exception;
+        public readonly bool IsUnhandled;
 
         public ExceptionRaisedEventArgs(NodeThread thread, NodeException exception, bool isUnhandled) {
-            _thread = thread;
-            _exception = exception;
-            _isUnhandled = isUnhandled;
-        }
-
-        public NodeException Exception {
-            get {
-                return _exception;
-            }
-        }
-
-        public NodeThread Thread {
-            get {
-                return _thread;
-            }
-        }
-
-        public bool IsUnhandled {
-            get {
-                return _isUnhandled;
-            }
+            Thread = thread;
+            Exception = exception;
+            IsUnhandled = isUnhandled;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/FilePosition.cs
+++ b/Nodejs/Product/Nodejs/Debugger/FilePosition.cs
@@ -19,35 +19,14 @@ namespace Microsoft.NodejsTools.Debugger {
     /// Stores line and column position in the file.
     /// </summary>
     sealed class FilePosition {
-        private readonly int _column;
-        private readonly string _fileName;
-        private readonly int _line;
+        public readonly int Column;
+        public readonly string FileName;
+        public readonly int Line;
 
         public FilePosition(string fileName, int line, int column) {
-            _fileName = fileName;
-            _line = line;
-            _column = column;
-        }
-
-        /// <summary>
-        /// Gets a file name.
-        /// </summary>
-        public string FileName {
-            get { return _fileName; }
-        }
-
-        /// <summary>
-        /// Gets a line number.
-        /// </summary>
-        public int Line {
-            get { return _line; }
-        }
-
-        /// <summary>
-        /// Gets a column number.
-        /// </summary>
-        public int Column {
-            get { return _column; }
+            FileName = fileName;
+            Line = line;
+            Column = column;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/ModuleLoadedEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/ModuleLoadedEventArgs.cs
@@ -17,17 +17,11 @@
 using System;
 
 namespace Microsoft.NodejsTools.Debugger {
-    class ModuleLoadedEventArgs : EventArgs {
-        private readonly NodeModule _module;
+    sealed class ModuleLoadedEventArgs : EventArgs {
+        public readonly NodeModule Module;
 
         public ModuleLoadedEventArgs(NodeModule module) {
-            _module = module;
-        }
-
-        public NodeModule Module {
-            get {
-                return _module;
-            }
+            Module = module;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/NodeEventEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeEventEventArgs.cs
@@ -19,14 +19,10 @@ using System.Collections.Generic;
 
 namespace Microsoft.NodejsTools.Debugger {
     sealed class NodeEventEventArgs : EventArgs {
-        private readonly Dictionary<string, object> _data;
+        public readonly Dictionary<string, object> Data;
 
         public NodeEventEventArgs(Dictionary<string, object> data) {
-            _data = data;
-        }
-
-        public Dictionary<string, object> Data {
-            get { return _data; }
+            Data = data;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/NodeException.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeException.cs
@@ -14,26 +14,13 @@
 //
 //*********************************************************//
 
-
 namespace Microsoft.NodejsTools.Debugger {
-    class NodeException {
-        private readonly string _typeName, _description;
+    sealed class NodeException {
+        public readonly string TypeName, Description;
 
         public NodeException(string typeName, string description) {
-            _typeName = typeName;
-            _description = description;
-        }
-
-        public string TypeName {
-            get {
-                return _typeName;
-            }
-        }
-
-        public string Description {
-            get {
-                return _description;
-            }
+            TypeName = typeName;
+            Description = description;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/NodeThread.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeThread.cs
@@ -17,18 +17,16 @@
 using System.Collections.Generic;
 
 namespace Microsoft.NodejsTools.Debugger {
-    class NodeThread {
+    sealed class NodeThread {
         private readonly int _identity;
         private readonly NodeDebugger _process;
         private readonly bool _isWorkerThread;
-        private string _name;
-        private IList<NodeStackFrame> _frames;
 
         internal NodeThread(NodeDebugger process, int identity, bool isWorkerThread) {
             _process = process;
             _identity = identity;
             _isWorkerThread = isWorkerThread;
-            _name = "main thread";
+            Name = "main thread";
         }
 
         public void StepInto() {
@@ -57,24 +55,17 @@ namespace Microsoft.NodejsTools.Debugger {
             _process.SendClearStepping(_identity);
         }
 
-        public IList<NodeStackFrame> Frames {
-            get {
-                return _frames;
-            }
-            set {
-                _frames = value;
-            }
-        }
+        public IList<NodeStackFrame> Frames { get; set; }
 
         public int CallstackDepth {
             get {
-                return _frames != null ? _frames.Count : 0;
+                return Frames != null ? Frames.Count : 0;
             }
         }
 
         public NodeStackFrame TopStackFrame {
             get {
-                return _frames != null && _frames.Count > 0 ? _frames[0] : null;
+                return Frames != null && Frames.Count > 0 ? Frames[0] : null;
             }
         }
 
@@ -84,14 +75,7 @@ namespace Microsoft.NodejsTools.Debugger {
             }
         }
 
-        public string Name {
-            get {
-                return _name;
-            }
-            set {
-                _name = value;
-            }
-        }
+        public string Name { get; set; }
 
         internal int Id {
             get {

--- a/Nodejs/Product/Nodejs/Debugger/OutputEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/OutputEventArgs.cs
@@ -18,24 +18,12 @@ using System;
 
 namespace Microsoft.NodejsTools.Debugger {
     sealed class OutputEventArgs : EventArgs {
-        private readonly string _output;
-        private readonly NodeThread _thread;
+        public readonly NodeThread Thread;
+        public readonly string Output;
 
         public OutputEventArgs(NodeThread thread, string output) {
-            _thread = thread;
-            _output = output;
-        }
-
-        public NodeThread Thread {
-            get {
-                return _thread;
-            }
-        }
-
-        public string Output {
-            get {
-                return _output;
-            }
+            Thread = thread;
+            Output = output;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/ProcessExitedEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/ProcessExitedEventArgs.cs
@@ -17,17 +17,11 @@
 using System;
 
 namespace Microsoft.NodejsTools.Debugger {
-    class ProcessExitedEventArgs : EventArgs {
-        private readonly int _exitCode;
+    sealed class ProcessExitedEventArgs : EventArgs {
+        public readonly int ExitCode;
 
         public ProcessExitedEventArgs(int exitCode) {
-            _exitCode = exitCode;
-        }
-
-        public int ExitCode {
-            get {
-                return _exitCode;
-            }
+            ExitCode = exitCode;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/ThreadEventArgs.cs
+++ b/Nodejs/Product/Nodejs/Debugger/ThreadEventArgs.cs
@@ -21,16 +21,10 @@ namespace Microsoft.NodejsTools.Debugger {
     /// Event args for start/stop of threads.
     /// </summary>
     class ThreadEventArgs : EventArgs {
-        private readonly NodeThread _thread;
+        public readonly NodeThread Thread;
 
         public ThreadEventArgs(NodeThread thread) {
-            _thread = thread;
-        }
-
-        public NodeThread Thread {
-            get {
-                return _thread;
-            }
+            Thread = thread;
         }
     }
 }


### PR DESCRIPTION
**Bug**
Small code annoyance: in the debugger we have a lot of boilerplate code to implement readonly properties by using a readonly member backing.

**Fix**
Just use readonly member values for this pattern. We already do this in a number of places in debugger. Also, marked some of these classes as sealed.

This make the code briefer and reduces duplication, making updates and understanding easier.