### PR TITLE
Fixes for Scoped NPM Modules

### DIFF
--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -112,7 +112,14 @@ namespace Microsoft.NodejsTools {
 
         private IEnumerable<string> GetNewTypingsToAcquire(IEnumerable<string> packages) {
             var currentTypings = _acquiredTypingsPackageNames.Value;
-            return packages.Where(package => !currentTypings.Contains(package));
+            return packages
+                .Where(name => {
+                    if (name.Contains('@')) { // We don't support typings for scoped modules
+                        return false;
+                    }
+                    return Uri.EscapeUriString(name).Equals(name, StringComparison.OrdinalIgnoreCase);
+                })
+                .Where(package => !currentTypings.Contains(package));
         }
 
         private async Task<bool> ExecuteTypingsTool(IEnumerable<string> arguments, Redirector redirector) {

--- a/Nodejs/Product/Npm/RootPackageFactory.cs
+++ b/Nodejs/Product/Npm/RootPackageFactory.cs
@@ -19,11 +19,13 @@ using Microsoft.NodejsTools.Npm.SPI;
 namespace Microsoft.NodejsTools.Npm {
     public static class RootPackageFactory {
         public static IRootPackage Create(
-            string fullPathToRootDirectory,
+            string fullPathToRootInstallDirectory,
+            string pathToPackageDirectory,
             bool showMissingDevOptionalSubPackages = false,
             int maxDepth = 1) {
             return new RootPackage(
-                fullPathToRootDirectory,
+                fullPathToRootInstallDirectory,
+                pathToPackageDirectory,
                 showMissingDevOptionalSubPackages,
                 null,
                 0,

--- a/Nodejs/Product/Npm/SPI/NpmController.cs
+++ b/Nodejs/Product/Npm/SPI/NpmController.cs
@@ -121,6 +121,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
                 RootPackage = RootPackageFactory.Create(
                             _fullPathToRootPackageDirectory,
+                            "",
                             _showMissingDevOptionalSubPackages);
                 return;
             } catch (IOException) {

--- a/Nodejs/Product/Npm/SPI/Package.cs
+++ b/Nodejs/Product/Npm/SPI/Package.cs
@@ -25,12 +25,13 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         public Package(
             IRootPackage parent,
-            string fullPathToRootDirectory,
+            string fullPathToRootInstallDirectory,
+            string pathToPackageDirectory,
             bool showMissingDevOptionalSubPackages,
             Dictionary<string, ModuleInfo> allModules = null,
             int depth = 0,
             int maxDepth = 1)
-            : base(fullPathToRootDirectory, showMissingDevOptionalSubPackages, allModules, depth, maxDepth) {
+            : base(fullPathToRootInstallDirectory, pathToPackageDirectory, showMissingDevOptionalSubPackages, allModules, depth, maxDepth) {
             _parent = parent;
         }
 


### PR DESCRIPTION
**Bug**
There are a few bugs around scoped modules currently:
- If a scope module is listed in the package.json but not installed, the NPM node shows it as "not in package.json".
- In the same situation, only the module name itself is shown, not the scope plus name
- We may try to acquire typings for scoped modules. These do not exist and are not supported by typings.

**Fix**
Add a check to filter out scoped modules before attempting to install typings for them.

Thread the entire name of the module through the npm structures instead of just the package path. Use the name instead of the last element of the path for the UI.
