### PR TITLE
Manually add install sizes for VS15 packages

### DIFF
--- a/Nodejs/Setup/swix/InteractiveWindow_files.swr
+++ b/Nodejs/Setup/swix/InteractiveWindow_files.swr
@@ -4,6 +4,7 @@ package name=Microsoft.VisualStudio.NodejsTools.InteractiveWindow
     version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=29102E6C-34F2-4FF1-BA2F-C02ADE3846E8
+    vs.package.installSize=125068
 
 vs.payloads
     vs.payload source=$(BuildOutputRoot)\Binaries\InteractiveWindow\Microsoft.NodejsTools.InteractiveWindow.vsix

--- a/Nodejs/Setup/swix/Nodejs_files.swr
+++ b/Nodejs/Setup/swix/Nodejs_files.swr
@@ -4,6 +4,7 @@ package name=Microsoft.VisualStudio.NodejsTools.NodejsTools
     version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=FE8A8C3D-328A-476D-99F9-2A24B75F8C7F
+    vs.package.installSize=2180803
 
 vs.payloads
     vs.payload source=$(BuildOutputRoot)\Binaries\Nodejs\Microsoft.NodejsTools.vsix

--- a/Nodejs/Setup/swix/Profiling_files.swr
+++ b/Nodejs/Setup/swix/Profiling_files.swr
@@ -4,6 +4,7 @@ package name=Microsoft.VisualStudio.NodejsTools.Profiling
     version=$(BuildVersion)
     vs.package.type=vsix
     vs.package.vsixId=B515653F-FB69-4B64-9D3F-F1FCF8421DD0
+    vs.package.installSize=139681
 
 vs.payloads
     vs.payload source="$(BuildOutputRoot)\Binaries\Profiling\Microsoft.NodejsTools.Profiling.vsix"


### PR DESCRIPTION
##### Bug
No install size in generated vsix packages for VS15

##### Fix
Add an install size field to these packages.

