### PR TITLE
Download typings on es5 -> Es6 switch

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -568,16 +568,6 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        /*
-         * Needed if we switch to per project Analysis levels
-        internal NodejsTools.Options.AnalysisLevel AnalysisLevel(){
-            var analyzer = _analyzer;
-            if (_analyzer != null) {
-                return _analyzer.AnalysisLevel;
-            }
-            return NodejsTools.Options.AnalysisLevel.None;
-        }
-        */
         private void IntellisenseOptionsPageAnalysisLevelChanged(object sender, EventArgs e) {
             var oldAnalyzer = _analyzer;
             _analyzer = null;
@@ -591,6 +581,7 @@ namespace Microsoft.NodejsTools.Project {
                 }
             }
             _analyzer = analyzer;
+            TryToAcquireCurrentTypings();
         }
 
         private void AnalysisLogMaximumChanged(object sender, EventArgs e) {


### PR DESCRIPTION
##### Bug
Typings not downloaded on es5 -> Es6 intellisense switch in NTVS 1.2

##### Fix
Hook into the intellisense change event to download them.

Closes #1021