### PR TITLE
Generic Project Characteristics Telemetry

### DIFF
--- a/Nodejs/Common/Telemetry/TelemetryEvents.cs
+++ b/Nodejs/Common/Telemetry/TelemetryEvents.cs
@@ -19,8 +19,9 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// Telemetry event names
     /// </summary>
     internal static class TelemetryEvents {
-        public const string ProjectImported = "ProjectImported";
         public const string AnalysisActivatedForProject = "AnalysisActivatedForProject";
         public const string AnalysisLevelChanged = "AnalysisLevelChanged";
+        public const string FileTypeInfoForProject = "FileTypeInfoForProject";
+        public const string ProjectImported = "ProjectImported";
     }
 }

--- a/Nodejs/Common/Telemetry/TelemetryProperties.cs
+++ b/Nodejs/Common/Telemetry/TelemetryProperties.cs
@@ -19,7 +19,9 @@ namespace Microsoft.NodejsTools.Telemetry {
     /// Property names for telemetry events
     /// </summary>
     internal static class TelemetryProperties {
-        public const string ProjectGuid = "ProjectGuid";
         public const string AnalysisLevel = "AnalysisLevel";
+        public const string FileType = "FileType";
+        public const string FileCount = "FileCount";
+        public const string ProjectGuid = "ProjectGuid";
     }
 }

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NodejsTools.Commands {
             "CommandLineArguments"
         };
 
-        private static readonly string[] _interestingFileExtensions = new[] {
+        public static readonly string[] InterestingTelemetryFileExtensions = new[] {
             ".js",
             ".jsx",
             ".tsx",
@@ -192,7 +192,7 @@ namespace Microsoft.NodejsTools.Commands {
             var fileTypeInfo = new Dictionary<string, FileTypeInfo>();
             foreach (var node in project.DiskNodes) {
                 var file = node.Key;
-                var matchedExt = _interestingFileExtensions.Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var matchedExt = InterestingTelemetryFileExtensions.Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
 
                 if (!string.IsNullOrEmpty(matchedExt)) {
                     var recordKey = string.Format("{0} ({1})", matchedExt, node.Value.ItemNode?.IsExcluded ?? true ? "excluded from project" : "included in project");

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -570,10 +570,9 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         /// <summary>
-        /// Log generic 
+        /// Log generic characteristics about the project, including number of files of each type in the project.
         /// </summary>
         private void LogProjectInformation() {
-            // Compute number of included files of each type in the project.
             var fileTypeInfo = new Dictionary<string, int>();
             foreach (var node in this.DiskNodes) {
                 if (node.Value?.ItemNode?.IsExcluded ?? true) {

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -564,6 +564,38 @@ namespace Microsoft.NodejsTools.Project {
                 // scan for files which were loaded from cached analysis but no longer
                 // exist and remove them.
                 _analyzer.ReloadComplete();
+
+                Task.Factory.StartNew(LogProjectInformation);
+            }
+        }
+
+        /// <summary>
+        /// Log generic 
+        /// </summary>
+        private void LogProjectInformation() {
+            // Compute number of included files of each type in the project.
+            var fileTypeInfo = new Dictionary<string, int>();
+            foreach (var node in this.DiskNodes) {
+                if (node.Value?.ItemNode?.IsExcluded ?? true) {
+                    continue;
+                }
+
+                var file = node.Key;
+                var matchedExt = Commands.DiagnosticsCommand.InterestingTelemetryFileExtensions
+                    .Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+
+                if (!string.IsNullOrEmpty(matchedExt)) {
+                    if (fileTypeInfo.ContainsKey(matchedExt)) {
+                        ++fileTypeInfo[matchedExt];
+                    } else {
+                        fileTypeInfo[matchedExt] = 1;
+                    }
+                }
+            }
+
+            foreach (var pair in fileTypeInfo) {
+                NodejsPackage.Instance.TelemetryLogger.LogFileTypeInfoForProject(ProjectGuid, pair.Key, pair.Value);
             }
         }
 

--- a/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/NodejsTelemetryExtensions.cs
@@ -42,5 +42,14 @@ namespace Microsoft.NodejsTools.Telemetry {
                 TelemetryProperties.ProjectGuid,
                 projectGuid.ToString("B"));
         }
+
+        public static void LogFileTypeInfoForProject(this ITelemetryLogger logger, Guid projectGuid, string extension, int fileCount) {
+            logger.ReportEvent(
+                TelemetryEvents.FileTypeInfoForProject,
+                new DataPointCollection(
+                    new DataPoint(TelemetryProperties.ProjectGuid, projectGuid.ToString("B")),
+                    new DataPoint(TelemetryProperties.FileType, extension),
+                    new DataPoint(TelemetryProperties.FileCount, fileCount)));
+        }
     }
 }


### PR DESCRIPTION
Issue #1115 

##### Bug
We would like to know understand general characteristics of the types of NTVS projects users work with. This will help us better test and tune NTVS for real world usage.

##### Fix
Add a telemetry point for uploading generic, non-identifying information about NTVS project characteristics. This currently uploads the number of files included in the project for a given file type (such as *.js or *.d.ts) Users can opt out of this by disabling visual studio telemetry.

closes #1115 