### PR TITLE
Fix Typings output Encoding

### DIFF
--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Security;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudioTools.Project;
@@ -112,7 +113,9 @@ namespace Microsoft.NodejsTools {
                 null,
                 false,
                 redirector,
-                quoteArgs: true)) {
+                quoteArgs: true,
+                outputEncoding: Encoding.UTF8,
+                errorEncoding: Encoding.UTF8)) {
                 if (!process.IsStarted) {
                     // Process failed to start, and any exception message has
                     // already been sent through the redirector


### PR DESCRIPTION
**Bug**
The output from the typings command is sometimes garbled. This seems to be an encoding issue.

**Fix**
Force the output to be treated as utf-8. Here's the fixed output:

![image](https://cloud.githubusercontent.com/assets/12821956/16604414/d711e51e-42d9-11e6-9edb-020ebd520de8.png)

Closes #1123 



