### PR TITLE
Handle Semver parse errors in NpmGetCatalogCommand for 'versions' field

### DIFF
--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -249,7 +249,7 @@ etc.
 
                 var versions = module["versions"];
                 if (versions != null) {
-                    builder.AvailableVersions = GetVersions(versions);
+                    builder.AvailableVersions = GetVersions(builder.Name, versions);
                 }
 
                 AddKeywords(builder, module["keywords"]);
@@ -281,14 +281,19 @@ etc.
 
         }
 
-        private IEnumerable<SemverVersion> GetVersions(JToken versionsToken) {
-            IEnumerable<string> versionStrings = versionsToken.OfType<JProperty>().Select(v => (string)v.Name);
+        private IEnumerable<SemverVersion> GetVersions(string name, JToken versionsToken) {
+            var versionStrings = versionsToken.OfType<JProperty>().Select(v => (string)v.Name);
             foreach (var versionString in versionStrings) {
                 if (!string.IsNullOrEmpty(versionString)) {
-                    yield return SemverVersion.Parse(versionString);
+                    SemverVersion ver;
+                    try {
+                        ver = SemverVersion.Parse(versionString);
+                    } catch (SemverVersionFormatException) {
+                        continue;
+                    }
+                    yield return ver;
                 }
             }
-
         }
 
         private static void AddKeywords(NodeModuleBuilder builder, JToken keywords) {

--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -249,7 +249,7 @@ etc.
 
                 var versions = module["versions"];
                 if (versions != null) {
-                    builder.AvailableVersions = GetVersions(builder.Name, versions);
+                    builder.AvailableVersions = GetVersions(versions);
                 }
 
                 AddKeywords(builder, module["keywords"]);
@@ -281,7 +281,7 @@ etc.
 
         }
 
-        private IEnumerable<SemverVersion> GetVersions(string name, JToken versionsToken) {
+        private IEnumerable<SemverVersion> GetVersions(JToken versionsToken) {
             var versionStrings = versionsToken.OfType<JProperty>().Select(v => (string)v.Name);
             foreach (var versionString in versionStrings) {
                 if (!string.IsNullOrEmpty(versionString)) {


### PR DESCRIPTION
Issue #1217 

**Bug**
Semver parsing is failing for version strings like `'latest'`. This prevents users from downloading the npm package catalog.

**Fix**
Instead of blocking users in this case, we should catch these exceptions and continue on.

Closes #1217 