### PR TITLE
#1078 Don't block install if VS version is below required version

### DIFF
--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -23,8 +23,6 @@
 
         <!-- Conditions for install -->
         <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/> 
-        <Condition Message="!(loc.VSRequires2015Update2)"> NOT VS_IS_2015_PRE_UPDATE_2 </Condition> 
-        
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>
 

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -21,5 +21,8 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
-    <String Id="VSRequires2015Update2">NTVS requires Visual Studio 2015 Update 2 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
+    <String Id="VSRequires2015Update2">Node.js Tools requires Visual Studio 2015 Update 2 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
+    <String Id="VSRequires2015Update2ContinueWarning">Continuing your installation of Node.js Tools without installing Update 2 may result in a degraded IntelliSense experience.</String>
+    <String Id="DontInstallLabel">Don't install</String>
+    <String Id="InstallAnywayLabel">Install anyway</String>
 </WixLocalization>

--- a/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
@@ -7,6 +7,22 @@
       <ProgressText Action="VWDSetup">Updating extension registration with Visual Studio Web Express...</ProgressText>
       <ProgressText Action="VWDSetup_Rollback">Removing extension registration with Visual Studio Web Express...</ProgressText>
 
+      <Dialog Id="VsPreUpdate2WarningDlg" Width="260" Height="120" Title="!(loc.CancelDlg_Title)">
+        <Control Id="AbortInstall" Type="PushButton" X="136" Y="90" Width="56" Height="17" Default="yes" Cancel="yes" Text="!(loc.DontInstallLabel)">
+          <Publish Event="EndDialog" Value="Exit">1</Publish>
+        </Control>
+        <Control Id="ContinueInstall" Type="PushButton" X="68" Y="90" Width="64" Height="17" Text="!(loc.InstallAnywayLabel)">
+          <Publish Property="ContinueInstall" Value="1">1</Publish>
+          <Publish Event="EndDialog" Value="Return">1</Publish>
+        </Control>
+        <Control Id="TextVersionWarning" Type="Text" X="48" Y="15" Width="194" Height="45" Text="!(loc.VSRequires2015Update2)" />
+        <Control Id="TextContinueWarning" Type="Text" X="48" Y="50" Width="194" Height="35" Text="!(loc.VSRequires2015Update2ContinueWarning)"/>
+        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.CancelDlgIconTooltip)" FixedSize="yes" IconSize="48" Text="WixUI_Ico_Exclam" />
+      </Dialog>
+      <Publish Event="SpawnDialog" Dialog="CustomAdvancedWelcomeEulaDlg" Control="LicenseText" Value="VsPreUpdate2WarningDlg">
+        <![CDATA[VS_IS_2015_PRE_UPDATE_2="1" AND ContinueInstall<>"1"]]>
+      </Publish>
+
       <Dialog Id="CustomAdvancedWelcomeEulaDlg" Width="370" Height="270" Title="!(loc.AdvancedWelcomeEulaDlg_Title)">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.AdvancedWelcomeEulaDlgBannerBitmap)" />
         <Control Id="Title" Type="Text" X="20" Y="10" Width="300" Height="24" Transparent="yes" NoPrefix="yes" Text="!(loc.AdvancedWelcomeEulaDlgTitle)" />
@@ -152,6 +168,7 @@
     </UI>
 
     <Property Id="EasyInstall" Value="0" />
+    <Property Id="ContinueInstall" Value="0"/>
     <UIRef Id="WixUI_Common" />
 
     <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />


### PR DESCRIPTION
Issue #1078
Instead warn users, but allow them to continue with the installation even
if the detected version is less than what NTVS requires
![image](https://cloud.githubusercontent.com/assets/762848/16344464/8a0fe702-39f1-11e6-9d11-7396ca88d0f8.png)

##### Testing
* Set VS_IS_2015_PRE_UPDATE_2 property to 0 and 1, walk through several installer workflows (install, upgrade, different options)
* verify dialog pops up when it's set to 1
* verify doesn't pop up when it's set to 0
* verify "continue anyways" does not abort install
* verify "don't install" aborts install
* verify message box default selections
* verify dialog pops up at most once in any workflow
* verify message box text displays appropriately on different windows font sizes

close #1078