### PR TITLE
Copy Dlls for Test Adapter into VSIX for VS15

### DIFF
--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -28,5 +28,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="ProjectWizard" Path="|ProjectWizard|" AssemblyName="|ProjectWizard;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="%CurrentProject%" d:TargetPath="|%CurrentProject%;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="%CurrentProject%" d:TargetPath="|%CurrentProject%;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+	<Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.VisualStudio.Shell.Interop.dll" AssemblyName="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
**Bug**
Test adapter is not working in VS15.

One cause is that it cannot resolve two dlls: shell.interop and newtonsoft.json. The first is in the GAC in vs14 and the second is installed by our MSI (not entirely sure how it works for devbuilds)

**Fix**
Copy these dlls into the vsix explicitly. I tried embedding shell.interop, but it cannot be embedded.