### PR TITLE
Adds Telemetry for IntelliSense Levels

### DIFF
--- a/Nodejs/Common/Telemetry/TelemetryEvents.cs
+++ b/Nodejs/Common/Telemetry/TelemetryEvents.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// </summary>
     internal static class TelemetryEvents {
         public const string ProjectImported = "ProjectImported";
-        public const string IntelliSenseActivatedForProject = "IntelliSenseActivatedForProject";
-        public const string IntelliSenseLevelChanged = "IntelliSenseLevelChanged";
+        public const string AnalysisActivatedForProject = "AnalysisActivatedForProject";
+        public const string AnalysisLevelChanged = "AnalysisLevelChanged";
     }
 }

--- a/Nodejs/Common/Telemetry/TelemetryEvents.cs
+++ b/Nodejs/Common/Telemetry/TelemetryEvents.cs
@@ -20,5 +20,7 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// </summary>
     internal static class TelemetryEvents {
         public const string ProjectImported = "ProjectImported";
+        public const string IntelliSenseActivatedForProject = "IntelliSenseActivatedForProject";
+        public const string IntelliSenseLevelChanged = "IntelliSenseLevelChanged";
     }
 }

--- a/Nodejs/Common/Telemetry/TelemetryProperties.cs
+++ b/Nodejs/Common/Telemetry/TelemetryProperties.cs
@@ -20,5 +20,6 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// </summary>
     internal static class TelemetryProperties {
         public const string ProjectGuid = "ProjectGuid";
+        public const string IntelliSenseLevel = "IntelliSenseLevel";
     }
 }

--- a/Nodejs/Common/Telemetry/TelemetryProperties.cs
+++ b/Nodejs/Common/Telemetry/TelemetryProperties.cs
@@ -20,6 +20,6 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// </summary>
     internal static class TelemetryProperties {
         public const string ProjectGuid = "ProjectGuid";
-        public const string IntelliSenseLevel = "IntelliSenseLevel";
+        public const string AnalysisLevel = "AnalysisLevel";
     }
 }

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -684,6 +684,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="NodejsPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Telemetry\NodejsTelemetryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <TelemetryFiles Include="..\..\Common\Telemetry\*.cs" />

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -241,6 +241,8 @@ namespace Microsoft.NodejsTools {
             MakeDebuggerContextAvailable();
 
             IntellisenseOptionsPage.AnalysisLogMaximumChanged += IntellisenseOptionsPage_AnalysisLogMaximumChanged;
+            IntellisenseOptionsPage.AnalysisLevelChanged += IntellisenseOptionsPageAnalysisLevelChanged;
+            IntellisenseOptionsPage.SaveToDiskChanged += IntellisenseOptionsPageSaveToDiskChanged;
 
             InitializeLogging();
 
@@ -633,25 +635,28 @@ namespace Microsoft.NodejsTools {
                     _analyzer = CreateLooseVsProjectAnalyzer();
                     LogLooseFileAnalysisLevel();
                     _analyzer.MaxLogLength = IntellisenseOptionsPage.AnalysisLogMax;
-                    IntellisenseOptionsPage.AnalysisLevelChanged += IntellisenseOptionsPageAnalysisLevelChanged;
-                    IntellisenseOptionsPage.SaveToDiskChanged += IntellisenseOptionsPageSaveToDiskChanged;
                 }
                 return _analyzer;
             }
         }
 
         private void IntellisenseOptionsPageSaveToDiskChanged(object sender, EventArgs e) {
-            _analyzer.SaveToDisk = IntellisenseOptionsPage.SaveToDisk;
+            if (_analyzer != null) {
+                _analyzer.SaveToDisk = IntellisenseOptionsPage.SaveToDisk;
+            }
         }
 
         private void IntellisenseOptionsPageAnalysisLevelChanged(object sender, EventArgs e) {
-            var analyzer = CreateLooseVsProjectAnalyzer();
-            analyzer.SwitchAnalyzers(_analyzer);
-            if (_analyzer.RemoveUser()) {
-                _analyzer.Dispose();
+            if (_analyzer != null) {
+                var analyzer = CreateLooseVsProjectAnalyzer();
+                analyzer.SwitchAnalyzers(_analyzer);
+                if (_analyzer.RemoveUser()) {
+                    _analyzer.Dispose();
+                }
+                _analyzer = analyzer;
+                LogLooseFileAnalysisLevel();
             }
-            _analyzer = analyzer;
-            LogLooseFileAnalysisLevel();
+            TelemetryLogger.LogIntelliSenseLevelChanged(IntellisenseOptionsPage.AnalysisLevel);
         }
 
         private VsProjectAnalyzer CreateLooseVsProjectAnalyzer() {
@@ -660,7 +665,7 @@ namespace Microsoft.NodejsTools {
             // it will throw to JSLS. This means that currently, loose files will be handled by the JSLS editor,
             // rather than the NodeLS editor (which means that the loose project analyzer will not be invoked
             // in these scenarios.)
-            //
+            //git sta
             // Because Salsa doesn't support the stitching together inputs from the surrounding text view,
             // we do not throw to Salsa from the REPL window. However, in order to provide a workable editing
             // experience within the REPL context, we initialize the loose analyzer with Quick IntelliSense
@@ -671,8 +676,7 @@ namespace Microsoft.NodejsTools {
 
         private void LogLooseFileAnalysisLevel() {
             var analyzer = _analyzer;
-            if(analyzer != null)
-            {
+            if (analyzer != null) {
                 var val = analyzer.AnalysisLevel;
                 _logger.LogEvent(NodejsToolsLogEvent.AnalysisLevel, (int)val);
             }

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -665,7 +665,7 @@ namespace Microsoft.NodejsTools {
             // it will throw to JSLS. This means that currently, loose files will be handled by the JSLS editor,
             // rather than the NodeLS editor (which means that the loose project analyzer will not be invoked
             // in these scenarios.)
-            //git sta
+            //
             // Because Salsa doesn't support the stitching together inputs from the surrounding text view,
             // we do not throw to Salsa from the REPL window. However, in order to provide a workable editing
             // experience within the REPL context, we initialize the loose analyzer with Quick IntelliSense

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -656,7 +656,7 @@ namespace Microsoft.NodejsTools {
                 _analyzer = analyzer;
                 LogLooseFileAnalysisLevel();
             }
-            TelemetryLogger.LogIntelliSenseLevelChanged(IntellisenseOptionsPage.AnalysisLevel);
+            TelemetryLogger.LogAnalysisLevelChanged(IntellisenseOptionsPage.AnalysisLevel);
         }
 
         private VsProjectAnalyzer CreateLooseVsProjectAnalyzer() {

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -208,9 +208,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
                     using (var writer = GetDefaultWriter(projectPath)) {
                         WriteProjectXml(writer, projectPath, sourcePath, filters, startupFile, true, out projectGuid);
                     }
-                    if (NodejsPackage.Instance != null) {
-                        NodejsPackage.Instance.TelemetryLogger.ReportEvent(TelemetryEvents.ProjectImported, TelemetryProperties.ProjectGuid, projectGuid.ToString("B"));
-                    }
+                    NodejsPackage.Instance?.TelemetryLogger.LogProjectImported(projectGuid);
                     success = true;
                     return projectPath;
                 } finally {

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -35,6 +35,7 @@ using Microsoft.VisualStudioTools.Project.Automation;
 using MSBuild = Microsoft.Build.Evaluation;
 using VsCommands = Microsoft.VisualStudio.VSConstants.VSStd97CmdID;
 using Microsoft.NodejsTools.Options;
+using Microsoft.NodejsTools.Telemetry;
 #if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
@@ -605,9 +606,11 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-        private static void LogAnalysisLevel(VsProjectAnalyzer analyzer) {
+        private void LogAnalysisLevel(VsProjectAnalyzer analyzer) {
             if (analyzer != null) {
-                NodejsPackage.Instance.Logger.LogEvent(Logging.NodejsToolsLogEvent.AnalysisLevel, (int)analyzer.AnalysisLevel);
+                var level = analyzer.AnalysisLevel;
+                NodejsPackage.Instance.Logger.LogEvent(Logging.NodejsToolsLogEvent.AnalysisLevel, (int)level);
+                NodejsPackage.Instance.TelemetryLogger.LogIntelliSenseActivatedForProject(ProjectGuid, level);
             }
         }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -610,7 +610,7 @@ namespace Microsoft.NodejsTools.Project {
             if (analyzer != null) {
                 var level = analyzer.AnalysisLevel;
                 NodejsPackage.Instance.Logger.LogEvent(Logging.NodejsToolsLogEvent.AnalysisLevel, (int)level);
-                NodejsPackage.Instance.TelemetryLogger.LogIntelliSenseActivatedForProject(ProjectGuid, level);
+                NodejsPackage.Instance.TelemetryLogger.LogAnalysisActivatedForProject(ProjectGuid, level);
             }
         }
 

--- a/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
@@ -1,0 +1,46 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+using System;
+
+namespace Microsoft.NodejsTools.Telemetry {
+    /// <summary>
+    /// Extensions for logging telemetry events.
+    /// </summary>
+    internal static class NodejsTelemetryExtensions {
+        public static void LogIntelliSenseActivatedForProject(this ITelemetryLogger logger, Guid projectGuid, Options.AnalysisLevel newAnalysisLevel) {
+            logger.ReportEvent(
+                TelemetryEvents.IntelliSenseActivatedForProject,
+                new DataPointCollection(
+                    new DataPoint(TelemetryProperties.ProjectGuid, projectGuid.ToString("B")),
+                    new DataPoint(TelemetryProperties.IntelliSenseLevel, newAnalysisLevel.ToString())));
+        }
+
+        public static void LogIntelliSenseLevelChanged(this ITelemetryLogger logger, Options.AnalysisLevel newAnalysisLevel) {
+            logger.ReportEvent(
+                TelemetryEvents.IntelliSenseLevelChanged,
+                TelemetryProperties.IntelliSenseLevel,
+                newAnalysisLevel.ToString());
+        }
+
+        public static void LogProjectImported(this ITelemetryLogger logger, Guid projectGuid) {
+            logger.ReportEvent(
+                TelemetryEvents.ProjectImported,
+                TelemetryProperties.ProjectGuid,
+                projectGuid.ToString("B"));
+        }
+    }
+}

--- a/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
@@ -21,18 +21,18 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// Extensions for logging telemetry events.
     /// </summary>
     internal static class NodejsTelemetryExtensions {
-        public static void LogIntelliSenseActivatedForProject(this ITelemetryLogger logger, Guid projectGuid, Options.AnalysisLevel newAnalysisLevel) {
+        public static void LogAnalysisActivatedForProject(this ITelemetryLogger logger, Guid projectGuid, Options.AnalysisLevel newAnalysisLevel) {
             logger.ReportEvent(
-                TelemetryEvents.IntelliSenseActivatedForProject,
+                TelemetryEvents.AnalysisActivatedForProject,
                 new DataPointCollection(
                     new DataPoint(TelemetryProperties.ProjectGuid, projectGuid.ToString("B")),
-                    new DataPoint(TelemetryProperties.IntelliSenseLevel, newAnalysisLevel.ToString())));
+                    new DataPoint(TelemetryProperties.AnalysisLevel, newAnalysisLevel.ToString())));
         }
 
-        public static void LogIntelliSenseLevelChanged(this ITelemetryLogger logger, Options.AnalysisLevel newAnalysisLevel) {
+        public static void LogAnalysisLevelChanged(this ITelemetryLogger logger, Options.AnalysisLevel newAnalysisLevel) {
             logger.ReportEvent(
-                TelemetryEvents.IntelliSenseLevelChanged,
-                TelemetryProperties.IntelliSenseLevel,
+                TelemetryEvents.AnalysisLevelChanged,
+                TelemetryProperties.AnalysisLevel,
                 newAnalysisLevel.ToString());
         }
 


### PR DESCRIPTION
##### Bug
We would like to understand what IntelliSense level users are on and when they change IntelliSense levels. This will help us identify adoption of the ES6 analyzer as well as any potential issues keeping people on the old analyzer. It also helps us plan the phase out of the old analyzer

##### Fix
Adds two telemetry points:

* IntelliSenseLevelChanged - General, IntelliSense level has changed event. Sent when user changes the level through the options.
* IntelliSenseActivatedForProject - Logged for each project when the project is first loaded or when the intellisense level is changed.

These events are both implemented using helper extension methods on `NodejsPackage.Instance.TelemetryLogger`. This unifies and hides the actual logging logic. I also updated `LogProjectImported` to use this style of logging.

Closes #1096