### PR TITLE
Fix Building NTVS with devenv /Build

### DIFF
--- a/Common/Product/SharedProject/UIThread.cs
+++ b/Common/Product/SharedProject/UIThread.cs
@@ -26,12 +26,10 @@ namespace Microsoft.VisualStudioTools {
         private readonly Thread _uiThread;
 
         private UIThread() {
-            try {
-                _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
-            } catch (InvalidOperationException) {
+            if (SynchronizationContext.Current == null) {
                 SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
-                _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
             }
+            _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
             _factory = new TaskFactory(_scheduler);
             _uiThread = Thread.CurrentThread;
         }

--- a/Common/Product/SharedProject/UIThread.cs
+++ b/Common/Product/SharedProject/UIThread.cs
@@ -26,7 +26,12 @@ namespace Microsoft.VisualStudioTools {
         private readonly Thread _uiThread;
 
         private UIThread() {
-            _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+            try {
+                _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+            } catch (InvalidOperationException) {
+                SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+                _scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+            }
             _factory = new TaskFactory(_scheduler);
             _uiThread = Thread.CurrentThread;
         }


### PR DESCRIPTION
Issue #1230

**Bug**
Crash when trying to build a NTVS project from the command line with `devenv /build`. The root cause is in the `UIThread` where we attempt to call `TaskScheduler.FromCurrentSynchronizationContext`. In non-ui flows, this throws an `InvalidOperationException`.

**Fix**
If `TaskScheduler.FromCurrentSynchronizationContext` fails, try setting the current syntronization context manually and retrying the call. This fixes the `UIThread`, but also fixes all other code paths (including some in the VS extension bases themseleves) that use `TaskScheduler.FromCurrentSynchronizationContext` or assume a `SyncronizationContext`  exists.

closes #1230