### PR TITLE
#1104 VS Update 3 gating check is unreliable

### DIFF
--- a/Common/Setup/LaunchConditions.wxs
+++ b/Common/Setup/LaunchConditions.wxs
@@ -66,11 +66,9 @@
   <Fragment>
     <Property Id="VS_IS_2015_PRE_UPDATE_3" Secure="yes">
       <?if "$(var.VSTargetVersion)"="14.0" ?>
-        <RegistrySearch Id="VSPrereleaseInstallDir" Root="HKLM" Key="Software\Microsoft\VisualStudio\$(var.VSTargetVersion)\Setup\VS" Name="ProductDir" Type="directory">
-          <DirectorySearch Id="VSPrereleaseInstallDir_Common7_IDE" Path="Common7\IDE" Depth="1">
-            <FileSearch Id="VSPrerelease_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.25414.0"/>
-          </DirectorySearch>
-        </RegistrySearch>
+        <DirectorySearch Id="VSPreUpdate3InstallDir_Common7_IDE" Path="[VSINSTALLPATH]" Depth="1">
+          <FileSearch Id="VSPreUpdate3_Common7_IDE_msenv_dll" Name="msenv.dll" MinVersion="14.0.0.0" MaxVersion="14.0.25414.0"/>
+        </DirectorySearch>
       <?endif ?>
     </Property>
   </Fragment>

--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -25,8 +25,8 @@
         <PropertyRef Id="NETFRAMEWORK45"/>
         <Condition Message="!(loc.NetFx45NotInstalled)"> NETFRAMEWORK45 OR Installed </Condition>
 
-        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_3"/>
         <PropertyRef Id="VSINSTALLPATH"/>
+        <PropertyRef Id="VS_IS_2015_PRE_UPDATE_3"/>
         <PropertyRef Id="VWDINSTALLPATH"/>
         <PropertyRef Id="DEVENV_PATH"/>
         <PropertyRef Id="VWDEXPRESS_PATH"/>
@@ -146,6 +146,7 @@
         </InstallExecuteSequence>
         <InstallUISequence>
             <Show Dialog="CustomAdvancedWelcomeEulaDlg" Before="FindRelatedProducts">NOT Installed</Show>
+            <Show Dialog="VsPreUpdate3WarningDlg" Before="CostInitialize">VS_IS_2015_PRE_UPDATE_3 AND NOT Installed</Show>
             <Show Dialog="CustomFeaturesDlg" After="CostFinalize">NOT Installed AND EasyInstall=0</Show>
             <Show Dialog="CustomExitDialog" OnExit="success" />
         </InstallUISequence>

--- a/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/UI.wxs
@@ -12,17 +12,12 @@
           <Publish Event="EndDialog" Value="Exit">1</Publish>
         </Control>
         <Control Id="ContinueInstall" Type="PushButton" X="68" Y="90" Width="64" Height="17" Text="!(loc.InstallAnywayLabel)">
-          <Publish Property="ContinueInstall" Value="1">1</Publish>
           <Publish Event="EndDialog" Value="Return">1</Publish>
         </Control>
         <Control Id="TextVersionWarning" Type="Text" X="48" Y="15" Width="194" Height="45" Text="!(loc.VSRequires2015Update3)" />
         <Control Id="TextContinueWarning" Type="Text" X="48" Y="50" Width="194" Height="35" Text="!(loc.VSRequires2015Update3ContinueWarning)"/>
         <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.CancelDlgIconTooltip)" FixedSize="yes" IconSize="48" Text="WixUI_Ico_Exclam" />
       </Dialog>
-      <Publish Event="SpawnDialog" Dialog="CustomAdvancedWelcomeEulaDlg" Control="LicenseText" Value="VsPreUpdate3WarningDlg">
-        <![CDATA[VS_IS_2015_PRE_UPDATE_3="1" AND ContinueInstall<>"1"]]>
-      </Publish>
-
       <Dialog Id="CustomAdvancedWelcomeEulaDlg" Width="370" Height="270" Title="!(loc.AdvancedWelcomeEulaDlg_Title)">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.AdvancedWelcomeEulaDlgBannerBitmap)" />
         <Control Id="Title" Type="Text" X="20" Y="10" Width="300" Height="24" Transparent="yes" NoPrefix="yes" Text="!(loc.AdvancedWelcomeEulaDlgTitle)" />
@@ -168,7 +163,6 @@
     </UI>
 
     <Property Id="EasyInstall" Value="0" />
-    <Property Id="ContinueInstall" Value="0"/>
     <UIRef Id="WixUI_Common" />
 
     <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />


### PR DESCRIPTION
Issue #1104
* update way we check VS version - instead use VS install path to check assembly version
* change way we spawn U3 gating dialog - for some reason variables weren't being initialized properly at the EULA dialog, so in the interim, simply launch the dialog in a similar fashion that we do with other dialogs

##### Testing
* verify that the version check works properly by changing up the target assembly version
* verify the check works properly on a couple machines
* verify dialog doesn't pop up when changing / uninstalling NTVS
* verify dialog fires on both advanced and regular installs
* verify dialog appears at most once throughout flow