### PR TITLE
Prototype Starter Express App template Express 3 to 4 change

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -910,6 +910,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>ItemTemplates</VSIXSubPath>
     </Content>
+    <ZipProject Include="ProjectTemplates\StarterExpressApp\www" />
     <None Include="Theme\contrast.vstheme">
       <SubType>Designer</SubType>
     </None>
@@ -1064,7 +1065,6 @@
     <ZipProject Include="ProjectTemplates\StarterExpressApp\StarterExpressApp.vstemplate">
       <SubType>Designer</SubType>
     </ZipProject>
-    <ZipProject Include="ProjectTemplates\StarterExpressApp\user.js" />
     <TypeScriptProject Include="ProjectTemplates\TypeScriptStarterExpressApp\_references.js" />
     <TypeScriptProject Include="ProjectTemplates\TypeScriptStarterExpressApp\app.ts" />
     <TypeScriptProject Include="ProjectTemplates\TypeScriptStarterExpressApp\bootstrap.css" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/StarterExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/StarterExpressApp.njsproj
@@ -10,7 +10,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>$guid1$</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>app.js</StartupFile>
+    <StartupFile>bin\www</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
@@ -29,6 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="app.js" />
+    <Compile Include="bin\www" />
     <Compile Include="routes\index.js" />
   </ItemGroup>
   <ItemGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/StarterExpressApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/StarterExpressApp.vstemplate
@@ -15,6 +15,9 @@
   </TemplateData>
   <TemplateContent>
     <Project File="StarterExpressApp.njsproj" ReplaceParameters="true">
+      <Folder Name="bin">
+        <ProjectItem ReplaceParameters="true">www</ProjectItem>
+      </Folder>
       <Folder Name="public">
         <Folder Name="fonts">
           <ProjectItem>glyphicons-halflings-regular.eot</ProjectItem>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/app.js
@@ -1,37 +1,59 @@
-﻿
-/**
- * Module dependencies.
- */
-
-var express = require('express');
-var routes = require('./routes');
-var http = require('http');
+﻿var express = require('express');
 var path = require('path');
+var favicon = require('serve-favicon');
+var logger = require('morgan');
+var cookieParser = require('cookie-parser');
+var bodyParser = require('body-parser');
+
+var routes = require('./routes/index');
 
 var app = express();
 
-// all environments
-app.set('port', process.env.PORT || 3000);
+// view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
-app.use(express.favicon());
-app.use(express.logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded());
-app.use(express.methodOverride());
-app.use(app.router);
+
+// uncomment after placing your favicon in /public
+//app.use(favicon(__dirname + '/public/favicon.ico'));
+app.use(logger('dev'));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(cookieParser());
 app.use(require('stylus').middleware(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'public')));
 
-// development only
-if ('development' == app.get('env')) {
-    app.use(express.errorHandler());
+app.use('/', routes);
+
+// catch 404 and forward to error handler
+app.use(function (req, res, next) {
+    var err = new Error('Not Found');
+    err.status = 404;
+    next(err);
+});
+
+// error handlers
+
+// development error handler
+// will print stacktrace
+if (app.get('env') === 'development') {
+    app.use(function (err, req, res, next) {
+        res.status(err.status || 500);
+        res.render('error', {
+            message: err.message,
+            error: err
+        });
+    });
 }
 
-app.get('/', routes.index);
-app.get('/about', routes.about);
-app.get('/contact', routes.contact);
-
-http.createServer(app).listen(app.get('port'), function () {
-    console.log('Express server listening on port ' + app.get('port'));
+// production error handler
+// no stacktraces leaked to user
+app.use(function (err, req, res, next) {
+    res.status(err.status || 500);
+    res.render('error', {
+        message: err.message,
+        error: {}
+    });
 });
+
+
+module.exports = app;

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/index.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/index.js
@@ -1,16 +1,16 @@
-﻿
-/*
- * GET home page.
- */
+﻿var express = require('express');
+var router = express.Router();
 
-exports.index = function (req, res) {
+router.get('/', function (req, res) {
     res.render('index', { title: 'Express', year: new Date().getFullYear() });
-};
+});
 
-exports.about = function (req, res) {
+router.get('/about', function (req, res) {
     res.render('about', { title: 'About', year: new Date().getFullYear(), message: 'Your application description page' });
-};
+});
 
-exports.contact = function (req, res) {
+router.get('/contact', function (req, res) {
     res.render('contact', { title: 'Contact', year: new Date().getFullYear(), message: 'Your contact page' });
-};
+});
+
+module.exports = router;

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/package.json
@@ -1,14 +1,22 @@
 {
   "name": "$npmsafeprojectname$",
   "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node ./bin/www"
+  },
   "description": "$projectname$",
-  "main": "app.js",
   "author": {
     "name": "$username$"
   },
   "dependencies": {
-    "express": "3.4.4",
-    "jade": "*",
-    "stylus": "*"
+    "express": "~4.9.0",
+    "body-parser": "~1.8.1",
+    "cookie-parser": "~1.3.3",
+    "morgan": "~1.3.0",
+    "serve-favicon": "~2.1.3",
+    "debug": "~2.0.0",
+    "jade": "~1.6.0",
+    "stylus": "0.42.3"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/typings.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/typings.json
@@ -1,6 +1,15 @@
 {
   "globalDependencies": {
-    "express": "registry:dt/express#3.1.0+20140618213111",
-    "jade": "registry:dt/jade#0.0.0+20160316155526"
+    "body-parser": "registry:dt/body-parser#0.0.0+20160317120654",
+    "cookie-parser": "registry:dt/cookie-parser#1.3.4+20160316155526",
+    "debug": "registry:dt/debug#0.0.0+20160317120654",
+    "express": "registry:dt/express#4.0.0+20160317120654",
+    "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160602151406",
+    "jade": "registry:dt/jade#0.0.0+20160316155526",
+    "mime": "registry:dt/mime#0.0.0+20160316155526",
+    "morgan": "registry:dt/morgan#1.7.0+20160524142355",
+    "serve-favicon": "registry:dt/serve-favicon#0.0.0+20160316155526",
+    "serve-static": "registry:dt/serve-static#0.0.0+20160606155157",
+    "stylus": "registry:dt/stylus#0.0.0+20160317120654"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/user.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/user.js
@@ -1,8 +1,0 @@
-﻿
-/*
- * GET users listing.
- */
-
-exports.list = function(req, res){
-  res.send("respond with a resource");
-};

--- a/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/www
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/StarterExpressApp/www
@@ -1,0 +1,9 @@
+﻿#!/usr/bin/env node
+var debug = require('debug')('$safeprojectname$');
+var app = require('../app');
+
+app.set('port', process.env.PORT || 3000);
+
+var server = app.listen(app.get('port'), function() {
+    debug('Express server listening on port ' + server.address().port);
+});

--- a/Nodejs/Product/Nodejs/Templates/VS_Nodejs.item.vstman
+++ b/Nodejs/Product/Nodejs/Templates/VS_Nodejs.item.vstman
@@ -622,8 +622,8 @@
     <TemplateFileName>StarterExpressApp.vstemplate</TemplateFileName>
     <VSTemplateHeader>
       <TemplateData xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
-        <Name>Starter Node.js Express 3 Application</Name>
-        <Description>A project for creating an application using the Express 3 web framework with the Jade template engine. It features sample pages that use the Twitter Bootstrap framework for responsive web design.</Description>
+        <Name>Starter Node.js Express 4 Application</Name>
+        <Description>A project for creating an application using the Express 4 web framework with the Jade template engine. It features sample pages that use the Twitter Bootstrap framework for responsive web design.</Description>
         <Icon Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="406" />
         <ProjectType>JavaScript</ProjectType>
         <TemplateID>Microsoft.JavaScript.StarterExpressApp</TemplateID>
@@ -642,8 +642,8 @@
     <TemplateFileName>StarterExpressApp.vstemplate</TemplateFileName>
     <VSTemplateHeader>
       <TemplateData xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
-        <Name>Starter Node.js Express 3 Application</Name>
-        <Description>A project for creating an application using the Express 3 web framework with the Jade template engine. It features sample pages that use the Twitter Bootstrap framework for responsive web design.</Description>
+        <Name>Starter Node.js Express 4 Application</Name>
+        <Description>A project for creating an application using the Express 4 web framework with the Jade template engine. It features sample pages that use the Twitter Bootstrap framework for responsive web design.</Description>
         <Icon Package="{FE8A8C3D-328A-476D-99F9-2A24B75F8C7F}" ID="406" />
         <ProjectType>JavaScript</ProjectType>
         <TemplateID>Microsoft.JavaScript.StarterExpressApp</TemplateID>


### PR DESCRIPTION
Related to #1058

This prototypes moving the basic StarterApp from Express3 to Express4. The update is based on our existing Express 4 template.

I'd like to get feedback on this change before doing the work to migrate the other 5 Starter Express based templates.

If we can cut down the number of templates, that would also help us a lot.