### PR TITLE
Alert User if Typescript is Not Installed

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -254,12 +254,17 @@ namespace Microsoft.NodejsTools {
         }
 
         public static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript(IVsTextManager4 textMgr) {
-            var langPrefs = new LANGPREFERENCES3[1];
-            langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
-            ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences4(null, langPrefs, null));
-            langPrefs[0].guidLang = typeof(NodejsLanguageInfo).GUID;
-            textMgr.SetUserPreferences4(null, langPrefs, null);
-            return langPrefs;
+            try {
+                var langPrefs = new LANGPREFERENCES3[1];
+                langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
+                ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences4(null, langPrefs, null));
+                langPrefs[0].guidLang = typeof(NodejsLanguageInfo).GUID;
+                textMgr.SetUserPreferences4(null, langPrefs, null);
+                return langPrefs;
+            } catch (Exception) {
+                MessageBox.Show(Project.SR.GetString(Project.SR.CouldNotGetTypeScriptLanguagePreferences), Project.SR.ProductName);
+                throw;
+            }
         }
 
         private void SubscribeToVsCommandEvents(

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -254,17 +254,16 @@ namespace Microsoft.NodejsTools {
         }
 
         public static LANGPREFERENCES3[] GetNodejsLanguagePreferencesFromTypeScript(IVsTextManager4 textMgr) {
-            try {
-                var langPrefs = new LANGPREFERENCES3[1];
-                langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
-                ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences4(null, langPrefs, null));
-                langPrefs[0].guidLang = typeof(NodejsLanguageInfo).GUID;
-                textMgr.SetUserPreferences4(null, langPrefs, null);
-                return langPrefs;
-            } catch (Exception) {
+            var langPrefs = new LANGPREFERENCES3[1];
+            langPrefs[0].guidLang = Guids.TypeScriptLanguageInfo;
+            int hr = textMgr.GetUserPreferences4(null, langPrefs, null);
+            if (ErrorHandler.Failed(hr)) {
                 MessageBox.Show(Project.SR.GetString(Project.SR.CouldNotGetTypeScriptLanguagePreferences), Project.SR.ProductName);
-                throw;
+                ErrorHandler.ThrowOnFailure(hr);
             }
+            langPrefs[0].guidLang = typeof(NodejsLanguageInfo).GUID;
+            textMgr.SetUserPreferences4(null, langPrefs, null);
+            return langPrefs;
         }
 
         private void SubscribeToVsCommandEvents(

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string CacheDirectoryClearFailedTitle = "CacheDirectoryClearFailedTitle";
         internal const string CacheDirectoryClearFailedCaption = "CacheDirectoryClearFailedCaption";
         internal const string ContinueWithoutAzureToolsUpgrade = "ContinueWithoutAzureToolsUpgrade";
+        internal const string CouldNotGetTypeScriptLanguagePreferences = "CouldNotGetTypeScriptLanguagePreferences";
         internal const string DebuggerConnectionClosed = "DebuggerConnectionClosed";
         internal const string DebuggerModuleUpdateFailed = "DebuggerModuleUpdateFailed";
         internal const string DebuggerPort = "DebuggerPort";

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -627,4 +627,7 @@ You will need to restart Visual Studio after installation.</value>
   <data name="TypingsToolCouldNotStart" xml:space="preserve">
     <value>Could not start Typings tool used for IntelliSense</value>
   </data>
+  <data name="CouldNotGetTypeScriptLanguagePreferences" xml:space="preserve">
+    <value>Could not retrieve Typescript language preferences. Please ensure Typescript is properly installed.</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -628,6 +628,6 @@ You will need to restart Visual Studio after installation.</value>
     <value>Could not start Typings tool used for IntelliSense</value>
   </data>
   <data name="CouldNotGetTypeScriptLanguagePreferences" xml:space="preserve">
-    <value>Could not retrieve Typescript language preferences. Please ensure Typescript is properly installed.</value>
+    <value>Could not retrieve Typescript language preferences. NTVS is not able to load. Please ensure Typescript is properly installed.</value>
   </data>
 </root>


### PR DESCRIPTION
From #1208

**Bug**
If TS is not properly installed, NTVS will silently crash when loaded. The root cause is `GetNodejsLanguagePreferencesFromTypeScript` failing.

**Fix**
Instead of throwing right away, alter the user that there is something wrong. Fixing this requires user intervention.

**Testing**
My machine somehow got into a state where TS we not registered properly. I see this error message displayed. After fixing the error, I no longer see the error.