### PR TITLE
Replace Tsd with Typings for Automatic Typings Acquisition

### DIFF
--- a/Nodejs/Product/Nodejs/Options/SalsaLsIntellisenseOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/SalsaLsIntellisenseOptionsControl.Designer.cs
@@ -86,7 +86,7 @@
             this._saveChangesToConfigFile.Name = "_saveChangesToConfigFile";
             this._saveChangesToConfigFile.Size = new System.Drawing.Size(384, 29);
             this._saveChangesToConfigFile.TabIndex = 2;
-            this._saveChangesToConfigFile.Text = "Save changes to tsd.json &config file";
+            this._saveChangesToConfigFile.Text = "Save changes to typings.json &config file";
             this._saveChangesToConfigFile.UseVisualStyleBackColor = true;
             // 
             // _showTypingsInfoBar

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -182,9 +182,9 @@ namespace Microsoft.NodejsTools.Project {
         internal const string SurroundWith = "SurroundWith";
         internal const string TestFramework = "TestFramework";
         internal const string TestFrameworkDescription = "TestFrameworkDescription";
-        internal const string TsdInstallCompleted = "TsdInstallCompleted";
-        internal const string TsdInstallErrorOccurred = "TsdInstallErrorOccurred";
-        internal const string TsdNotInstalledError = "TsdNotInstalledError";
+        internal const string TypingsToolInstallCompleted = "TypingsToolInstallCompleted";
+        internal const string TypingsToolInstallErrorOccurred = "TypingsToolInstallErrorOccurred";
+        internal const string TypingsToolNotInstalledError = "TypingsToolNotInstalledError";
         internal const string TypingsInfoBarSpan1 = "TypingsInfoBarSpan1";
         internal const string TypingsInfoBarSpan2 = "TypingsInfoBarSpan2";
         internal const string TypingsInfoBarSpan3 = "TypingsInfoBarSpan3";

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -609,14 +609,11 @@ You will need to restart Visual Studio after installation.</value>
   <data name="RemoteDebugProxyFolderDoesNotExist" xml:space="preserve">
     <value>Could not find RemoteDebugProxyFolder</value>
   </data>
-  <data name="TypingsToolErrorOccured" xml:space="preserve">
-    <value>Error installing typings files used for Intellisense.</value>
-  </data>
   <data name="TypingsToolInstallCompleted" xml:space="preserve">
     <value>Successfully installed typing files for Intellisense.</value>
   </data>
   <data name="TypingsToolNotInstalledError" xml:space="preserve">
-    <value>Could not find Typings TypeScript package manager tool used for Intellisense.</value>
+    <value>Could not find Typings package manager tool used for Intellisense.</value>
   </data>
   <data name="TypingsInfoBarSpan1" xml:space="preserve">
     <value>Node.js IntelliSense added a </value>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -609,14 +609,14 @@ You will need to restart Visual Studio after installation.</value>
   <data name="RemoteDebugProxyFolderDoesNotExist" xml:space="preserve">
     <value>Could not find RemoteDebugProxyFolder</value>
   </data>
-  <data name="TsdErrorOccured" xml:space="preserve">
+  <data name="TypingsToolErrorOccured" xml:space="preserve">
     <value>Error installing typings files used for Intellisense.</value>
   </data>
-  <data name="TsdInstallCompleted" xml:space="preserve">
+  <data name="TypingsToolInstallCompleted" xml:space="preserve">
     <value>Successfully installed typing files for Intellisense.</value>
   </data>
-  <data name="TsdNotInstalledError" xml:space="preserve">
-    <value>Could not find TSD TypeScript package manager tool used for Intellisense. Please install it globally by running 'npm install -g tsd'.</value>
+  <data name="TypingsToolNotInstalledError" xml:space="preserve">
+    <value>Could not find Typings TypeScript package manager tool used for Intellisense.</value>
   </data>
   <data name="TypingsInfoBarSpan1" xml:space="preserve">
     <value>Node.js IntelliSense added a </value>

--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -98,16 +98,16 @@ namespace Microsoft.NodejsTools {
                 return true;
             }
 
-            string tsdPath = await EnsureTypingsToolInstalled();
-            if (string.IsNullOrEmpty(tsdPath)) {
+            string typingsTool = await EnsureTypingsToolInstalled();
+            if (string.IsNullOrEmpty(typingsTool)) {
                 if (redirector != null) {
-                    redirector.WriteErrorLine(SR.GetString(SR.TsdNotInstalledError));
+                    redirector.WriteErrorLine(SR.GetString(SR.TypingsToolNotInstalledError));
                 }
                 return false;
             }
 
             using (var process = ProcessOutput.Run(
-                tsdPath,
+                typingsTool,
                 GetTypingsToolInstallArguments(packages),
                 _pathToRootProjectDirectory,
                 null,
@@ -118,20 +118,20 @@ namespace Microsoft.NodejsTools {
                     // Process failed to start, and any exception message has
                     // already been sent through the redirector
                     if (redirector != null) {
-                        redirector.WriteErrorLine("could not start tsd");
+                        redirector.WriteErrorLine("could not start typings");
                     }
                     return false;
                 }
                 var i = await process;
                 if (i == 0) {
                     if (redirector != null) {
-                        redirector.WriteLine(SR.GetString(SR.TsdInstallCompleted));
+                        redirector.WriteLine(SR.GetString(SR.TypingsToolInstallCompleted));
                     }
                     return true;
                 } else {
                     process.Kill();
                     if (redirector != null) {
-                        redirector.WriteErrorLine(SR.GetString(SR.TsdInstallErrorOccurred));
+                        redirector.WriteErrorLine(SR.GetString(SR.TypingsToolInstallErrorOccurred));
                     }
                     return false;
                 }

--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -38,13 +38,13 @@ namespace Microsoft.NodejsTools {
         /// <summary>
         /// Path the the private package where the typings acquisition tool is installed.
         /// </summary>
-        private static string NtvsToolsPath {
+        private static string NtvsExternalToolsPath {
             get {
                 return Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                     "Microsoft",
                     "Node.js Tools",
-                    "Tools");
+                    "ExternalTools");
             }
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.NodejsTools {
         private static string ToolPath {
             get {
                 return Path.Combine(
-                    NtvsToolsPath,
+                    NtvsExternalToolsPath,
                     "node_modules",
                     ".bin",
                     ToolExe);

--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -153,8 +153,9 @@ namespace Microsoft.NodejsTools {
         }
 
         private async Task<bool> InstallTool() {
-            Directory.CreateDirectory(NtvsToolsPath);
             _didTryToInstallTool = true;
+
+            Directory.CreateDirectory(NtvsToolsPath);
 
             // install typings
             using (var commander = _npmController.CreateNpmCommander()) {

--- a/Nodejs/Product/Npm/INpmCommander.cs
+++ b/Nodejs/Product/Npm/INpmCommander.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NodejsTools.Npm {
             string packageName,
             string versionRange);
 
-        Task<bool> InstallNonLocalPackageByVersionAsync(
+        Task<bool> InstallPackageToFolderByVersionAsync(
             string pathToRootDirectory,
             string packageName,
             string versionRange,

--- a/Nodejs/Product/Npm/INpmCommander.cs
+++ b/Nodejs/Product/Npm/INpmCommander.cs
@@ -60,6 +60,12 @@ namespace Microsoft.NodejsTools.Npm {
             string packageName,
             string versionRange);
 
+        Task<bool> InstallNonLocalPackageByVersionAsync(
+            string pathToRootDirectory,
+            string packageName,
+            string versionRange,
+            bool saveToPackageJson);
+
         /// <summary>
         /// 
         /// </summary>

--- a/Nodejs/Product/Npm/SPI/NpmCommander.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommander.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             return InstallPackageByVersionAsync(_npmController.FullPathToRootPackageDirectory,packageName, versionRange, DependencyType.Standard, true, false);
         }
 
-        public Task<bool> InstallNonLocalPackageByVersionAsync(string pathToRootDirectory, string packageName, string versionRange, bool saveToPackageJson) {
+        public Task<bool> InstallPackageToFolderByVersionAsync(string pathToRootDirectory, string packageName, string versionRange, bool saveToPackageJson) {
             return InstallPackageByVersionAsync(pathToRootDirectory, packageName, versionRange, DependencyType.Standard, false, saveToPackageJson);
         }
 

--- a/Nodejs/Product/Npm/SPI/NpmCommander.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommander.cs
@@ -128,15 +128,16 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                     _npmController.PathToNpm));
         }
 
-        private async Task<bool> InstallPackageByVersionAsync(
+        private Task<bool> InstallPackageByVersionAsync(
+            string pathToRootDirectory,
             string packageName,
             string versionRange,
             DependencyType type,
             bool global,
             bool saveToPackageJson) {
-            return await DoCommandExecute(true,
+            return DoCommandExecute(true,
                 new NpmInstallCommand(
-                    _npmController.FullPathToRootPackageDirectory,
+                    pathToRootDirectory,
                     packageName,
                     versionRange,
                     type,
@@ -145,16 +146,20 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                     _npmController.PathToNpm));
         }
 
-        public async Task<bool> InstallPackageByVersionAsync(
+        public Task<bool> InstallPackageByVersionAsync(
             string packageName,
             string versionRange,
             DependencyType type,
             bool saveToPackageJson) {
-            return await InstallPackageByVersionAsync(packageName, versionRange, type, false, saveToPackageJson);
+            return InstallPackageByVersionAsync(_npmController.FullPathToRootPackageDirectory, packageName, versionRange, type, false, saveToPackageJson);
         }
 
-        public async Task<bool> InstallGlobalPackageByVersionAsync(string packageName, string versionRange) {
-            return await InstallPackageByVersionAsync(packageName, versionRange, DependencyType.Standard, true, false);
+        public Task<bool> InstallGlobalPackageByVersionAsync(string packageName, string versionRange) {
+            return InstallPackageByVersionAsync(_npmController.FullPathToRootPackageDirectory,packageName, versionRange, DependencyType.Standard, true, false);
+        }
+
+        public Task<bool> InstallNonLocalPackageByVersionAsync(string pathToRootDirectory, string packageName, string versionRange, bool saveToPackageJson) {
+            return InstallPackageByVersionAsync(pathToRootDirectory, packageName, versionRange, DependencyType.Standard, false, saveToPackageJson);
         }
 
         private DependencyType GetDependencyType(string packageName) {


### PR DESCRIPTION
##### Bug
We currently use TSD to acquire typings metadata for intellisense in VS2015 with NTVS 1.2. Tsd is now deprecated. We are also installing TSD globally, which may cause problems for users. 

##### Fix
Use typings instead of TSD. We now also install typings in `%localappdata%` instead of installing it as a global dependency.

closes #768