### PR TITLE
Always install node typings and gate alert to when typings actually created

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NodejsTools.Project {
                 .ContinueWith(x => {
                     if (NodejsPackage.Instance.IntellisenseOptionsPage.ShowTypingsInfoBar &&
                         x.Result &&
-                        (hadExistingTypingsFolder && Directory.Exists(typingsPath))) {
+                        (!hadExistingTypingsFolder && Directory.Exists(typingsPath))) {
                         NodejsPackage.Instance.GetUIThread().Invoke(() => {
                             TypingsInfoBar.Instance.ShowInfoBar();
                         });

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -151,13 +151,14 @@ namespace Microsoft.NodejsTools.Project {
                 return;
             }
 
-            bool isNewTypingsFolder = !Directory.Exists(Path.Combine(this.ProjectHome, "typings"));
+            var typingsPath = Path.Combine(this.ProjectHome, "typings");
+            bool hadExistingTypingsFolder = Directory.Exists(typingsPath);
             TypingsAcquirer
                 .AcquireTypings(packages, null /*redirector*/)
                 .ContinueWith(x => {
                     if (NodejsPackage.Instance.IntellisenseOptionsPage.ShowTypingsInfoBar &&
                         x.Result &&
-                        isNewTypingsFolder) {
+                        (hadExistingTypingsFolder && Directory.Exists(typingsPath))) {
                         NodejsPackage.Instance.GetUIThread().Invoke(() => {
                             TypingsInfoBar.Instance.ShowInfoBar();
                         });
@@ -182,7 +183,7 @@ namespace Microsoft.NodejsTools.Project {
                     || package.IsDevDependency
                     || !package.IsListedInParentPackageJson);
 
-            TryToAcquireTypings(currentPackages.Select(package => package.Name));
+            TryToAcquireTypings(currentPackages.Select(package => package.Name).Concat(new[] { "node" }));
         }
 #endif
 


### PR DESCRIPTION
Two small fixes:
* Ensure we always install the `node` typings. It currently is only installed when loading a project for the first time.
* Only show the typings warning when we actually create a typings folder. The first fix should prevent us hitting this in most cases, but its worth fixing so we don't hit this in the future.

closes #1032