### PR TITLE
Add --save-dev to Test framework not installed messages

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -74,7 +74,7 @@ function findTape(projectFolder) {
         var tapePath = path.join(projectFolder, 'node_modules', 'tape');
         return require(tapePath);
     } catch (e) {
-        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Tape can be installed locally with the npm manager via solution explorer or with \".npm install tape\" via the Node.js interactive window.");
+        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Tape can be installed locally with the npm manager via solution explorer or with \".npm install tape --save-dev\" via the Node.js interactive window.");
         return null;
     }
 }

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -93,7 +93,7 @@ function detectMocha(projectFolder) {
         var Mocha = new require(mochaPath);
         return Mocha;
     } catch (ex) {
-        logError("Failed to find Mocha package.  Mocha must be installed in the project locally.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install mocha\" via the Node.js interactive window.");
+        logError("Failed to find Mocha package.  Mocha must be installed in the project locally.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install mocha --save-dev\" via the Node.js interactive window.");
         return null;
     }
 }


### PR DESCRIPTION
Just tacks on `--save-dev` to mocha and tape's suggested fix message.

Closes #1041