### PR TITLE
Update Installer Gate for NTVS 1.2 Beta to target VS 2015 Update 3 or later

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -64,11 +64,11 @@
   </Fragment>
 
   <Fragment>
-    <Property Id="VS_IS_2015_PRE_UPDATE_2" Secure="yes">
+    <Property Id="VS_IS_2015_PRE_UPDATE_3" Secure="yes">
       <?if "$(var.VSTargetVersion)"="14.0" ?>
         <RegistrySearch Id="VSPrereleaseInstallDir" Root="HKLM" Key="Software\Microsoft\VisualStudio\$(var.VSTargetVersion)\Setup\VS" Name="ProductDir" Type="directory">
           <DirectorySearch Id="VSPrereleaseInstallDir_Common7_IDE" Path="Common7\IDE" Depth="1">
-            <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.25122.0"/>
+            <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.25414.0"/>
           </DirectorySearch>
         </RegistrySearch>
       <?endif ?>

--- a/Nodejs/Product/AssemblyVersion.cs
+++ b/Nodejs/Product/AssemblyVersion.cs
@@ -41,7 +41,7 @@ class AssemblyVersionInfo {
 
     // This version should never change from "4100.00"; BuildRelease.ps1
     // will replace it with a generated value.
-    public const string BuildNumber = "40624.23";
+    public const string BuildNumber = "4100.00";
 #if DEV11
     public const string VSMajorVersion = "11";
     const string VSVersionSuffix = "2012";

--- a/Nodejs/Product/AssemblyVersion.cs
+++ b/Nodejs/Product/AssemblyVersion.cs
@@ -41,7 +41,7 @@ class AssemblyVersionInfo {
 
     // This version should never change from "4100.00"; BuildRelease.ps1
     // will replace it with a generated value.
-    public const string BuildNumber = "4100.00";
+    public const string BuildNumber = "40624.23";
 #if DEV11
     public const string VSMajorVersion = "11";
     const string VSVersionSuffix = "2012";

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -22,10 +22,10 @@
         <Property Id="ARPPRODUCTICON">AddRemoveProgramsIcon</Property>
 
         <!-- Conditions for install -->
-        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_2"/> 
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>
 
+        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_3"/>
         <PropertyRef Id="VSINSTALLPATH"/>
         <PropertyRef Id="VWDINSTALLPATH"/>
         <PropertyRef Id="DEVENV_PATH"/>
@@ -146,6 +146,7 @@
         </InstallExecuteSequence>
         <InstallUISequence>
             <Show Dialog="CustomAdvancedWelcomeEulaDlg" Before="FindRelatedProducts">NOT Installed</Show>
+            <Show Dialog="VsPreUpdate3WarningDlg" After="FindRelatedProducts">VS_IS_2015_PRE_UPDATE_3</Show>
             <Show Dialog="CustomFeaturesDlg" After="CostFinalize">NOT Installed AND EasyInstall=0</Show>
             <Show Dialog="CustomExitDialog" OnExit="success" />
         </InstallUISequence>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -146,7 +146,6 @@
         </InstallExecuteSequence>
         <InstallUISequence>
             <Show Dialog="CustomAdvancedWelcomeEulaDlg" Before="FindRelatedProducts">NOT Installed</Show>
-            <Show Dialog="VsPreUpdate3WarningDlg" After="FindRelatedProducts">VS_IS_2015_PRE_UPDATE_3</Show>
             <Show Dialog="CustomFeaturesDlg" After="CostFinalize">NOT Installed AND EasyInstall=0</Show>
             <Show Dialog="CustomExitDialog" OnExit="success" />
         </InstallUISequence>

--- a/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
+++ b/Nodejs/Setup/NodejsToolsInstaller/Strings14.0.wxl
@@ -21,8 +21,8 @@
     <String Id="VWDExpressSetup_Rollback">Removing extension from !(loc.VWDProductName)...</String>
     <String Id="AcceptLicenseText">I agree to the license terms and conditions and to the</String>
     <String Id="PrivacyStatementLinkText">privacy statement</String>
-    <String Id="VSRequires2015Update2">Node.js Tools requires Visual Studio 2015 Update 2 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
-    <String Id="VSRequires2015Update2ContinueWarning">Continuing your installation of Node.js Tools without installing Update 2 may result in a degraded IntelliSense experience.</String>
+    <String Id="VSRequires2015Update3">Node.js Tools requires Visual Studio 2015 Update 3 or later. Please install it from  http://go.microsoft.com/fwlink/?LinkID=808380</String> 
+    <String Id="VSRequires2015Update3ContinueWarning">Continuing your installation of Node.js Tools without installing Update 3 may result in a degraded IntelliSense experience.</String>
     <String Id="DontInstallLabel">Don't install</String>
     <String Id="InstallAnywayLabel">Install anyway</String>
 </WixLocalization>

--- a/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
@@ -19,6 +19,9 @@
         <Control Id="TextContinueWarning" Type="Text" X="48" Y="50" Width="194" Height="35" Text="!(loc.VSRequires2015Update3ContinueWarning)"/>
         <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.CancelDlgIconTooltip)" FixedSize="yes" IconSize="48" Text="WixUI_Ico_Exclam" />
       </Dialog>
+      <Publish Event="SpawnDialog" Dialog="CustomAdvancedWelcomeEulaDlg" Control="LicenseText" Value="VsPreUpdate3WarningDlg">
+        <![CDATA[VS_IS_2015_PRE_UPDATE_3="1" AND ContinueInstall<>"1"]]> 
+      </Publish> 
 
       <Dialog Id="CustomAdvancedWelcomeEulaDlg" Width="370" Height="270" Title="!(loc.AdvancedWelcomeEulaDlg_Title)">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.AdvancedWelcomeEulaDlgBannerBitmap)" />

--- a/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
@@ -7,7 +7,7 @@
       <ProgressText Action="VWDSetup">Updating extension registration with Visual Studio Web Express...</ProgressText>
       <ProgressText Action="VWDSetup_Rollback">Removing extension registration with Visual Studio Web Express...</ProgressText>
 
-      <Dialog Id="VsPreUpdate2WarningDlg" Width="260" Height="120" Title="!(loc.CancelDlg_Title)">
+      <Dialog Id="VsPreUpdate3WarningDlg" Width="260" Height="120" Title="!(loc.CancelDlg_Title)">
         <Control Id="AbortInstall" Type="PushButton" X="136" Y="90" Width="56" Height="17" Default="yes" Cancel="yes" Text="!(loc.DontInstallLabel)">
           <Publish Event="EndDialog" Value="Exit">1</Publish>
         </Control>
@@ -15,13 +15,10 @@
           <Publish Property="ContinueInstall" Value="1">1</Publish>
           <Publish Event="EndDialog" Value="Return">1</Publish>
         </Control>
-        <Control Id="TextVersionWarning" Type="Text" X="48" Y="15" Width="194" Height="45" Text="!(loc.VSRequires2015Update2)" />
-        <Control Id="TextContinueWarning" Type="Text" X="48" Y="50" Width="194" Height="35" Text="!(loc.VSRequires2015Update2ContinueWarning)"/>
+        <Control Id="TextVersionWarning" Type="Text" X="48" Y="15" Width="194" Height="45" Text="!(loc.VSRequires2015Update3)" />
+        <Control Id="TextContinueWarning" Type="Text" X="48" Y="50" Width="194" Height="35" Text="!(loc.VSRequires2015Update3ContinueWarning)"/>
         <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.CancelDlgIconTooltip)" FixedSize="yes" IconSize="48" Text="WixUI_Ico_Exclam" />
       </Dialog>
-      <Publish Event="SpawnDialog" Dialog="CustomAdvancedWelcomeEulaDlg" Control="LicenseText" Value="VsPreUpdate2WarningDlg">
-        <![CDATA[VS_IS_2015_PRE_UPDATE_2="1" AND ContinueInstall<>"1"]]>
-      </Publish>
 
       <Dialog Id="CustomAdvancedWelcomeEulaDlg" Width="370" Height="270" Title="!(loc.AdvancedWelcomeEulaDlg_Title)">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.AdvancedWelcomeEulaDlgBannerBitmap)" />

--- a/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
@@ -20,8 +20,8 @@
         <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.CancelDlgIconTooltip)" FixedSize="yes" IconSize="48" Text="WixUI_Ico_Exclam" />
       </Dialog>
       <Publish Event="SpawnDialog" Dialog="CustomAdvancedWelcomeEulaDlg" Control="LicenseText" Value="VsPreUpdate3WarningDlg">
-        <![CDATA[VS_IS_2015_PRE_UPDATE_3="1" AND ContinueInstall<>"1"]]> 
-      </Publish> 
+        <![CDATA[VS_IS_2015_PRE_UPDATE_3="1" AND ContinueInstall<>"1"]]>
+      </Publish>
 
       <Dialog Id="CustomAdvancedWelcomeEulaDlg" Width="370" Height="270" Title="!(loc.AdvancedWelcomeEulaDlg_Title)">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.AdvancedWelcomeEulaDlgBannerBitmap)" />


### PR DESCRIPTION
Updates the Installer gating to target VS 2015 update 3 or later.

Also move the non-update 3 warning UI to be part of `InstallUISequence`

Closes #994