### PR TITLE
Default NodejsTools.targets to VS2015

### DIFF
--- a/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
+++ b/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
 


### PR DESCRIPTION
**Bug**
The current `Microsoft.NodejsTools.targets` falls back to vs 10.0 if no version is explicitly provided in the environment.

**Fix**
Fall back to VS 2015 instead.

**Testing**
Ran through basic builds that use this file. Invoked the file from a normal command prompt without the variable set to ensure we fall back to 2015