### PR TITLE
Remove DEV14_OR_LATER Guards

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.Debugger.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.Debugger.cs
@@ -32,10 +32,8 @@ namespace Microsoft.NodejsTools {
     // Keep declared exceptions in sync with those given default values in NodeDebugger.GetDefaultExceptionTreatments()
     [ProvideNodeDebugException()]
     [ProvideNodeDebugException("Error")]
-#if DEV14_OR_LATER
     // VS2015's exception manager uses a different nesting structure, so it's necessary to register Error explicitly.
     [ProvideNodeDebugException("Error", "Error")]
-#endif
     [ProvideNodeDebugException("Error", "Error(EACCES)")]
     [ProvideNodeDebugException("Error", "Error(EADDRINUSE)")]
     [ProvideNodeDebugException("Error", "Error(EADDRNOTAVAIL)")]

--- a/Nodejs/Product/Nodejs/NodejsProject.cs
+++ b/Nodejs/Product/Nodejs/NodejsProject.cs
@@ -467,13 +467,11 @@ namespace Microsoft.NodejsTools {
                         return res;
                     }
             }
-#if DEV14_OR_LATER
             switch((__VSHPROPID8)propId) {
                 case __VSHPROPID8.VSHPROPID_SupportsIconMonikers:
                     property = true;
                     return VSConstants.S_OK;
             }
-#endif
 
             return base.GetProperty(itemId, propId, out property);
         }

--- a/Nodejs/Product/Nodejs/Project/AbstractNpmNode.cs
+++ b/Nodejs/Product/Nodejs/Project/AbstractNpmNode.cs
@@ -5,10 +5,8 @@ using Microsoft.NodejsTools.Npm;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudioTools.Project;
-#if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
-#endif
 
 namespace Microsoft.NodejsTools.Project {
     internal abstract class AbstractNpmNode : HierarchyNode {

--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -93,9 +93,7 @@ namespace Microsoft.NodejsTools.Project {
             get { return PkgCmdId.menuIdNpm; }
         }
 
-#if DEV14_OR_LATER
         [Obsolete]
-#endif
         public override object GetIconHandle(bool open) {
             int imageIndex = _projectNode.ImageIndexFromNameDictionary[NodejsProjectImageName.Dependency];
             if (Package.IsMissing) {

--- a/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFileNode.cs
@@ -18,10 +18,8 @@ using System;
 using System.IO;
 using Microsoft.VisualStudioTools.Project;
 using Microsoft.VisualStudioTools;
-#if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
-#endif
 
 namespace Microsoft.NodejsTools.Project {
     class NodejsFileNode : CommonFileNode {
@@ -42,13 +40,11 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-#if DEV14_OR_LATER
         protected override ImageMoniker CodeFileIconMoniker {
             get {
                 return KnownMonikers.JSScript;
             }
         }
-#endif
 
         internal override int IncludeInProject(bool includeChildren) {
             if (!ItemNode.IsExcluded) {

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -34,10 +34,8 @@ using Microsoft.VisualStudioTools.Project.Automation;
 using MSBuild = Microsoft.Build.Evaluation;
 using VsCommands = Microsoft.VisualStudio.VSConstants.VSStd97CmdID;
 using Microsoft.NodejsTools.Options;
-#if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
-#endif
 
 namespace Microsoft.NodejsTools.Project {
     class NodejsProjectNode : CommonProjectNode, VsWebSite.VSWebSite, INodePackageModulesCommands, IVsBuildPropertyStorage {
@@ -60,15 +58,7 @@ namespace Microsoft.NodejsTools.Project {
         private Timer _idleNodeModulesTimer;
 #pragma warning restore 0414
 
-        public NodejsProjectNode(NodejsProjectPackage package)
-            : base(
-                  package,
-#if DEV14_OR_LATER
-                  null
-#else
-                  Utilities.GetImageList(typeof(NodejsProjectNode).Assembly.GetManifestResourceStream("Microsoft.NodejsTools.Resources.Icons.NodejsImageList.bmp"))
-#endif
-        ) {
+        public NodejsProjectNode(NodejsProjectPackage package) : base(package, null) {
             Type projectNodePropsType = typeof(NodejsProjectNodeProperties);
             AddCATIDMapping(projectNodePropsType, projectNodePropsType.GUID);
 #pragma warning disable 0612
@@ -236,9 +226,7 @@ namespace Microsoft.NodejsTools.Project {
             get { return _imageIndexFromNameDictionary; }
         }
 
-#if DEV14_OR_LATER
         [Obsolete]
-#endif
         private void InitNodejsProjectImages() {
             // HACK: https://nodejstools.codeplex.com/workitem/1268
 
@@ -280,16 +268,6 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
 
-#if !DEV14_OR_LATER
-        public override int ImageIndex {
-            get {
-                if (string.Equals(GetProjectProperty(NodejsConstants.EnableTypeScript), "true", StringComparison.OrdinalIgnoreCase)) {
-                    return ImageIndexFromNameDictionary[NodejsProjectImageName.TypeScriptProjectFile];
-                }
-                return base.ImageIndex;
-            }
-        }
-#endif
         internal override string IssueTrackerUrl {
             get { return NodejsConstants.IssueTrackerUrl; }
         }

--- a/Nodejs/Product/Nodejs/Project/NodejsTypeScriptFileNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsTypeScriptFileNode.cs
@@ -15,10 +15,8 @@
 //*********************************************************//
 
 using Microsoft.VisualStudioTools.Project;
-#if DEV14_OR_LATER
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Imaging;
-#endif
 
 namespace Microsoft.NodejsTools.Project {
     class NodejsTypeScriptFileNode : NodejsFileNode {
@@ -26,13 +24,11 @@ namespace Microsoft.NodejsTools.Project {
             : base(root, e) {
         }
 
-#if DEV14_OR_LATER
         protected override ImageMoniker CodeFileIconMoniker {
             get {
                 return KnownMonikers.TSFileNode;
             }
         }
-#endif
 
         protected override NodeProperties CreatePropertiesObject() {
             if (IsLinkFile) {


### PR DESCRIPTION
We currently only target VS2015+, so DEV14_OR_LATER  is always true. This change simple removes these guards from the NodeJs codebase (not common project).