### PR TITLE
Fix potential crash for weird %PATH%

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -92,10 +92,12 @@ namespace Microsoft.NodejsTools {
 
             // If we didn't find node.js in the registry we should look at the user's path.
             foreach (var dir in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator)) {
-                var execPath = Path.Combine(dir, executable);
-                if (File.Exists(execPath)) {
-                    return execPath;
-                }
+                try {
+                    var execPath = Path.Combine(dir, executable);
+                    if (File.Exists(execPath)) {
+                        return execPath;
+                    }
+                } catch (ArgumentException) { /*noop*/ }
             }
 
             // It wasn't in the users path.  Check Program Files for the nodejs folder.


### PR DESCRIPTION
Issue #1211
##### Bug
If the %PATH% env var contains path entries which are not valid, NTVS can end up crashing in `GetPathToNodeExecutableFromEnvironment` when invoking `Path.combine`

##### Fix
Wrap this section in a try catch block to handle these entries.

Closes #1211