### PR TITLE
Add use-strict to Js Template Files

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/app.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
 var logger = require('morgan');
@@ -58,3 +59,4 @@ app.use(function (err, req, res, next) {
 
 
 module.exports = app;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/app.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
@@ -59,4 +59,3 @@ app.use(function (err, req, res, next) {
 
 
 module.exports = app;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/index.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/index.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var router = express.Router();
 
@@ -8,4 +8,3 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/index.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/index.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var router = express.Router();
 
 /* GET home page. */
@@ -7,3 +8,4 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/users.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/users.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var router = express.Router();
 
@@ -8,4 +8,3 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/users.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/users.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var router = express.Router();
 
 /* GET users listing. */
@@ -7,3 +8,4 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
@@ -1,6 +1,8 @@
-﻿var http = require('http');
+'use strict';
+var http = require('http');
 var port = process.env.port || 1337;
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Hello World\n');
 }).listen(port);
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
@@ -1,8 +1,8 @@
 'use strict';
 var http = require('http');
 var port = process.env.port || 1337;
+
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Hello World\n');
 }).listen(port);
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/startup.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/startup.js
@@ -1,3 +1,2 @@
-'use strict';
 /** Placeholder for role startup **/
-
+'use strict';

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/startup.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/startup.js
@@ -1,1 +1,3 @@
-﻿/** Placeholder for role startup **/
+'use strict';
+/** Placeholder for role startup **/
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/worker.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/worker.js
@@ -1,9 +1,9 @@
-'use strict';
 /*
  * Worker roles run asynchronous, long-running, or perpetual 
  * tasks independent of user interaction or input. 
  */
+'use strict';
+
 while (true) {
 
 }
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/worker.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/worker.js
@@ -1,7 +1,9 @@
-﻿/*
+'use strict';
+/*
  * Worker roles run asynchronous, long-running, or perpetual 
  * tasks independent of user interaction or input. 
  */
 while (true) {
 
 }
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
 var logger = require('morgan');
@@ -58,3 +59,4 @@ app.use(function (err, req, res, next) {
 
 
 module.exports = app;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');
@@ -59,4 +59,3 @@ app.use(function (err, req, res, next) {
 
 
 module.exports = app;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/index.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/index.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var router = express.Router();
 
@@ -8,4 +8,3 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/index.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/index.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var router = express.Router();
 
 /* GET home page. */
@@ -7,3 +8,4 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/users.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/users.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 var express = require('express');
 var router = express.Router();
 
@@ -8,4 +8,3 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
-

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/users.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/users.js
@@ -1,4 +1,5 @@
-﻿var express = require('express');
+'use strict';
+var express = require('express');
 var router = express.Router();
 
 /* GET users listing. */
@@ -7,3 +8,4 @@ router.get('/', function (req, res) {
 });
 
 module.exports = router;
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/app.js
@@ -1,3 +1,3 @@
 'use strict';
-console.log('Hello world');
 
+console.log('Hello world');

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/app.js
@@ -1,1 +1,3 @@
-﻿console.log('Hello world');
+'use strict';
+console.log('Hello world');
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
@@ -1,6 +1,8 @@
-﻿var http = require('http');
+'use strict';
+var http = require('http');
 var port = process.env.port || 1337;
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Hello World\n');
 }).listen(port);
+

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
@@ -1,8 +1,8 @@
 'use strict';
 var http = require('http');
 var port = process.env.port || 1337;
+
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('Hello World\n');
 }).listen(port);
-


### PR DESCRIPTION
Part of #1271 

**Bug**
Javascript templates should encourage the use of strict mode for modern Javascript.

**Fix**
Append `'use strict';` to all js files in templates.

```
Get-Childitem *\*.js -Recurse  | ForEach-Object { set-content -path $_.FullName -value ("'use strict';`r`n" + (get-content -path $_.FullName |out-string)) }
```