### PR TITLE
Fixed an issue where certain tests would be skipped since Mocha 3.0.0.

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -65,7 +65,10 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder) {
     var mocha = initializeMocha(Mocha, projectFolder);
 
     if (testName) {
-        mocha.grep(testName);
+        if (typeof mocha.fgrep === 'function')
+            mocha.fgrep(testName); // since Mocha 3.0.0
+        else
+            mocha.grep(testName); // prior Mocha 3.0.0
     }
     mocha.addFile(testFile);
 


### PR DESCRIPTION
### Steps to reproduce:
Create a new 'Blank Node.js Console Application' project.
Install npm package Mocha 3.0.2.
Add a test:
```
const assert = require('assert');

it('+ ', function () {
    assert(false);
});
```
Run this test.

### Expected:
Test should fail.

### Actual result:
Test is skipped. Output:
```
Test Name:  +
Test Outcome:   Passed
Result StandardOutput:  
1..0
# tests 0
# pass 0
# fail 0
```

### Explanation:
Since Mocha 3.0.0 method mocha.grep() accepts a regexp string. Before Mocha 3.0.0 string passed to mocha.grep() was escaped. Method mocha.fgrep() appeared in Mocha 3.0.0, it behaves exactly as mocha.grep() in Mocha 2.x.x.

### Fix
Check that mocha.fgrep() method exists, then call it. Otherwise call mocha.grep().