### PR TITLE
Fix Node 6 Debugging

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
@@ -61,12 +61,9 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
             if (_module != null) {
                 _arguments["type"] = "scriptId";
                 _arguments["target"] = _module.Id;
-            } else if (remote) {
+            } else {
                 _arguments["type"] = "scriptRegExp";
                 _arguments["target"] = GetCaseInsensitiveRegex(_position.FileName);
-            } else {
-                _arguments["type"] = "script";
-                _arguments["target"] = _position.FileName;
             }
 
             if (!NodeBreakpointBinding.GetEngineEnabled(_breakpoint.Enabled, _breakpoint.BreakOn, 0)) {

--- a/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
@@ -126,40 +126,24 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
 
         private static string CreateRemoteScriptRegExp(string filePath) {
             string fileName = Path.GetFileName(filePath) ?? string.Empty;
-            bool trailing = fileName != filePath;
-
-            fileName = Regex.Escape(fileName);
-
-            var builder = new StringBuilder();
-            if (trailing) {
-                builder.Append(pathSeperatorCharacterGroup);
-            } else {
-                builder.Append('^');
-            }
-
-            AddCaseInsensitiveStringToRegExp(fileName, builder);
-
-            builder.Append("$");
-            return builder.ToString();
+            string start = fileName != filePath ? pathSeperatorCharacterGroup : "^";
+            return string.Format("{0}{1}$", start, CreateCaseInsensitiveRegExpFromString(fileName));
         }
 
         private static string CreateLocalScriptRegExp(string filePath) {
-            string fileName = Regex.Escape(filePath);
-
-            var builder = new StringBuilder();
-            builder.Append('^');
-            AddCaseInsensitiveStringToRegExp(fileName, builder);
-            builder.Append("$");
-            return builder.ToString();
+            return string.Format("^{0}$", CreateCaseInsensitiveRegExpFromString(filePath));
         }
 
         /// <summary>
-        /// Add a case-insensitive string to a string buffer containing a regular expression.
+        /// Convert a string into a case-insensitive regular expression.
         /// 
         /// This is a work around for the fact that we cannot pass a regex case insensitive modifier to the Node (V8) engine.
         /// </summary>
-        private static void AddCaseInsensitiveStringToRegExp(string str, StringBuilder builder) {
-            foreach (var ch in str) {
+        private static string CreateCaseInsensitiveRegExpFromString(string str) {
+            string escapedString = Regex.Escape(str);
+
+            var builder = new StringBuilder();
+            foreach (var ch in escapedString) {
                 string upper = ch.ToString(CultureInfo.InvariantCulture).ToUpper();
                 string lower = ch.ToString(CultureInfo.InvariantCulture).ToLower();
                 if (upper != lower) {
@@ -171,6 +155,7 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
                     builder.Append(upper);
                 }
             }
+            return builder.ToString();
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NodejsTools.Debugger.Commands {
     sealed class SetBreakpointCommand : DebuggerCommand {
-        private static string pathSeperatorCharacterGroup = string.Format("[{0}{1}]", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        private static string _pathSeperatorCharacterGroup = string.Format("[{0}{1}]", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         private readonly Dictionary<string, object> _arguments;
         private readonly NodeBreakpoint _breakpoint;
@@ -126,7 +126,7 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
 
         private static string CreateRemoteScriptRegExp(string filePath) {
             string fileName = Path.GetFileName(filePath) ?? string.Empty;
-            string start = fileName == filePath ? "^" : pathSeperatorCharacterGroup;
+            string start = fileName == filePath ? "^" : _pathSeperatorCharacterGroup;
             return string.Format("{0}{1}$", start, CreateCaseInsensitiveRegExpFromString(fileName));
         }
 

--- a/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
@@ -126,24 +126,22 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
 
         private static string CreateRemoteScriptRegExp(string filePath) {
             string fileName = Path.GetFileName(filePath) ?? string.Empty;
-            string start = fileName != filePath ? pathSeperatorCharacterGroup : "^";
+            string start = fileName == filePath ? "^" : pathSeperatorCharacterGroup;
             return string.Format("{0}{1}$", start, CreateCaseInsensitiveRegExpFromString(fileName));
         }
 
-        private static string CreateLocalScriptRegExp(string filePath) {
+        public static string CreateLocalScriptRegExp(string filePath) {
             return string.Format("^{0}$", CreateCaseInsensitiveRegExpFromString(filePath));
         }
 
         /// <summary>
         /// Convert a string into a case-insensitive regular expression.
         /// 
-        /// This is a work around for the fact that we cannot pass a regex case insensitive modifier to the Node (V8) engine.
+        /// This is a workaround for the fact that we cannot pass a regex case insensitive modifier to the Node (V8) engine.
         /// </summary>
         private static string CreateCaseInsensitiveRegExpFromString(string str) {
-            string escapedString = Regex.Escape(str);
-
             var builder = new StringBuilder();
-            foreach (var ch in escapedString) {
+            foreach (var ch in Regex.Escape(str)) {
                 string upper = ch.ToString(CultureInfo.InvariantCulture).ToUpper();
                 string lower = ch.ToString(CultureInfo.InvariantCulture).ToLower();
                 if (upper != lower) {

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -530,15 +530,13 @@ namespace Microsoft.NodejsTools.Debugger {
             foreach (NodeModule module in modules) {
                 NodeModule newModule;
                 if (GetOrAddModule(module, out newModule)) {
-                    if (newModule.FileName != newModule.JavaScriptFileName) {
-                        foreach (var breakpoint in _breakpointBindings) {
-                            var target = breakpoint.Value.Breakpoint.Target;
-                            if (target.FileName == newModule.FileName) {
-                                // attempt to rebind the breakpoint
-                                DebuggerClient.RunWithRequestExceptionsHandled(async () => {
-                                    await breakpoint.Value.Breakpoint.BindAsync().WaitAsync(TimeSpan.FromSeconds(2));
-                                });
-                            }
+                    foreach (var breakpoint in _breakpointBindings) {
+                        var target = breakpoint.Value.Breakpoint.Target;
+                        if (target.FileName.Equals(newModule.FileName, StringComparison.OrdinalIgnoreCase)) {
+                            // attempt to rebind the breakpoint
+                            DebuggerClient.RunWithRequestExceptionsHandled(async () => {
+                                await breakpoint.Value.Breakpoint.BindAsync().WaitAsync(TimeSpan.FromSeconds(2));
+                            });
                         }
                     }
 

--- a/Nodejs/Tests/Core/Debugger/Commands/SetBreakpointCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/SetBreakpointCommandTests.cs
@@ -15,6 +15,8 @@
 //*********************************************************//
 
 using System;
+using System.IO;
+using System.Text.RegularExpressions;
 using Microsoft.NodejsTools.Debugger;
 using Microsoft.NodejsTools.Debugger.Commands;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,6 +25,37 @@ using Newtonsoft.Json.Linq;
 namespace NodejsTests.Debugger.Commands {
     [TestClass]
     public class SetBreakpointCommandTests {
+        [TestMethod, Priority(0), TestCategory("Debugging")]
+        public void CreateLocalScriptRegExpShouldCreateCaseInSensitiveRegularExpression() {
+            const string drive = "c:";
+            var pathParts = new[] { "nOdE", "IS", "awsome.js" };
+            string fileName = Path.Combine(drive, Path.Combine(pathParts));
+
+            var scriptRegExp = new Regex(SetBreakpointCommand.CreateLocalScriptRegExp(fileName));
+
+            Assert.IsTrue(scriptRegExp.IsMatch(fileName));
+            Assert.IsTrue(scriptRegExp.IsMatch(fileName.ToUpperInvariant()));
+            Assert.IsTrue(scriptRegExp.IsMatch(fileName.ToLowerInvariant()));
+
+            Assert.IsTrue(scriptRegExp.IsMatch(Path.Combine(drive.ToUpperInvariant(), Path.Combine(pathParts))));
+            Assert.IsTrue(scriptRegExp.IsMatch(Path.Combine(drive.ToLowerInvariant(), Path.Combine(pathParts))));
+        }
+
+        [TestMethod, Priority(0), TestCategory("Debugging")]
+        public void CreateLocalScriptRegExpShouldOnlyMatchExactPath() {
+            const string drive = "c:";
+            var pathParts = new[] { "nOdE", "IS", "awsome.js" };
+            string fileName = Path.Combine(drive, Path.Combine(pathParts));
+
+            var scriptRegExp = new Regex(SetBreakpointCommand.CreateLocalScriptRegExp(fileName));
+       
+            Assert.IsFalse(scriptRegExp.IsMatch(Path.Combine("d:", Path.Combine(pathParts))));
+
+             Assert.IsFalse(scriptRegExp.IsMatch(fileName + 'x'));
+             Assert.IsFalse(scriptRegExp.IsMatch(Path.Combine(fileName, "x")));
+             Assert.IsFalse(scriptRegExp.IsMatch("x" + fileName));
+        }
+
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void CreateSetBreakpointCommand() {
             // Arrange
@@ -114,8 +147,8 @@ namespace NodejsTests.Debugger.Commands {
             Assert.AreEqual(commandId, setBreakpointCommand.Id);
             Assert.AreEqual(
                 string.Format(
-                    "{{\"command\":\"setbreakpoint\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"line\":{1},\"column\":{2},\"type\":\"script\",\"target\":\"{3}\",\"ignoreCount\":1}}}}",
-                    commandId, line, column, fileName.Replace(@"\", @"\\")),
+                    "{{\"command\":\"setbreakpoint\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"line\":{1},\"column\":{2},\"type\":\"scriptRegExp\",\"target\":\"{3}\",\"ignoreCount\":1}}}}",
+                    commandId, line, column, SetBreakpointCommand.CreateLocalScriptRegExp(fileName).Replace(@"\", @"\\")),
                 setBreakpointCommand.ToString());
         }
 

--- a/Nodejs/Tests/Core/Debugger/Commands/SetBreakpointCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/SetBreakpointCommandTests.cs
@@ -28,7 +28,7 @@ namespace NodejsTests.Debugger.Commands {
         [TestMethod, Priority(0), TestCategory("Debugging")]
         public void CreateLocalScriptRegExpShouldCreateCaseInSensitiveRegularExpression() {
             const string drive = "c:";
-            var pathParts = new[] { "nOdE", "IS", "awsome.js" };
+            var pathParts = new[] { "nOdE", "IS", "awesome.js" };
             string fileName = Path.Combine(drive, Path.Combine(pathParts));
 
             var scriptRegExp = new Regex(SetBreakpointCommand.CreateLocalScriptRegExp(fileName));


### PR DESCRIPTION
Issue #934

##### Bug
Initial breakpoints currently sometimes do not resolve when using Node 6.x. In most cases, you can remove the breakpoint and add it back about 30 seconds after the program has started in order to get it to resolve.

##### Fix
I believe something with Node 6 changed the casing for the names of scripts in the v8-debug protocol. 

There were two fixes here:

* Use a case insensitive regular expression to match the script names when setting a breakpoint (I believe this is similar to what VS code does)
* Fix one case where we were relying on a case sensitive comparision to update a breakpoint.

This is not quite tested to be get merged in just yet, but wanted to see if there were any initial concerns or feedback with the approch here.