### PR TITLE
Fix smart indent settings crash

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -251,6 +251,11 @@ namespace Microsoft.NodejsTools {
             Environment.SetEnvironmentVariable(NodejsConstants.NodeToolsProcessIdEnvironmentVariable, Process.GetCurrentProcess().Id.ToString());
         }
 
+        public static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript() {
+            IVsTextManager4 textMgr = (IVsTextManager4)Instance.GetService(typeof(SVsTextManager));
+            return GetNodejsLanguagePreferencesFromTypeScript(textMgr);
+        }
+
         private static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript(IVsTextManager4 textMgr) {
             var langPrefs = new LANGPREFERENCES3[1];
             langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -251,12 +251,7 @@ namespace Microsoft.NodejsTools {
             Environment.SetEnvironmentVariable(NodejsConstants.NodeToolsProcessIdEnvironmentVariable, Process.GetCurrentProcess().Id.ToString());
         }
 
-        public static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript() {
-            IVsTextManager4 textMgr = (IVsTextManager4)Instance.GetService(typeof(SVsTextManager));
-            return GetNodejsLanguagePreferencesFromTypeScript(textMgr);
-        }
-
-        private static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript(IVsTextManager4 textMgr) {
+        public static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript(IVsTextManager4 textMgr) {
             var langPrefs = new LANGPREFERENCES3[1];
             langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
             ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences4(null, langPrefs, null));

--- a/Nodejs/Product/Nodejs/SmartIndent.cs
+++ b/Nodejs/Product/Nodejs/SmartIndent.cs
@@ -23,6 +23,8 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio;
 
 namespace Microsoft.NodejsTools {
     sealed class SmartIndent : ISmartIndent {
@@ -46,19 +48,17 @@ namespace Microsoft.NodejsTools {
         #region ISmartIndent Members
 
         public int? GetDesiredIndentation(VisualStudio.Text.ITextSnapshotLine line) {
-            var dte = (EnvDTE.DTE)NodejsPackage.GetGlobalService(typeof(EnvDTE.DTE));
-
-            var props = dte.get_Properties("TextEditor", "Node.js");
-            switch ((EnvDTE._vsIndentStyle)(int)props.Item("IndentStyle").Value) {
+            var langPrefs = NodejsPackage.GetNodejsLanguagePreferencesFromTypeScript();
+            switch ((EnvDTE._vsIndentStyle)langPrefs[0].IndentStyle) {
                 case EnvDTE._vsIndentStyle.vsIndentStyleNone:
                     return null;
                 case EnvDTE._vsIndentStyle.vsIndentStyleDefault:
                     return DoBlockIndent(line);
                 case EnvDTE._vsIndentStyle.vsIndentStyleSmart:
                     return DoSmartIndent(line);
+                default:
+                    return null;
             }
-
-            return null;
         }
 
         #endregion

--- a/Nodejs/Product/Nodejs/SmartIndent.cs
+++ b/Nodejs/Product/Nodejs/SmartIndent.cs
@@ -16,13 +16,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Tagging;
-using EnvDTE;
 
 namespace Microsoft.NodejsTools {
     sealed class SmartIndent : ISmartIndent {
@@ -46,8 +44,7 @@ namespace Microsoft.NodejsTools {
         #region ISmartIndent Members
 
         public int? GetDesiredIndentation(ITextSnapshotLine line) {
-            var langPrefs = NodejsPackage.GetNodejsLanguagePreferencesFromTypeScript();
-            switch (langPrefs[0].IndentStyle) {
+            switch (NodejsPackage.Instance.LangPrefs.IndentMode) {
                 case VisualStudio.TextManager.Interop.vsIndentStyle.vsIndentStyleNone:
                     return null;
                 case VisualStudio.TextManager.Interop.vsIndentStyle.vsIndentStyleDefault:

--- a/Nodejs/Product/Nodejs/SmartIndent.cs
+++ b/Nodejs/Product/Nodejs/SmartIndent.cs
@@ -22,9 +22,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Tagging;
-using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.TextManager.Interop;
-using Microsoft.VisualStudio;
+using EnvDTE;
 
 namespace Microsoft.NodejsTools {
     sealed class SmartIndent : ISmartIndent {
@@ -47,14 +45,14 @@ namespace Microsoft.NodejsTools {
 
         #region ISmartIndent Members
 
-        public int? GetDesiredIndentation(VisualStudio.Text.ITextSnapshotLine line) {
+        public int? GetDesiredIndentation(ITextSnapshotLine line) {
             var langPrefs = NodejsPackage.GetNodejsLanguagePreferencesFromTypeScript();
-            switch ((EnvDTE._vsIndentStyle)langPrefs[0].IndentStyle) {
-                case EnvDTE._vsIndentStyle.vsIndentStyleNone:
+            switch (langPrefs[0].IndentStyle) {
+                case VisualStudio.TextManager.Interop.vsIndentStyle.vsIndentStyleNone:
                     return null;
-                case EnvDTE._vsIndentStyle.vsIndentStyleDefault:
+                case VisualStudio.TextManager.Interop.vsIndentStyle.vsIndentStyleDefault:
                     return DoBlockIndent(line);
-                case EnvDTE._vsIndentStyle.vsIndentStyleSmart:
+                case VisualStudio.TextManager.Interop.vsIndentStyle.vsIndentStyleSmart:
                     return DoSmartIndent(line);
                 default:
                     return null;


### PR DESCRIPTION
Issue #1014

##### Bug
Crash in `SmartIndent.cs` in the interactive window. I believe that the root cause is #995, which changed how we store our settings.

##### Fix
Switch to using the NodeJs language preferences from typescript instead. This ensures we are using the same logic to get the language settings as we use in other places.

closes #1014