### PR TITLE
Use msbuild version based on VSTarget version in BuildRelease.ps1

### DIFF
--- a/Nodejs/Setup/BuildRelease.ps1
+++ b/Nodejs/Setup/BuildRelease.ps1
@@ -170,13 +170,13 @@ if ($release -or $mockrelease) {
 }
 
 # Get the path to msbuild for a configuration
-function msbuild-exe($target, $config) {
-	$toolpath = Get-ItemProperty -Path "HKLM:\Software\Wow6432Node\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
-	$target_exe = $toolpath.MSBuildToolsPath + "msbuild.exe"
-	if (-not (Test-Path $target_exe)) {
-		Throw "Visual Studio build tools not found for $($target.VSTarget)."
-	}
-	$target_exe
+function msbuild-exe($target) {
+    $toolpath = Get-ItemProperty -Path "HKLM:\Software\Wow6432Node\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
+    $target_exe = $toolpath.MSBuildToolsPath + "msbuild.exe"
+    if (-not (Test-Path $target_exe)) {
+        Throw "Visual Studio build tools $($target.VSTarget) not found."
+    }
+    $target_exe
 }
 
 # This function is used to get options for each configuration
@@ -472,7 +472,7 @@ try {
         
         foreach ($i in $target_info) {
             if (-not $skipbuild) {
-				$target_msbuild_exe = msbuild-exe $i
+                $target_msbuild_exe = msbuild-exe $i
                 $target_msbuild_options = msbuild-options $i
                 if (-not $skipclean) {
                     & $target_msbuild_exe /t:Clean $global_msbuild_options $target_msbuild_options $build_project
@@ -525,8 +525,8 @@ try {
                 }
                 submit_symbols "$project_name$spacename" "$buildnumber $($i.VSName) $config" "binaries" $i.signed_bindir $symbol_contacts
                 submit_symbols "$project_name$spacename" "$buildnumber $($i.VSName) $config" "symbols" $i.symboldir $symbol_contacts
-				
-				$target_msbuild_exe = msbuild-exe $i
+
+                $target_msbuild_exe = msbuild-exe $i
                 $target_msbuild_options = msbuild-options $i
                 & $target_msbuild_exe $global_msbuild_options $target_msbuild_options `
                     /fl /flp:logfile=$($i.signed_logfile) `

--- a/Nodejs/Setup/BuildRelease.ps1
+++ b/Nodejs/Setup/BuildRelease.ps1
@@ -171,7 +171,7 @@ if ($release -or $mockrelease) {
 
 # Get the path to msbuild for a configuration
 function msbuild-exe($target) {
-    $msbuild_reg = Get-ItemProperty -Path "HKLM:\Software\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
+    $msbuild_reg = Get-ItemProperty -Path "HKLM:\Software\Wow6432Node\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
     if (-not $msbuild_reg) {
         Throw "Visual Studio build tools $($target.VSTarget) not found."
     }

--- a/Nodejs/Setup/BuildRelease.ps1
+++ b/Nodejs/Setup/BuildRelease.ps1
@@ -171,9 +171,13 @@ if ($release -or $mockrelease) {
 
 # Get the path to msbuild for a configuration
 function msbuild-exe($target) {
-    $toolpath = Get-ItemProperty -Path "HKLM:\Software\Wow6432Node\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
-    $target_exe = $toolpath.MSBuildToolsPath + "msbuild.exe"
-    if (-not (Test-Path $target_exe)) {
+    $msbuild_reg = Get-ItemProperty -Path "HKLM:\Software\Microsoft\MSBuild\ToolsVersions\$($target.VSTarget)" -EA 0
+    if (-not $msbuild_reg) {
+        Throw "Visual Studio build tools $($target.VSTarget) not found."
+    }
+    
+    $target_exe = $msbuild_reg.MSBuildToolsPath + "msbuild.exe"
+    if (-not (Test-Path -Path $target_exe)) {
         Throw "Visual Studio build tools $($target.VSTarget) not found."
     }
     $target_exe


### PR DESCRIPTION
##### Bug
The BuildRelease.ps1 script can only be run from a visual studio command prompt. It needs a specific version of msbuild, and the default one found by a powershell / normal command prompt will not work.

##### Fix
Lookup the msbuild path based on the vstarget version we are using for the build. This checks the registry to find where `msbuild.exe` is located.

closes #1101