### PR TITLE
Add Project File Info to Diagnostics Window Output

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -423,6 +423,12 @@ namespace Microsoft.VisualStudioTools.Project {
             }
         }
 
+        public Dictionary<string, HierarchyNode> DiskNodes {
+            get {
+                return _diskNodes;
+            }
+        }
+
         #region overridden properties
 
         public override bool CanOpenCommandPrompt {

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -152,6 +152,7 @@ namespace Microsoft.NodejsTools.Commands {
                     jsAnalyzer.DumpLog(writer);
                 }
             }
+            res.AppendLine(GetProjectNpmInfo(project));
             res.AppendLine(GetProjectFileInfo(project));
             return res.ToString();
         }
@@ -213,6 +214,19 @@ namespace Microsoft.NodejsTools.Commands {
                 res.AppendLine(Indent(2, "Average Line Count: " + entry.Value.AverageLineLength));
                 res.AppendLine(Indent(2, "Max Line Count: " + entry.Value.MaxLineLength));
             }
+
+            return res.ToString();
+        }
+
+        private static string GetProjectNpmInfo(Project.NodejsProjectNode project) {
+            var modules = project?.ModulesNode?.RootPackage?.Modules;
+            if (modules == null) {
+                return "";
+            }
+
+            var res = new StringBuilder();
+            res.AppendLine("Npm Info:");
+            res.AppendLine(Indent(1, string.Format("Number of Top Level Modules: " + modules.Count())));
 
             return res.ToString();
         }

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -27,7 +27,7 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Commands {
     internal sealed class DiagnosticsCommand : Command {
-        private static readonly string[] interestingDteProperties = new[] {
+        private static readonly string[] _interestingDteProperties = new[] {
             "StartupFile",
             "WorkingDirectory",
             "PublishUrl",
@@ -35,7 +35,7 @@ namespace Microsoft.NodejsTools.Commands {
             "CommandLineArguments"
         };
 
-        private static readonly string[] interestingFileExtensions = new[] {
+        private static readonly string[] _interestingFileExtensions = new[] {
             ".js",
             ".jsx",
             ".tsx",
@@ -128,7 +128,7 @@ namespace Microsoft.NodejsTools.Commands {
             var res = new StringBuilder();
             if (Utilities.GuidEquals(Guids.NodejsBaseProjectFactoryString, project.Kind)) {
                 res.AppendLine("Kind: Node.js");
-                foreach (var prop in interestingDteProperties) {
+                foreach (var prop in _interestingDteProperties) {
                     res.AppendLine(prop + ": " + GetProjectProperty(project, prop));
                 }
                 var njsProj = project.GetNodejsProject();
@@ -192,7 +192,7 @@ namespace Microsoft.NodejsTools.Commands {
             var fileTypeInfo = new Dictionary<string, FileTypeInfo>();
             foreach (var node in project.DiskNodes) {
                 var file = node.Key;
-                var matchedExt = interestingFileExtensions.Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var matchedExt = _interestingFileExtensions.Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
 
                 if (!string.IsNullOrEmpty(matchedExt)) {
                     var recordKey = string.Format("{0} ({1})", matchedExt, node.Value.ItemNode?.IsExcluded ?? true ? "excluded from project" : "included in project");

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -141,7 +141,6 @@ namespace Microsoft.NodejsTools.Commands {
             return res.ToString();
         }
 
-
         private static string GetNodeJsProjectProperties(Project.NodejsProjectNode project) {
             var res = new StringBuilder();
 

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -23,7 +24,6 @@ using System.Threading;
 using Microsoft.NodejsTools.Logging;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
-using System.Collections.Generic;
 
 namespace Microsoft.NodejsTools.Commands {
     internal sealed class DiagnosticsCommand : Command {


### PR DESCRIPTION
This builds on #1118 to add some additional information about what a user's project looks like in the Diagnostics window.

Issue #1116 

##### Bug
For perf investigations, we would like to be able to understand what type of projects users are working with

##### Fix
Add first patch of information: information about the number and type of files found in the project to the diagnostics window. Here's some example output:

```
Use Ctrl-C to copy contents

Projects:
    Project: ExpressApp11\ExpressApp11.njsproj
        Kind: Node.js
        StartupFile: C:\Users\matb.REDMOND\documents\visual studio 2015\Projects\ExpressApp11\ExpressApp11\bin\www
        WorkingDirectory: .
        PublishUrl: <undefined>
        SearchPath: <undefined>
        CommandLineArguments: <undefined>
        Analysis Log: 
        Analysis loading...
        Files:
            .js:
                Number of Files: 3
                Average Line Count: 26
                Max Line Count: 61
            .json:
                Number of Files: 2
                Average Line Count: 18
                Max Line Count: 22
            .styl:
                Number of Files: 1
                Average Line Count: 5
                Max Line Count: 5
            .md:
                Number of Files: 1
                Average Line Count: 3
                Max Line Count: 3
            .jade:
                Number of Files: 3
                Average Line Count: 6
                Max Line Count: 7
```