### PR TITLE
Use buildversion variable instead of hardcoded 1.2 version for vsix packages

### DIFF
--- a/Nodejs/Setup/swix/InteractiveWindow_files.swr
+++ b/Nodejs/Setup/swix/InteractiveWindow_files.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NodejsTools.InteractiveWindow
-    version=1.2
+    version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=29102E6C-34F2-4FF1-BA2F-C02ADE3846E8
 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
   
   <PropertyGroup> 
-      <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
+      <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(Build.BuildNumber)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
   
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
   
   <PropertyGroup> 
-      <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot)</PackagePreprocessorDefinitions>
+      <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
   
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
 
   <PropertyGroup> 
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
 
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
 
   <PropertyGroup> 
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(Build.BuildNumber)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
 
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
 
   <PropertyGroup> 
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
 
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
@@ -9,7 +9,7 @@
   </PropertyGroup> 
 
   <PropertyGroup> 
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(Build.BuildNumber)</PackagePreprocessorDefinitions>
   </PropertyGroup> 
 
   <ItemGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
@@ -11,7 +11,7 @@
     <TargetPath>$(BuildOutputRoot)Setup\Microsoft.VisualStudio.NodejsTools.Targets.vsix</TargetPath>
     <WebRoleDll Condition="'$(SignedBinariesPath)' != ''">$(SignedBinariesPath)\Microsoft.NodejsTools.WebRole.dll</WebRoleDll>
     <WebRoleDll Condition="'$(SignedBinariesPath)' == ''">$(BuildOutputRoot)\Binaries\WebRole\Microsoft.NodejsTools.WebRole.dll</WebRoleDll>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion);WebRoleDll=$(WebRoleDll)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(Build.BuildNumber);WebRoleDll=$(WebRoleDll)</PackagePreprocessorDefinitions>
     <!--Retrigger a build on webrole.dll to pick up signed version. TODO: see if there's a better way to do this.-->
     <MSBuildAllProjects>$(WebRoleDll)</MSBuildAllProjects>
   </PropertyGroup> 

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
@@ -11,7 +11,7 @@
     <TargetPath>$(BuildOutputRoot)Setup\Microsoft.VisualStudio.NodejsTools.Targets.vsix</TargetPath>
     <WebRoleDll Condition="'$(SignedBinariesPath)' != ''">$(SignedBinariesPath)\Microsoft.NodejsTools.WebRole.dll</WebRoleDll>
     <WebRoleDll Condition="'$(SignedBinariesPath)' == ''">$(BuildOutputRoot)\Binaries\WebRole\Microsoft.NodejsTools.WebRole.dll</WebRoleDll>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);WebRoleDll=$(WebRoleDll)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BuildOutputRoot=$(BuildOutputRoot);BuildVersion=$(BuildVersion);WebRoleDll=$(WebRoleDll)</PackagePreprocessorDefinitions>
     <!--Retrigger a build on webrole.dll to pick up signed version. TODO: see if there's a better way to do this.-->
     <MSBuildAllProjects>$(WebRoleDll)</MSBuildAllProjects>
   </PropertyGroup> 

--- a/Nodejs/Setup/swix/Nodejs_files.swr
+++ b/Nodejs/Setup/swix/Nodejs_files.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NodejsTools.NodejsTools
-    version=1.2
+    version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=FE8A8C3D-328A-476D-99F9-2A24B75F8C7F
 

--- a/Nodejs/Setup/swix/Profiling_files.swr
+++ b/Nodejs/Setup/swix/Profiling_files.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NodejsTools.Profiling
-    version=1.2
+    version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=B515653F-FB69-4B64-9D3F-F1FCF8421DD0
 

--- a/Nodejs/Setup/swix/Targets_files.swr
+++ b/Nodejs/Setup/swix/Targets_files.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name="Microsoft.VisualStudio.NodejsTools.Targets"
-    version=1.2
+    version=$(BuildVersion)
 
 folder "InstallFolder:\"
     folder "MSBuild\Microsoft\VisualStudio\v15.0\Node.js Tools"


### PR DESCRIPTION
Changes to use a variable for the version instead of a 1.2 version number for our vsix packages. 