### PR TITLE
Add Typescript Version Check for 1.3

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Web.Script.Serialization;
 using System.Windows.Forms;
@@ -109,6 +110,16 @@ namespace Microsoft.NodejsTools {
         // after the initialization
         private List<EnvDTE.CommandEvents> _subscribedCommandEvents = new List<EnvDTE.CommandEvents>();
 
+        private static readonly Version _minRequiredTypescriptVersion = new Version("1.8");
+
+        private readonly Lazy<bool> _hasRequiredTypescriptVersion = new Lazy<bool>(() => {
+            Version version;
+            var versionString = GetTypeScriptToolsVersion();
+            return !string.IsNullOrEmpty(versionString)
+                && Version.TryParse(versionString, out version)
+                && version.CompareTo(_minRequiredTypescriptVersion) > -1;
+        });
+
         /// <summary>
         /// Default constructor of the package.
         /// Inside this method you can place any initialization code that does not require 
@@ -187,6 +198,14 @@ namespace Microsoft.NodejsTools {
         protected override void Initialize() {
             Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", this.ToString()));
             base.Initialize();
+
+            if (!_hasRequiredTypescriptVersion.Value) {
+                MessageBox.Show(
+                   Project.SR.GetString(Project.SR.TypeScriptMinVersionNotInstalled, _minRequiredTypescriptVersion.ToString()),
+                   Project.SR.ProductName,
+                   MessageBoxButtons.OK,
+                   MessageBoxIcon.Error);
+            }
 
             SubscribeToVsCommandEvents(
                 (int)VSConstants.VSStd97CmdID.AddNewProject,
@@ -615,6 +634,44 @@ namespace Microsoft.NodejsTools {
                 var val = analyzer.AnalysisLevel;
                 _logger.LogEvent(NodejsToolsLogEvent.AnalysisLevel, (int)val);
             }
+        }
+
+        private static string GetTypeScriptToolsVersion() {
+            var toolsVersion = string.Empty;
+            try {
+                object installDirAsObject = null;
+                var shell = NodejsPackage.Instance.GetService(typeof(SVsShell)) as IVsShell;
+                if (shell != null) {
+                    shell.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out installDirAsObject);
+                }
+
+                var idePath = CommonUtils.NormalizeDirectoryPath((string)installDirAsObject) ?? string.Empty;
+                if (string.IsNullOrEmpty(idePath)) {
+                    return toolsVersion;
+                }
+
+                var typeScriptServicesPath = Path.Combine(idePath, @"CommonExtensions\Microsoft\TypeScript\typescriptServices.js");
+                if (!File.Exists(typeScriptServicesPath)) {
+                    return toolsVersion;
+                }
+
+                var regex = new Regex(@"toolsVersion = ""(?<version>\d.\d?)"";");
+                var fileText = File.ReadAllText(typeScriptServicesPath);
+                var match = regex.Match(fileText);
+
+                var version = match.Groups["version"].Value;
+                if (!string.IsNullOrWhiteSpace(version)) {
+                    toolsVersion = version;
+                }
+            } catch (Exception ex) {
+                if (ex.IsCriticalException()) {
+                    throw;
+                }
+
+                Debug.WriteLine(string.Format("Failed to obtain TypeScript tools version: {0}", ex.ToString()));
+            }
+
+            return toolsVersion;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
@@ -88,43 +88,5 @@ namespace Microsoft.NodejsTools.Options {
             SaveBool(ShowTypingsInfoBarSetting, ShowTypingsInfoBar);
             SaveBool(SaveChangesToConfigFileSetting, SaveChangesToConfigFile);
         }
-
-        private static string GetTypeScriptToolsVersion() {
-            var toolsVersion = string.Empty;
-            try {
-                object installDirAsObject = null;
-                var shell = NodejsPackage.Instance.GetService(typeof(SVsShell)) as IVsShell;
-                if (shell != null) {
-                    shell.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out installDirAsObject);
-                }
-
-                var idePath = CommonUtils.NormalizeDirectoryPath((string)installDirAsObject) ?? string.Empty;
-                if (string.IsNullOrEmpty(idePath)) {
-                    return toolsVersion;
-                }
-
-                var typeScriptServicesPath = Path.Combine(idePath, @"CommonExtensions\Microsoft\TypeScript\typescriptServices.js");
-                if (!File.Exists(typeScriptServicesPath)) {
-                    return toolsVersion;
-                }
-
-                var regex = new Regex(@"toolsVersion = ""(?<version>\d.\d?)"";");
-                var fileText = File.ReadAllText(typeScriptServicesPath);
-                var match = regex.Match(fileText);
-
-                var version = match.Groups["version"].Value;
-                if (!string.IsNullOrWhiteSpace(version)) {
-                    toolsVersion = version;
-                }
-            } catch (Exception ex) {
-                if (ex.IsCriticalException()) {
-                    throw;
-                }
-
-                Debug.WriteLine(string.Format("Failed to obtain TypeScript tools version: {0}", ex.ToString()));
-            }
-
-            return toolsVersion;
-        }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -182,6 +182,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string TypingsInfoBarSpan2 = "TypingsInfoBarSpan2";
         internal const string TypingsInfoBarSpan3 = "TypingsInfoBarSpan3";
         internal const string TypingsOpenOptionsText = "TypingsOpenOptionsText";
+        internal const string TypeScriptMinVersionNotInstalled = "TypeScriptMinVersionNotInstalled";
         internal const string TypingsToolCouldNotStart = "TypingsToolCouldNotStart";
         internal const string TypingsToolInstallFailed = "TypingsToolInstallFailed";
         internal const string TypingsToolNotInstalledError = "TypingsToolNotInstalledError";

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -630,4 +630,7 @@ You will need to restart Visual Studio after installation.</value>
   <data name="CouldNotGetTypeScriptLanguagePreferences" xml:space="preserve">
     <value>Could not retrieve Typescript language preferences. NTVS is not able to load. Please ensure Typescript is properly installed.</value>
   </data>
+  <data name="TypeScriptMinVersionNotInstalled" xml:space="preserve">
+    <value>Node.js Tools requires TypeScript for Visual Studio {0} or higher. Please ensure TypeScript is installed</value>
+  </data>
 </root>


### PR DESCRIPTION
**Bug**
With NTVS 1.3, we will depend on TypeScript being installed. With VS15, this is enforced during instalation, but this dependency is not enforced in VS2015. However, we see the majority of users do have TypeScript installed.

**Fix**
Add runtime check to alert users if TypeScript is not installed.

Closes #1259