### PR TITLE
Update Express Template Dependecy Versions

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
@@ -10,11 +10,12 @@
     "name": "$username$"
   },
   "dependencies": {
-    "express": "^4.14.0",
     "body-parser": "^1.15.0",
     "cookie-parser": "^1.4.0",
+    "debug": "^2.2.0",
+    "express": "^4.14.0",
     "morgan": "^1.7.0",
-    "serve-favicon": "^2.3.0",
-    "pug": "^2.0.0-beta6"
+    "pug": "^2.0.0-beta6",
+    "serve-favicon": "^2.3.0"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/package.json
@@ -10,12 +10,11 @@
     "name": "$username$"
   },
   "dependencies": {
-    "express": "~4.9.0",
-    "body-parser": "~1.8.1",
-    "cookie-parser": "~1.3.3",
-    "morgan": "~1.3.0",
-    "serve-favicon": "~2.1.3",
-    "debug": "~2.0.0",
-    "pug": "~2.0.0-beta6"
+    "express": "^4.14.0",
+    "body-parser": "^1.15.0",
+    "cookie-parser": "^1.4.0",
+    "morgan": "^1.7.0",
+    "serve-favicon": "^2.3.0",
+    "pug": "^2.0.0-beta6"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
@@ -10,12 +10,12 @@
     "name": "$username$"
   },
   "dependencies": {
-    "express": "~4.9.0",
-    "body-parser": "~1.8.1",
-    "cookie-parser": "~1.3.3",
-    "morgan": "~1.3.0",
-    "serve-favicon": "~2.1.3",
+    "express": "^4.14.0",
+    "body-parser": "^1.15.0",
+    "cookie-parser": "^1.4.0",
+    "morgan": "^1.7.0",
+    "serve-favicon": "^2.3.0",
     "debug": "~2.0.0",
-    "pug": "~2.0.0-beta6"
+    "pug": "^2.0.0-beta6"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/package.json
@@ -10,12 +10,12 @@
     "name": "$username$"
   },
   "dependencies": {
-    "express": "^4.14.0",
     "body-parser": "^1.15.0",
     "cookie-parser": "^1.4.0",
+    "debug": "^2.2.0",
+    "express": "^4.14.0",
     "morgan": "^1.7.0",
-    "serve-favicon": "^2.3.0",
-    "debug": "~2.0.0",
-    "pug": "^2.0.0-beta6"
+    "pug": "^2.0.0-beta6",
+    "serve-favicon": "^2.3.0"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "express": "3.4.4",
-    "pug": "~2.0.0-beta6"
+    "pug": "^2.0.0-beta6"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressWebRole/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressWebRole/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "express": "3.4.4",
-    "pug": "~2.0.0-beta6"
+    "pug": "^2.0.0-beta6"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "express": "3.4.4",
-    "pug": "~2.0.0-beta6"
+    "pug": "^2.0.0-beta6"
   }
 }


### PR DESCRIPTION
Part of #1271

This bumps the express templates to use the most recent versions of packages. It also relaxes the version matching to use ^ instead of ~