### PR TITLE
Upgrade Newtonsoft.json to 6.x

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -184,22 +184,11 @@
   <ItemGroup>
     <OutputBinariesToSign Include="Microsoft.NodejsTools.Telemetry.$(VSTarget).dll" />
   </ItemGroup>
-  <Choose>
-    <!-- 
-    VS 2015's devenv.config.exe contains a bindingRedirect for Newtonsoft.Json
-    (versions 0.0.0.0-6.0.0.0 -> 6.0.0.0) so until we upgrade everything to use
-    6.0.0.0 (or get VS to remove the redirect) and deal with all the breaking changes,
-    we should conditionally include the respective Newtonsoft.Json dll version so 
-    that our tests will work with the version shipped with VS 2015.
-    -->
-    <When Condition="'$(VSTarget)' == '14.0' or '$(VSTarget)' == '15.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ReferenceGenerator\ReferenceCode.cs">
       <Link>Project\ReferenceCode.cs</Link>

--- a/Nodejs/Product/Nodejs/packages.config
+++ b/Nodejs/Product/Nodejs/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="1.2.0" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.PersistenceChannel" version="1.2.0" targetFramework="net45" />

--- a/Nodejs/Product/Npm/Npm.csproj
+++ b/Nodejs/Product/Npm/Npm.csproj
@@ -50,22 +50,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
-  <Choose>
-    <!-- 
-    VS 2015's devenv.config.exe contains a bindingRedirect for Newtonsoft.Json
-    (versions 0.0.0.0-6.0.0.0 -> 6.0.0.0) so until we upgrade everything to use
-    6.0.0.0 (or get VS to remove the redirect) and deal with all the breaking changes,
-    we should conditionally include the respective Newtonsoft.Json dll version so 
-    that our tests will work with the version shipped with VS 2015.
-    -->
-    <When Condition="'$(VSTarget)' == '14.0' Or '$(VSTarget)' == '15.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Common\Product\SharedProject\ProcessOutput.cs">
       <Link>ProcessOutput.cs</Link>

--- a/Nodejs/Product/Npm/packages.config
+++ b/Nodejs/Product/Npm/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -93,29 +93,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <Choose>
-    <!-- 
-    VS 2015's devenv.config.exe contains a bindingRedirect for Newtonsoft.Json
-    (versions 0.0.0.0-6.0.0.0 -> 6.0.0.0) so until we upgrade everything to use
-    6.0.0.0 (or get VS to remove the redirect) and deal with all the breaking changes,
-    we should conditionally include the respective Newtonsoft.Json dll version so 
-    that our tests will work with the version shipped with VS 2015.
-    -->
-    <When Condition="'$(VSTarget)' == '12.0' Or '$(VSTarget)' == '11.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="'$(VSTarget)' == '14.0' Or '$(VSTarget)' == '15.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Common\Product\SharedProject\CommonConstants.cs">
       <Link>CommonConstants.cs</Link>

--- a/Nodejs/Product/TestAdapter/packages.config
+++ b/Nodejs/Product/TestAdapter/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/Nodejs/Tests/Core/NodejsTests.csproj
+++ b/Nodejs/Tests/Core/NodejsTests.csproj
@@ -43,22 +43,11 @@
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Choose>
-    <!-- 
-    VS 2015's devenv.config.exe contains a bindingRedirect for Newtonsoft.Json
-    (versions 0.0.0.0-6.0.0.0 -> 6.0.0.0) so until we upgrade everything to use
-    6.0.0.0 (or get VS to remove the redirect) and deal with all the breaking changes,
-    we should conditionally include the respective Newtonsoft.Json dll version so 
-    that our tests will work with the version shipped with VS 2015.
-    -->
-    <When Condition="'$(VSTarget)' == '14.0' Or '$(VSTarget)' == '15.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1312.1622\lib\net40\Moq.dll</HintPath>

--- a/Nodejs/Tests/Core/packages.config
+++ b/Nodejs/Tests/Core/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/Nodejs/Tests/NpmTests/NpmTests.csproj
+++ b/Nodejs/Tests/NpmTests/NpmTests.csproj
@@ -45,29 +45,11 @@
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Choose>
-    <!-- 
-    VS 2015's devenv.config.exe contains a bindingRedirect for Newtonsoft.Json
-    (versions 0.0.0.0-6.0.0.0 -> 6.0.0.0) so until we upgrade everything to use
-    6.0.0.0 (or get VS to remove the redirect) and deal with all the breaking changes,
-    we should conditionally include the respective Newtonsoft.Json dll version so 
-    that our tests will work with the version shipped with VS 2015.
-    -->
-    <When Condition="'$(VSTarget)' == '12.0' Or '$(VSTarget)' == '11.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="'$(VSTarget)' == '14.0' Or '$(VSTarget)' == '15.0'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/Nodejs/Tests/NpmTests/packages.config
+++ b/Nodejs/Tests/NpmTests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
After dropping dev11 and dev12 support, we can now get rid of the hack to support both newtonsoft.json 4 and 6. This workaround prevented tools like the nuget package management console from working properly.


Closes #645