### PR TITLE
Run AppVeyor for v1.2.x branch 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@
   branches:
     only:
     - master
+    - v1.2.x
   skip_tags: true
   image: Visual Studio 2015
   environment:


### PR DESCRIPTION
##### Bug
AppVeyor CI not run for v1.2.x branch.


##### Fix
Run AppVeyor for the v1.2.x branch using the same settings as master currently.

Will also take this change into the v1.2.x branch.