### PR TITLE
Remove pkgdef template references

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectPackage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectPackage.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NodejsTools.Project {
     [Guid("2C52FA27-791E-4D04-9F82-234BBB58DE78")]
     [DeveloperActivity(NodejsConstants.JavaScript, typeof(NodejsProjectPackage))]
     [ProvideObject(typeof(NodejsGeneralPropertyPage))]
-    [ProvideProjectFactory(typeof(BaseNodeProjectFactory), NodejsConstants.JavaScript, NodeFileFilter, "njsproj", "njsproj", "ProjectTemplates", LanguageVsTemplate = NodejsConstants.Nodejs, SortPriority = 0x17)]
+    [ProvideProjectFactory(typeof(BaseNodeProjectFactory), NodejsConstants.JavaScript, NodeFileFilter, "njsproj", "njsproj", ".\\NullPath", LanguageVsTemplate = NodejsConstants.Nodejs, SortPriority = 0x17)]
     public class NodejsProjectPackage : CommonProjectPackage {
         internal const string NodeFileFilter = "Node.js Project Files (*.njsproj);*.njsproj";
 

--- a/Nodejs/Product/Nodejs/VSTemplateStore.pkgdef
+++ b/Nodejs/Product/Nodejs/VSTemplateStore.pkgdef
@@ -1,3 +1,3 @@
 ﻿[$RootKey$\VSTemplate\{AD294C77-3CF5-4B22-8595-E09926A015A3}]
-"ProjectTemplatesDir"="$AppDataLocalFolder$"
+"ProjectTemplatesDir"="$AppDataLocalFolder$\\ProjectTemplates"
 "ItemTemplatesDir"="$AppDataLocalFolder$"


### PR DESCRIPTION
**Bug**
Duplicate template entries showing up in VS15 #1177

**Fix**
The root cause seems to be our `*.pkgdef` file, which sets `ProjectTemplatesDir`. Set this to nullpath instead of the actual path. Also updated the dev pkgdef to point to the correct location for testing.

**Testing**
Tested VS14 dev build. Create a new VS15 drop and try the change out there. Manually copying over the pkgdef to a VS15 instance seemed to work fine:

![image](https://cloud.githubusercontent.com/assets/12821956/17536923/9364f9e8-5e4d-11e6-8f45-6ddd585e9583.png)

closes #1177


