### PR TITLE
Change go.microsoft Links to Https instead of Http

### DIFF
--- a/Nodejs/Product/Nodejs/Commands/OpenRemoteDebugDocumentationCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/OpenRemoteDebugDocumentationCommand.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudioTools;
 namespace Microsoft.NodejsTools.Commands {
     internal sealed class OpenRemoteDebugDocumentationCommand : Command {
         public override void DoCommand(object sender, EventArgs args) {
-            Process.Start("http://go.microsoft.com/fwlink/?LinkId=525504");
+            Process.Start("https://go.microsoft.com/fwlink/?LinkId=525504");
         }
 
         public override int CommandId {

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
@@ -21,8 +21,8 @@ using System.Windows.Forms;
 namespace Microsoft.NodejsTools.Options {
     [ComVisible(true)]
     public class NodejsGeneralOptionsPage : NodejsDialogPage {
-        private const string DefaultSurveyNewsFeedUrl = "http://go.microsoft.com/fwlink/?LinkId=328027";
-        private const string DefaultSurveyNewsIndexUrl = "http://go.microsoft.com/fwlink/?LinkId=328029";
+        private const string DefaultSurveyNewsFeedUrl = "https://go.microsoft.com/fwlink/?LinkId=328027";
+        private const string DefaultSurveyNewsIndexUrl = "https://go.microsoft.com/fwlink/?LinkId=328029";
         private const string SurveyNewsCheckSetting = "SurveyNewsCheck";
         private const string SurveyNewsLastCheckSetting = "SurveyNewsLastCheck";
         private const string SurveyNewsFeedUrlSetting = "SurveyNewsFeedUrl";

--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsControl.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NodejsTools.Options {
         }
 
         private void _analysisPreviewFeedbackLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
-            Process.Start("http://go.microsoft.com/fwlink/?LinkID=808344");
+            Process.Start("https://go.microsoft.com/fwlink/?LinkID=808344");
         }
 
         private void _intelliSenseModeDropdown_SelectedValueChanged(object sender, EventArgs e) {

--- a/Nodejs/Product/Nodejs/Options/SalsaLsIntellisenseOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/SalsaLsIntellisenseOptionsControl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NodejsTools.Options {
         }
 
         private void typingsLearnMoreLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
-            Process.Start("http://go.microsoft.com/fwlink/?LinkID=808343");
+            Process.Start("https://go.microsoft.com/fwlink/?LinkID=808343");
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Options/TypingsInfoBar.cs
+++ b/Nodejs/Product/Nodejs/Options/TypingsInfoBar.cs
@@ -114,7 +114,7 @@ namespace Microsoft.NodejsTools.Options {
 
                 menuCommandService.GlobalInvoke(optionsCommand, intelliSenseOptionsGuidString);
             } else if (actionItem.Equals(_typingsFolderHyperlink)) {
-                Process.Start("http://go.microsoft.com/fwlink/?LinkID=808345");
+                Process.Start("https://go.microsoft.com/fwlink/?LinkID=808345");
             }
         }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -745,13 +745,13 @@ namespace Microsoft.NodejsTools.Project {
                 taskDialog.HyperlinkClicked += (sender, e) => {
                     switch (e.Url) {
                         case "#msdn":
-                            Process.Start("http://go.microsoft.com/fwlink/?LinkId=454508");
+                            Process.Start("https://go.microsoft.com/fwlink/?LinkId=454508");
                             break;
                         case "#uservoice":
-                            Process.Start("http://go.microsoft.com/fwlink/?LinkID=456509");
+                            Process.Start("https://go.microsoft.com/fwlink/?LinkID=456509");
                             break;
                         case "#help":
-                            Process.Start("http://go.microsoft.com/fwlink/?LinkId=456511");
+                            Process.Start("https://go.microsoft.com/fwlink/?LinkId=456511");
                             break;
                         default:
                             System.Windows.Clipboard.SetText(e.Url);

--- a/Nodejs/Product/ProjectWizard/CloudServiceWizard.cs
+++ b/Nodejs/Product/ProjectWizard/CloudServiceWizard.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NodejsTools.ProjectWizard {
         private readonly bool _recommendUpgrade;
 
 #if DEV14
-        const string AzureToolsDownload = "http://go.microsoft.com/fwlink/?LinkID=517353";
+        const string AzureToolsDownload = "https://go.microsoft.com/fwlink/?LinkID=517353";
 #elif DEV15
         const string AzureToolsDownload = "https://go.microsoft.com/fwlink/?LinkId=746956";
 #else


### PR DESCRIPTION
**Bug**
Some go.microsoft links use http before the redirect to their https destination.

**Fix**
Change these to use https instead.

**testing**
Tried out links in product.