### PR TITLE
Run ClearCache on Setup Install

### DIFF
--- a/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
+++ b/Nodejs/Setup/NodejsToolsInstaller/NodejsToolsInstaller.wxs
@@ -133,9 +133,9 @@
         </Feature>
         
         <!-- Execute devenv /setup -->
-        <CustomAction Id="DevEnvSetup" Property="DEVENV_PATH" ExeCommand="/setup" Execute="deferred" Return="check" Impersonate="no" />
+        <CustomAction Id="DevEnvSetup" Property="DEVENV_PATH" ExeCommand="/setup /clearCache /allowDuringSetup" Execute="deferred" Return="check" Impersonate="no" />
         <CustomAction Id="DevEnvSetup_Rollback" Property="DEVENV_PATH" ExeCommand="/setup" Execute="rollback" Return="check" Impersonate="no" />
-        <CustomAction Id="VWDExpressSetup" Property="VWDEXPRESS_PATH" ExeCommand="/setup" Execute="deferred" Return="check" Impersonate="no" />
+        <CustomAction Id="VWDExpressSetup" Property="VWDEXPRESS_PATH" ExeCommand="/setup /clearCache /allowDuringSetup" Execute="deferred" Return="check" Impersonate="no" />
         <CustomAction Id="VWDExpressSetup_Rollback" Property="VWDEXPRESS_PATH" ExeCommand="/setup" Execute="rollback" Return="check" Impersonate="no" />
 
         <InstallExecuteSequence>


### PR DESCRIPTION
This is an attempt to fix #1162. For some reason, the component model cache is not being cleared properly onNTVS upgrade installs with VS 2015 update 3. This force clears the cache.