### PR TITLE
Provide ability to add project references

### DIFF
--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -63,7 +63,8 @@ namespace Microsoft.VisualStudioTools.Project {
         IBuildDependencyUpdate,
         IVsProjectSpecialFiles,
         IVsProjectBuildSystem,
-        IOleCommandTarget {
+        IOleCommandTarget,
+        IVsReferenceManagerUser {
         #region nested types
 
 #if DEV14_OR_LATER
@@ -1383,71 +1384,173 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         /// <summary>
-        /// This overrides the base class method to show the VS 2005 style Add reference dialog. The ProjectNode implementation
-        /// shows the VS 2003 style Add Reference dialog.
+        /// Shows the Add Reference dialog.
         /// </summary>
-        /// <returns>S_OK if succeeded. Failure other wise</returns>
-        public virtual int AddProjectReference() {
-            IVsComponentSelectorDlg2 componentDialog;
-            Guid guidEmpty = Guid.Empty;
-            VSCOMPONENTSELECTORTABINIT[] tabInit = new VSCOMPONENTSELECTORTABINIT[4];
-            string strBrowseLocations = Path.GetDirectoryName(ProjectHome);
-
-            //Add the Project page
-            tabInit[0].dwSize = (uint)Marshal.SizeOf(typeof(VSCOMPONENTSELECTORTABINIT));
-            // Tell the Add Reference dialog to call hierarchies GetProperty with the following
-            // propID to enable filtering out ourself from the Project to Project reference
-            tabInit[0].varTabInitInfo = (int)__VSHPROPID.VSHPROPID_ShowProjInSolutionPage;
-            tabInit[0].guidTab = VSConstants.GUID_SolutionPage;
-
-            // Add the Browse for file page            
-            tabInit[1].dwSize = (uint)Marshal.SizeOf(typeof(VSCOMPONENTSELECTORTABINIT));
-            tabInit[1].guidTab = VSConstants.GUID_COMPlusPage;
-            tabInit[1].varTabInitInfo = 0;
-
-            // Add the Browse for file page            
-            tabInit[2].dwSize = (uint)Marshal.SizeOf(typeof(VSCOMPONENTSELECTORTABINIT));
-            tabInit[2].guidTab = VSConstants.GUID_BrowseFilePage;
-            tabInit[2].varTabInitInfo = 0;
-
-            // Add the WebPI page
-            tabInit[3].dwSize = (uint)Marshal.SizeOf(typeof(VSCOMPONENTSELECTORTABINIT));
-            tabInit[3].guidTab = typeof(WebPiComponentPickerControl).GUID;
-            tabInit[3].varTabInitInfo = 0;
-
-            uint pX = 0, pY = 0;
-
-            componentDialog = GetService(typeof(SVsComponentSelectorDlg)) as IVsComponentSelectorDlg2;
-            try {
-                // call the container to open the add reference dialog.
-                if (componentDialog != null) {
-                    // Let the project know not to show itself in the Add Project Reference Dialog page
-                    ShowProjectInSolutionPage = false;
-
-                    // call the container to open the add reference dialog.
-                    ErrorHandler.ThrowOnFailure(componentDialog.ComponentSelectorDlg2(
-                        (System.UInt32)(__VSCOMPSELFLAGS.VSCOMSEL_MultiSelectMode | __VSCOMPSELFLAGS.VSCOMSEL_IgnoreMachineName),
-                        (IVsComponentUser)this,
-                        0,
-                        null,
-                        SR.GetString(SR.AddReferenceDialogTitle), // Title
-                        "VS.AddReference", // Help topic
-                        ref pX,
-                        ref pY,
-                        (uint)tabInit.Length,
-                        tabInit,
-                        ref guidEmpty,
-                        AddReferenceExtensions.Replace('|', '\0') + "\0",
-                        ref strBrowseLocations));
-                }
-            } catch (COMException e) {
-                Trace.WriteLine("Exception : " + e.Message);
-                return e.ErrorCode;
-            } finally {
-                // Let the project know it can show itself in the Add Project Reference Dialog page
-                ShowProjectInSolutionPage = true;
+        /// <returns>S_OK if succeeded. Failure otherwise</returns>
+        public int AddProjectReference() {
+            var referenceManager = this.GetService(typeof(SVsReferenceManager)) as IVsReferenceManager;
+            if (referenceManager != null) {
+                var contextGuids = new[] {
+                    VSConstants.ProjectReferenceProvider_Guid,
+                    VSConstants.FileReferenceProvider_Guid
+                };
+                referenceManager.ShowReferenceManager(
+                    this,
+                    SR.GetString(SR.AddReferenceDialogTitle),
+                    "VS.ReferenceManager",
+                    contextGuids.First(),
+                    false);
+                return VSConstants.S_OK;
+            } else {
+                return VSConstants.E_NOINTERFACE;
             }
-            return VSConstants.S_OK;
+        }
+
+        #region IVsReferenceManagerUser Members
+
+        void IVsReferenceManagerUser.ChangeReferences(uint operation, IVsReferenceProviderContext changedContext) {
+            var op = (__VSREFERENCECHANGEOPERATION)operation;
+            __VSREFERENCECHANGEOPERATIONRESULT result;
+
+            try {
+                if (op == __VSREFERENCECHANGEOPERATION.VSREFERENCECHANGEOPERATION_ADD) {
+                    result = this.AddReferences(changedContext);
+                } else {
+                    result = this.RemoveReferences(changedContext);
+                }
+            } catch (InvalidOperationException e) {
+                Debug.Fail(e.ToString());
+                result = __VSREFERENCECHANGEOPERATIONRESULT.VSREFERENCECHANGEOPERATIONRESULT_DENY;
+            }
+
+            if (result == __VSREFERENCECHANGEOPERATIONRESULT.VSREFERENCECHANGEOPERATIONRESULT_DENY) {
+                throw new InvalidOperationException();
+            }
+        }
+
+        Array IVsReferenceManagerUser.GetProviderContexts() {
+            var referenceManager = this.GetService(typeof(SVsReferenceManager)) as IVsReferenceManager;
+
+            var contextProviders = new[] {
+                CreateProjectReferenceProviderContext(referenceManager),
+                CreateFileReferenceProviderContext(referenceManager),
+            };
+
+            return contextProviders;
+        }
+
+        #endregion
+
+        private IVsReferenceProviderContext CreateProjectReferenceProviderContext(IVsReferenceManager mgr) {
+            var context = mgr.CreateProviderContext(VSConstants.ProjectReferenceProvider_Guid) as IVsProjectReferenceProviderContext;
+            context.CurrentProject = this;
+
+            var referenceContainer = this.GetReferenceContainer();
+            var references = referenceContainer
+                .EnumReferences()
+                .OfType<ProjectReferenceNode>();
+            foreach (var reference in references) {
+                var newReference = context.CreateReference() as IVsProjectReference;
+                newReference.Identity = reference.ReferencedProjectGuid.ToString("B");
+            }
+
+            return context as IVsReferenceProviderContext;
+        }
+
+        private IVsReferenceProviderContext CreateFileReferenceProviderContext(IVsReferenceManager mgr) {
+            var context = mgr.CreateProviderContext(VSConstants.FileReferenceProvider_Guid) as IVsFileReferenceProviderContext;
+
+            context.BrowseFilter = "Component Files" + "\0*.winmd\0\0";
+            return context as IVsReferenceProviderContext;
+        }
+
+        private __VSREFERENCECHANGEOPERATIONRESULT AddReferences(IVsReferenceProviderContext context) {
+            var addedReferences = Enumerable.Empty<VSCOMPONENTSELECTORDATA>();
+
+            if (context.ProviderGuid == VSConstants.ProjectReferenceProvider_Guid) {
+                addedReferences = GetAddedReferences(context as IVsProjectReferenceProviderContext);
+            } else if (context.ProviderGuid == VSConstants.FileReferenceProvider_Guid) {
+                addedReferences = GetAddedReferences(context as IVsFileReferenceProviderContext);
+            }
+
+            var referenceContainer = this.GetReferenceContainer();
+            foreach (var selectorData in addedReferences) {
+                referenceContainer.AddReferenceFromSelectorData(selectorData);
+            }
+
+            return __VSREFERENCECHANGEOPERATIONRESULT.VSREFERENCECHANGEOPERATIONRESULT_ALLOW;
+        }
+
+        private __VSREFERENCECHANGEOPERATIONRESULT RemoveReferences(IVsReferenceProviderContext context) {
+            var removedReferences = Enumerable.Empty<ReferenceNode>();
+
+            if (context.ProviderGuid == VSConstants.ProjectReferenceProvider_Guid) {
+                removedReferences = GetRemovedReferences(context as IVsProjectReferenceProviderContext);
+            } else if (context.ProviderGuid == VSConstants.FileReferenceProvider_Guid) {
+                removedReferences = GetRemovedReferences(context as IVsFileReferenceProviderContext);
+            }
+
+            foreach (var refNode in removedReferences) {
+                refNode.Remove(true /* delete from storage*/);
+            }
+
+            return __VSREFERENCECHANGEOPERATIONRESULT.VSREFERENCECHANGEOPERATIONRESULT_ALLOW;
+        }
+
+        private IEnumerable<VSCOMPONENTSELECTORDATA> GetAddedReferences(IVsProjectReferenceProviderContext context) {
+            var selectedReferences = context
+                .References
+                .OfType<IVsProjectReference>()
+                .Select(reference => new VSCOMPONENTSELECTORDATA() {
+                    type = VSCOMPONENTTYPE.VSCOMPONENTTYPE_Project,
+                    bstrTitle = reference.Name,
+                    bstrFile = new FileInfo(reference.FullPath).Directory.FullName,
+                    bstrProjRef = reference.ReferenceSpecification,
+                });
+
+            return selectedReferences;
+        }
+
+        private IEnumerable<ReferenceNode> GetRemovedReferences(IVsProjectReferenceProviderContext context) {
+            var selectedReferences = context
+                .References
+                .OfType<IVsProjectReference>()
+                .Select(asmRef => new Guid(asmRef.Identity));
+
+            var referenceContainer = this.GetReferenceContainer();
+            var references = referenceContainer
+                .EnumReferences()
+                .OfType<ProjectReferenceNode>()
+                .Where(refNode => selectedReferences.Contains(refNode.ReferencedProjectGuid));
+
+            return references;
+        }
+
+        private IEnumerable<VSCOMPONENTSELECTORDATA> GetAddedReferences(IVsFileReferenceProviderContext context) {
+            var selectedReferences = context
+                .References
+                .OfType<IVsFileReference>()
+                .Select(reference => new VSCOMPONENTSELECTORDATA() {
+                    type = VSCOMPONENTTYPE.VSCOMPONENTTYPE_File,
+                    bstrFile = reference.FullPath,
+                 });
+
+            return selectedReferences;
+        }
+
+        private IEnumerable<ReferenceNode> GetRemovedReferences(IVsFileReferenceProviderContext context) {
+            var selectedReferences = context
+                .References
+                .OfType<IVsFileReference>()
+                .Select(fileRef => fileRef.FullPath);
+
+            var referenceContainer = this.GetReferenceContainer();
+            var references = referenceContainer
+                .EnumReferences()
+                .OfType<ReferenceNode>()
+                .Where(refNode => selectedReferences.Contains(refNode.Url));
+
+            return references;
         }
 
         protected virtual string AddReferenceExtensions {

--- a/Common/Product/SharedProject/ProjectResources.resx
+++ b/Common/Product/SharedProject/ProjectResources.resx
@@ -609,7 +609,7 @@ Run Visual Studio with the /Log option and check ActivityLog.xml for more detail
 {0}</value>
   </data>
   <data name="AddReferenceExtensions" xml:space="preserve">
-    <value>Dynamic Link Libraries (*.dll)|*.dll|All Files (*.*)|*.*</value>
+    <value>Component Files|*.winmd</value>
   </data>
   <data name="WebPiFeedError" xml:space="preserve">
     <value>Unable to get feed "{0}".

--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -76,5 +76,8 @@ namespace Microsoft.NodejsTools
 
         public const string OfficeToolsBootstrapperCmdSetString = "{D26C976C-8EE8-4EC4-8746-F5F7702A17C5}";
         public static readonly Guid OfficeToolsBootstrapperCmdSet = new Guid(OfficeToolsBootstrapperCmdSetString);
+		
+        // UWP project flavor guid
+        public const string NodejsUwpProjectFlavor = "00251F00-BA30-4CE4-96A2-B8A1085F37AA";
     };
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -613,7 +613,19 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         protected override ReferenceContainerNode CreateReferenceContainerNode() {
-            return null;
+            // Only create a reference node if the project is targeting UWP
+            if(GetProjectTypeGuids().Contains(Guids.NodejsUwpProjectFlavor)) {
+                return base.CreateReferenceContainerNode();
+            } else {
+                return null;
+            }
+        }
+
+        private string GetProjectTypeGuids()
+        {
+            string projectTypeGuids = "";
+            ErrorHandler.ThrowOnFailure(((IVsAggregatableProject)this).GetAggregateProjectTypeGuids(out projectTypeGuids));
+            return projectTypeGuids;
         }
 
         public NodeModulesNode ModulesNode { get; private set; }


### PR DESCRIPTION
This change is needed for the https://github.com/ms-iot/ntvsiot project (the subtype of NTVS for targeting UWP) to allow adding references to projects. 
I couldn't find a way to only change the subtype in a less intrusive way. If there is, please let me know.
The change in ProjectNode.cs will not affect NTVS functionality since it doesn't make use of the reference manager. In NodejsProjectNode.cs I added a condition to check if the UWP project subtype is active to decide whether to add the reference node.