### PR TITLE
Adds new line character to test framework not found output messages

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -1,5 +1,5 @@
 "use strict";
-
+var EOL = require('os').EOL;
 var fs = require('fs');
 var path = require('path');
 
@@ -8,7 +8,7 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
     if (test === null) {
         return;
     }
-    
+
     var harness = test.getHarness({ exit: false });
     var tests = harness["_tests"];
 
@@ -74,7 +74,10 @@ function findTape(projectFolder) {
         var tapePath = path.join(projectFolder, 'node_modules', 'tape');
         return require(tapePath);
     } catch (e) {
-        logError("Failed to find Tape package.  Tape must be installed in the project locally.  Tape can be installed locally with the npm manager via solution explorer or with \".npm install tape --save-dev\" via the Node.js interactive window.");
+        logError(
+            'Failed to find Tape package.  Tape must be installed in the project locally.' + EOL +
+            'Install Tape locally using the npm manager via solution explorer' + EOL +
+            'or with ".npm install tape --save-dev" via the Node.js interactive window.');
         return null;
     }
 }

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -1,4 +1,5 @@
-﻿var fs = require('fs');
+﻿var EOL = require('os').EOL;
+var fs = require('fs');
 var path = require('path');
 
 // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
@@ -79,21 +80,24 @@ function logError() {
 }
 
 function detectMocha(projectFolder) {
-  try {
+    try {
         var node_modulesFolder = projectFolder;
         var mochaJsonPath = path.join(node_modulesFolder, 'test', 'mocha.json');
         if (fs.existsSync(mochaJsonPath)) {
-          var opt = require(mochaJsonPath);
-          if (opt && opt.path) {
-            node_modulesFolder = path.resolve(projectFolder, opt.path);
-          }
+            var opt = require(mochaJsonPath);
+            if (opt && opt.path) {
+                node_modulesFolder = path.resolve(projectFolder, opt.path);
+            }
         }
 
         var mochaPath = path.join(node_modulesFolder, 'node_modules', 'mocha');
         var Mocha = new require(mochaPath);
         return Mocha;
     } catch (ex) {
-        logError("Failed to find Mocha package.  Mocha must be installed in the project locally.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install mocha --save-dev\" via the Node.js interactive window.");
+        logError(
+            'Failed to find Mocha package.  Mocha must be installed in the project locally.' + EOL +
+            'Install Mocha locally using the npm manager via solution explorer' + EOL +
+            'or with ".npm install mocha --save-dev" via the Node.js interactive window.');
         return null;
     }
 }


### PR DESCRIPTION
This change manually adds new lines to the error messages that are displayed when a test framework cannot be found. The mitigation steps in those cases are usually pushed off the screen.

##### Testing
Manually verified messages display correctly.

Closes #1042