### PR TITLE
Limit Depth of Npm Package Tree to a Single Level

### DIFF
--- a/Nodejs/Product/Npm/RootPackageFactory.cs
+++ b/Nodejs/Product/Npm/RootPackageFactory.cs
@@ -20,10 +20,14 @@ namespace Microsoft.NodejsTools.Npm {
     public static class RootPackageFactory {
         public static IRootPackage Create(
             string fullPathToRootDirectory,
-            bool showMissingDevOptionalSubPackages = false) {
+            bool showMissingDevOptionalSubPackages = false,
+            int maxDepth = 1) {
             return new RootPackage(
                 fullPathToRootDirectory,
-                showMissingDevOptionalSubPackages);
+                showMissingDevOptionalSubPackages,
+                null,
+                0,
+                maxDepth);
         }
     }
 }

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -48,13 +48,13 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                         // _requiredBy dependencies that begin with hash characters represent top-level dependencies
                         foreach (var requiredBy in packageJson.RequiredBy) {
                             if (requiredBy.StartsWith("#") || requiredBy == "/") {
-                                AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth);
+                                AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth, maxDepth);
                                 break;
                             }
                         }
                     } else {
                         // This dependency is a top-level dependency not added by npm v3
-                        AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth);
+                        AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth, maxDepth);
                     }
                 }
             }
@@ -71,7 +71,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                     // try to find folder by recursing up tree
                     do {
                         moduleDir = Path.Combine(moduleDir, dependency.Name);
-                        if (AddModuleIfNotExists(parent, moduleDir, showMissingDevOptionalSubPackages, depth, dependency)) {
+                        if (AddModuleIfNotExists(parent, moduleDir, showMissingDevOptionalSubPackages, depth, maxDepth, dependency)) {
                             break;
                         }
 
@@ -84,12 +84,12 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             _packagesSorted.Sort(new PackageComparer());
         }
 
-        private void AddTopLevelModule(IRootPackage parent, bool showMissingDevOptionalSubPackages, string moduleDir, int depth) {
+        private void AddTopLevelModule(IRootPackage parent, bool showMissingDevOptionalSubPackages, string moduleDir, int depth, int maxDepth) {
             Debug.Assert(depth == 0, "Depth should be 0 when adding a top level dependency");
-            AddModuleIfNotExists(parent, moduleDir, showMissingDevOptionalSubPackages, depth);
+            AddModuleIfNotExists(parent, moduleDir, showMissingDevOptionalSubPackages, depth, maxDepth);
         }
 
-        private bool AddModuleIfNotExists(IRootPackage parent, string moduleDir, bool showMissingDevOptionalSubPackages, int depth, IDependency dependency = null) {
+        private bool AddModuleIfNotExists(IRootPackage parent, string moduleDir, bool showMissingDevOptionalSubPackages, int depth, int maxDepth, IDependency dependency = null) {
             depth++;
 
             ModuleInfo moduleInfo;
@@ -124,7 +124,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
                 moduleInfo.RequiredBy.Add(parent.Path);
 
-                var pkg = new Package(parent, moduleDir, showMissingDevOptionalSubPackages, _allModules, depth);
+                var pkg = new Package(parent, moduleDir, showMissingDevOptionalSubPackages, _allModules, depth, maxDepth);
                 if (dependency != null) {
                     pkg.RequestedVersionRange = dependency.VersionRangeText;
                 }

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -22,10 +22,14 @@ using System.Linq;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NodeModules : AbstractNodeModules {
-        private Dictionary<string, ModuleInfo> _allModules;
+        private readonly Dictionary<string, ModuleInfo> _allModules;
         private static readonly string[] _ignoredDirectories = { @"\.bin", @"\.staging" };
 
-        public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0) {
+        public NodeModules(IRootPackage parent, bool showMissingDevOptionalSubPackages, Dictionary<string, ModuleInfo> allModulesToDepth = null, int depth = 0, int maxDepth = 1) {
+            if (depth >= maxDepth) {
+                return;
+            }
+
             var modulesBase = Path.Combine(parent.Path, NodejsConstants.NodeModulesFolder);
 
             _allModules = allModulesToDepth ?? new Dictionary<string, ModuleInfo>();

--- a/Nodejs/Product/Npm/SPI/Package.cs
+++ b/Nodejs/Product/Npm/SPI/Package.cs
@@ -28,8 +28,9 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             string fullPathToRootDirectory,
             bool showMissingDevOptionalSubPackages,
             Dictionary<string, ModuleInfo> allModules = null,
-            int depth = 0)
-            : base(fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth) {
+            int depth = 0,
+            int maxDepth = 1)
+            : base(fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth, maxDepth) {
             _parent = parent;
         }
 

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -24,7 +24,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             string fullPathToRootDirectory,
             bool showMissingDevOptionalSubPackages,
             Dictionary<string, ModuleInfo> allModules = null,
-            int depth = 0) {
+            int depth = 0,
+            int maxDepth = 1) {
             Path = fullPathToRootDirectory;
             var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
             try {
@@ -44,7 +45,7 @@ The following error was reported:
             }
 
             try {
-                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth);
+                Modules = new NodeModules(this, showMissingDevOptionalSubPackages, allModules, depth, maxDepth);
             }  catch (PathTooLongException) {
                 // otherwise we fail to create it completely...
             }

--- a/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
+++ b/Nodejs/Tests/NpmTests/ModuleHierarchyTests.cs
@@ -156,7 +156,7 @@ namespace NpmTests {
                 var rootDir = FilesystemPackageJsonTestHelpers.CreateRootPackage(manager, PkgSingleRecursiveDependency);
                 RunNpmInstall(rootDir);
 
-                var pkg = RootPackageFactory.Create(rootDir);
+                var pkg = RootPackageFactory.Create(rootDir, false, int.MaxValue);
 
                 var json = pkg.PackageJson;
                 var dependencies = json.AllDependencies;


### PR DESCRIPTION
This is a resbumission of #944

**Bug**
Now that our Node analyzer cannot be used in the main editor, there no real reason why we need to build a complete tree of npm packages. As #944 documented, this is a major source of memory and cpu usage at boot

**Fix**
Limit depth of explored npm tree to a single level. This brings some very nice perf gains for projects that have complex dependencies.