### PR TITLE
Revert "Disable Automatic creation of Scripts/typings/node/node.d.ts in Dev15"

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -272,7 +272,6 @@ namespace Microsoft.NodejsTools.Project {
             get { return NodejsConstants.IssueTrackerUrl; }
         }
 
-#if DEV14
         protected override void FinishProjectCreation(string sourceFolder, string destFolder) {
             foreach (MSBuild.ProjectItem item in this.BuildProject.Items) {
                 if (IsProjectTypeScriptSourceFile(item.EvaluatedInclude)) {
@@ -308,7 +307,6 @@ namespace Microsoft.NodejsTools.Project {
 
             base.FinishProjectCreation(sourceFolder, destFolder);
         }
-#endif
 
         protected override void AddNewFileNodeToHierarchy(HierarchyNode parentNode, string fileName) {
             base.AddNewFileNodeToHierarchy(parentNode, fileName);


### PR DESCRIPTION
Reverts Microsoft/nodejstools#1307

nevermind. Seems an explicit node  d.ts is still required in order to get the enhanced intellisense for Node.