### PR TITLE
Disable autoloading of Interactive Window

### DIFF
--- a/Common/Product/ReplWindow/ReplWindowPackage.cs
+++ b/Common/Product/ReplWindow/ReplWindowPackage.cs
@@ -47,8 +47,6 @@ namespace Microsoft.VisualStudio.Repl {
     [ProvideKeyBindingTable(ReplWindow.TypeGuid, 200)]        // Resource ID: "Interactive Console"
     [ProvideToolWindow(typeof(ReplWindow), Style = VsDockStyle.Linked, Orientation = ToolWindowOrientation.none, Window = ToolWindowGuids80.Outputwindow, MultiInstances = true)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.NoSolution)]
-    [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.SolutionExists)]
     [Guid(Guids.guidReplWindowPkgString)]
     internal sealed class ReplWindowPackage : Package, IVsToolWindowFactory {
         int IVsToolWindowFactory.CreateToolWindow(ref Guid toolWindowType, uint id) {


### PR DESCRIPTION
Issue #443

##### Bug
By default, VS does not autoload packages at startup to reduce memory/perf. We, however, decided to be special. 

##### Fix
Disable autoloading on InteractiveWindow package. This is in Common codebase, but a reasonable default for anyone taking a dependency on the IW code. PTVS no longer takes a dependency on IW logic, so we shouldn't have to worry about this for now. 

This was far easier than I anticipated (I expected to encounter some scenarios where we would need to fiddle around w/ UI context activation, but have yet to come across an instance where that's the case.) 

##### Testing
* Verified that `Microsoft.NodejsTools.InteractiveWindow.dll` does not get loaded at startup (unless Interactive Window has already been opened in a previous session)
* Verified that Open Interactive Window context menu command works from both Tools > Node.js Tools, global command, and right clicking project node
* Verified that dedupe command (which writes to the interactive window) still works 

close #443