### PR TITLE
fixed Issue #1083: EnvironmentSetup.ps1 copies .targets file to folder named after just the version number instead of 'v' and then the version number. 

### DIFF
--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -51,7 +51,7 @@ Write-Output "Copying required files"
 foreach ($version in $target_versions) {    
     # Copy Microsoft.NodejsTools.targets file to relevant location
     $from = "$rootDir\Nodejs\Product\Nodejs\Microsoft.NodejsTools.targets"
-    $to = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\$($version.number)\Node.js Tools\Microsoft.NodejsTools.targets"
+    $to = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\v$($version.number)\Node.js Tools\Microsoft.NodejsTools.targets"
     
     Write-Output "    $($from) -> $($to)"
     New-Item -Force $to > $null


### PR DESCRIPTION
Issue #1083 

##### Bug
EnvironmentSetup.ps1 copied the .targets file to a folder named after the version number instead of a folder named v($version.number).

##### Fix
EnvironmentSetup.ps1 now copies .targets file to a folder named v$($version.number).
