### PR TITLE
Disable Automatic creation of Scripts/typings/node/node.d.ts in Dev15

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -272,6 +272,7 @@ namespace Microsoft.NodejsTools.Project {
             get { return NodejsConstants.IssueTrackerUrl; }
         }
 
+#if DEV14
         protected override void FinishProjectCreation(string sourceFolder, string destFolder) {
             foreach (MSBuild.ProjectItem item in this.BuildProject.Items) {
                 if (IsProjectTypeScriptSourceFile(item.EvaluatedInclude)) {
@@ -307,6 +308,7 @@ namespace Microsoft.NodejsTools.Project {
 
             base.FinishProjectCreation(sourceFolder, destFolder);
         }
+#endif
 
         protected override void AddNewFileNodeToHierarchy(HierarchyNode parentNode, string fileName) {
             base.AddNewFileNodeToHierarchy(parentNode, fileName);


### PR DESCRIPTION
**Bug**
We automatically create a `Scripts/typings/node/node.d.ts` file for typescript projects to power intellisense. This is not required in dev15 with newer versions of Typescript.

**Fix**
Disable this in dev15