### PR TITLE
Disable Formatting Options Pages in Dev15

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -251,9 +251,6 @@
       <DependentUpon>NpmPackageInstallWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="NpmUI\PackageCatalogEntryViewModel.cs" />
-    <Compile Include="Options\NodejsFormattingDialogPage.cs">
-      <SubType>Component</SubType>
-    </Compile>
     <Compile Include="Options\TypeScriptRegistrySwitches.cs" />
     <Compile Include="Options\TypingsInfoBar.cs" />
     <Compile Include="Options\NodejsDiagnosticsOptionsPage.cs">
@@ -318,10 +315,15 @@
     <Compile Include="Debugger\SteppingKind.cs" />
     <Compile Include="Project\NodejsFileNodeProperties.cs" />
     <Compile Include="Jade\JadeEditorFactory.cs" />
+</ItemGroup>
+<ItemGroup Condition=" '$(VisualStudioVersion)'=='14.0'  Or '$(TargetVisualStudioVersion)'=='VS140' ">
+    <Compile Include="Options\NodejsFormattingDialogPage.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Options\NodejsFormattingBracesOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Options\NodejsFormattingSpacingOptionsPage.cs">
+    <Compile Include="Options\NodejsFormattingSpacingOptionsPage.cs" >
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Options\NodejsFormattingGeneralOptionsPage.cs">
@@ -345,6 +347,8 @@
     <Compile Include="Options\NodejsFormattingSpacingOptionsControl.Designer.cs">
       <DependentUpon>NodejsFormattingSpacingOptionsControl.cs</DependentUpon>
     </Compile>
+</ItemGroup>
+<ItemGroup>
     <Compile Include="Project\ProjectResources.cs" />
     <Compile Include="Repl\NpmReplCommand.cs" />
     <Compile Include="TaggerProviderMetadata.cs" />

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -84,10 +84,10 @@ namespace Microsoft.NodejsTools {
     [ProvideLanguageExtension(typeof(JadeEditorFactory), JadeContentTypeDefinition.JadeFileExtension)]
     [ProvideLanguageExtension(typeof(JadeEditorFactory), JadeContentTypeDefinition.PugFileExtension)]
     [ProvideTextEditorAutomation(JadeContentTypeDefinition.JadeLanguageName, 3041, 3045, ProfileMigrationType.PassThrough)]
+#if DEV14
     [ProvideLanguageEditorOptionPage(typeof(NodejsFormattingSpacingOptionsPage), NodejsConstants.Nodejs, "Formatting", "Spacing", "3042")]
     [ProvideLanguageEditorOptionPage(typeof(NodejsFormattingBracesOptionsPage), NodejsConstants.Nodejs, "Formatting", "Braces", "3043")]
     [ProvideLanguageEditorOptionPage(typeof(NodejsFormattingGeneralOptionsPage), NodejsConstants.Nodejs, "Formatting", "General", "3044")]
-#if DEV14
     [ProvideLanguageEditorOptionPage(typeof(NodejsIntellisenseOptionsPage), NodejsConstants.Nodejs, "IntelliSense", "", "3048")]
 #endif
     internal sealed partial class NodejsPackage : CommonPackage {


### PR DESCRIPTION
**Bug**
The formatting pages for Node currently just sync with their TypeScript counterparts. We kept our formatting pages around because it may not be clear to users that they need to change the TypeScript formatting options to change Node/JavaSccript formatting.

In Dev15, TypeScript has renamed their options page section to "JavaScript/TypeScript".

**Fix**
Disable these pages in dev15 only. We'll keep them around in VS2015, since users may have older versions of TypeScript installed that do not have the options page rename UI change.

Closes #1258 