### PR TITLE
Fix survey news showing multiple times and when users opt out

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -599,6 +599,7 @@ namespace Microsoft.NodejsTools {
                 var elapsedTime = DateTime.Now - options.SurveyNewsLastCheck;
                 switch (options.SurveyNewsCheck) {
                     case SurveyNewsPolicy.Disabled:
+                        shouldQueryServer = false;
                         break;
                     case SurveyNewsPolicy.CheckOnceDay:
                         shouldQueryServer = elapsedTime.TotalDays >= 1;

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -582,7 +582,7 @@ namespace Microsoft.NodejsTools {
         }
 
         internal void CheckSurveyNews(bool forceCheckAndWarnIfNoneAvailable) {
-            if (ShouldQuerySurveryNewsServer(forceCheckAndWarnIfNoneAvailable)) {
+            if (forceCheckAndWarnIfNoneAvailable || ShouldQuerySurveryNewsServer()) {
                 var options = GeneralOptionsPage;
                 options.SurveyNewsLastCheck = DateTime.Now;
                 options.SaveSettingsToStorage();
@@ -590,11 +590,7 @@ namespace Microsoft.NodejsTools {
             }
         }
 
-        private bool ShouldQuerySurveryNewsServer(bool forceCheckAndWarnIfNoneAvailable) {
-            if (forceCheckAndWarnIfNoneAvailable) {
-                return true;
-            }
-
+        private bool ShouldQuerySurveryNewsServer() {
             var options = GeneralOptionsPage;
             // Ensure that we don't prompt the user on their very first project creation.
             // Delay by 3 days by pretending we checked 4 days ago (the default of check

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -586,7 +586,6 @@ namespace Microsoft.NodejsTools {
             if (forceCheckAndWarnIfNoneAvailable) {
                 shouldQueryServer = true;
             } else {
-                shouldQueryServer = true;
                 var options = GeneralOptionsPage;
                 // Ensure that we don't prompt the user on their very first project creation.
                 // Delay by 3 days by pretending we checked 4 days ago (the default of check
@@ -612,6 +611,7 @@ namespace Microsoft.NodejsTools {
                         break;
                     default:
                         Debug.Assert(false, String.Format("Unexpected SurveyNewsPolicy: {0}.", options.SurveyNewsCheck));
+                        shouldQueryServer = false;
                         break;
                 }
             }

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -582,45 +582,41 @@ namespace Microsoft.NodejsTools {
         }
 
         internal void CheckSurveyNews(bool forceCheckAndWarnIfNoneAvailable) {
-            bool shouldQueryServer = false;
-            if (forceCheckAndWarnIfNoneAvailable) {
-                shouldQueryServer = true;
-            } else {
-                var options = GeneralOptionsPage;
-                // Ensure that we don't prompt the user on their very first project creation.
-                // Delay by 3 days by pretending we checked 4 days ago (the default of check
-                // once a week ensures we'll check again in 3 days).
-                if (options.SurveyNewsLastCheck == DateTime.MinValue) {
-                    options.SurveyNewsLastCheck = DateTime.Now - TimeSpan.FromDays(4);
-                    options.SaveSettingsToStorage();
-                }
-
-                var elapsedTime = DateTime.Now - options.SurveyNewsLastCheck;
-                switch (options.SurveyNewsCheck) {
-                    case SurveyNewsPolicy.Disabled:
-                        shouldQueryServer = false;
-                        break;
-                    case SurveyNewsPolicy.CheckOnceDay:
-                        shouldQueryServer = elapsedTime.TotalDays >= 1;
-                        break;
-                    case SurveyNewsPolicy.CheckOnceWeek:
-                        shouldQueryServer = elapsedTime.TotalDays >= 7;
-                        break;
-                    case SurveyNewsPolicy.CheckOnceMonth:
-                        shouldQueryServer = elapsedTime.TotalDays >= 30;
-                        break;
-                    default:
-                        Debug.Assert(false, String.Format("Unexpected SurveyNewsPolicy: {0}.", options.SurveyNewsCheck));
-                        shouldQueryServer = false;
-                        break;
-                }
-            }
-
-            if (shouldQueryServer) {
+            if (ShouldQuerySurveryNewsServer(forceCheckAndWarnIfNoneAvailable)) {
                 var options = GeneralOptionsPage;
                 options.SurveyNewsLastCheck = DateTime.Now;
                 options.SaveSettingsToStorage();
                 CheckSurveyNewsThread(new Uri(options.SurveyNewsFeedUrl), forceCheckAndWarnIfNoneAvailable);
+            }
+        }
+
+        private bool ShouldQuerySurveryNewsServer(bool forceCheckAndWarnIfNoneAvailable) {
+            if (forceCheckAndWarnIfNoneAvailable) {
+                return true;
+            }
+
+            var options = GeneralOptionsPage;
+            // Ensure that we don't prompt the user on their very first project creation.
+            // Delay by 3 days by pretending we checked 4 days ago (the default of check
+            // once a week ensures we'll check again in 3 days).
+            if (options.SurveyNewsLastCheck == DateTime.MinValue) {
+                options.SurveyNewsLastCheck = DateTime.Now - TimeSpan.FromDays(4);
+                options.SaveSettingsToStorage();
+            }
+
+            var elapsedTime = DateTime.Now - options.SurveyNewsLastCheck;
+            switch (options.SurveyNewsCheck) {
+                case SurveyNewsPolicy.Disabled:
+                    return false;
+                case SurveyNewsPolicy.CheckOnceDay:
+                    return elapsedTime.TotalDays >= 1;
+                case SurveyNewsPolicy.CheckOnceWeek:
+                    return elapsedTime.TotalDays >= 7;
+                case SurveyNewsPolicy.CheckOnceMonth:
+                    return elapsedTime.TotalDays >= 30;
+                default:
+                    Debug.Assert(false, String.Format("Unexpected SurveyNewsPolicy: {0}.", options.SurveyNewsCheck));
+                    return false;
             }
         }
 


### PR DESCRIPTION
Issue #1086

##### Bug
Not honoring never setting for Survey news options. The never case is actually the worst one since it can open multiple survey news pages, one for each project.

##### Fix
Make sure we do honor this option and never automatically display survey news when enabled.

##### Testing
Manually verified bad behavior before and that this change fixes the bad behavior.

Closes #1086