### PR TITLE
Fix es5 buffer parser crash

### DIFF
--- a/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
@@ -259,6 +259,10 @@ namespace Microsoft.NodejsTools.Intellisense {
             protected virtual void Dispose(bool disposing) {
                 if (!disposedValue) {
                     if (disposing) {
+                        foreach (var buffer in _buffers.ToArray())
+                            RemoveBuffer(buffer);
+                        _buffers.Clear();
+
                         _timer.Dispose();
                     }
 

--- a/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
@@ -23,7 +23,6 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.NodejsTools.Intellisense {
     sealed partial class VsProjectAnalyzer {
-
         class BufferParser : IDisposable {
             internal VsProjectAnalyzer _parser;
             private readonly Timer _timer;
@@ -259,8 +258,9 @@ namespace Microsoft.NodejsTools.Intellisense {
             protected virtual void Dispose(bool disposing) {
                 if (!disposedValue) {
                     if (disposing) {
-                        foreach (var buffer in _buffers.ToArray())
+                        foreach (var buffer in _buffers.ToArray()) {
                             RemoveBuffer(buffer);
+                        }
 
                         _timer.Dispose();
                     }

--- a/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
+++ b/Nodejs/Product/Nodejs/Intellisense/BufferParser.cs
@@ -261,7 +261,6 @@ namespace Microsoft.NodejsTools.Intellisense {
                     if (disposing) {
                         foreach (var buffer in _buffers.ToArray())
                             RemoveBuffer(buffer);
-                        _buffers.Clear();
 
                         _timer.Dispose();
                     }


### PR DESCRIPTION
##### Bug
A callback is getting invoked on BufferParser after the BufferParser is disposed. The easiest way to trigger a dispose is by switching between ES6 and ES5 Intellisense

##### Fix
Unregister all callbacks in the dispose method and remove all buffers.


closes #1018 
closes #1020
