### PR TITLE
Disable Node Language Service in Dev15 and Use TypeScript Language for Interactive Window

### DIFF
--- a/Common/Product/ReplWindow/Repl/ReplWindow.cs
+++ b/Common/Product/ReplWindow/Repl/ReplWindow.cs
@@ -1172,7 +1172,7 @@ namespace Microsoft.VisualStudio.Repl {
             }
 
             ITextSnapshotLine langLine = langCaret.Value.GetContainingLine();
-            int? langIndentation = _languageIndenter.GetDesiredIndentation(langLine);
+            int? langIndentation = _languageIndenter?.GetDesiredIndentation(langLine);
 
             if (langIndentation != null) {
                 if (langCaret.Value == langLine.End) {

--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -24,10 +24,9 @@ namespace Microsoft.NodejsTools
         public const string NodejsPackageString = "FE8A8C3D-328A-476D-99F9-2A24B75F8C7F";
         public const string NodejsCmdSetString = "695e37e2-c6df-4e0a-8833-f688e4c65f1f";
         public const string NodejsDebugLanguageString = "{65791609-BA29-49CF-A214-DBFF8AEC3BC2}";
-        //do not remove the curly braces. Without curly braces, in certain cases some language service features (e.g. snippets)  will fail to load because
-        //some comparisons in native code surround the guid string with curlies, and they'll fail to match unless we also surround the guid string with curlies.
+#if DEV14
         public const string NodejsLanguageInfoGuidString = "ABD5E8A5-5A35-4BE9-BCAF-E10C1212CB40";
-        public const string NodejsLanguageInfoString = "{" + NodejsLanguageInfoGuidString + "}";
+#endif
         public const string NodejsNpmCmdSetString = "9F4B31B4-09AC-4937-A2E7-F4BC02BB7DBA";
         public const string NodejsProjectFactoryString = "3AF33F2E-1136-4D97-BBB7-1795711AC8B8";
         public const string NodejsBaseProjectFactoryString = "9092AA53-FB77-4645-B42D-1CCCA6BD08BD";
@@ -37,8 +36,7 @@ namespace Microsoft.NodejsTools
         public const string DefaultLanguageServiceString = "{8239BEC4-EE87-11D0-8C98-00C04FC2AB22}";
 
         internal static readonly Guid DefaultLanguageService = new Guid(DefaultLanguageServiceString);
-        internal static readonly Guid NodejsLanguageInfo = new Guid(NodejsLanguageInfoString);
- 
+
         //Guid for our formatting service
         internal const string JavaScriptFormattingServiceString = "F414C260-6AC0-11CF-B6D1-00AA00BBBB58";
 

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Options\NodejsFormattingSpacingOptionsControl.Designer.cs">
       <DependentUpon>NodejsFormattingSpacingOptionsControl.cs</DependentUpon>
     </Compile>
+	<Compile Include="NodejsLanguageInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Project\ProjectResources.cs" />
@@ -447,7 +448,6 @@
     <Compile Include="Jade\Tokens\Tokenizer.cs" />
     <Compile Include="LanguagePreferences.cs" />
     <Compile Include="Nodejs.cs" />
-    <Compile Include="NodejsLanguageInfo.cs" />
     <Compile Include="NodejsProjectConfig.cs" />
     <Compile Include="NodejsToolsInstallPath.cs" />
     <Compile Include="NpmUI\ErrorHelper.cs" />

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -66,7 +66,9 @@ namespace Microsoft.NodejsTools {
     [ProvideOptionPage(typeof(NodejsGeneralOptionsPage), "Node.js Tools", "General", 114, 115, true)]
     [ProvideOptionPage(typeof(NodejsNpmOptionsPage), "Node.js Tools", "Npm", 114, 116, true)]
     [ProvideDebugEngine("Node.js Debugging", typeof(AD7ProgramProvider), typeof(AD7Engine), AD7Engine.DebugEngineId, setNextStatement: false, hitCountBp: true, justMyCodeStepping: false)]
+#if DEV14
     [ProvideLanguageService(typeof(NodejsLanguageInfo), NodejsConstants.Nodejs, 106, RequestStockColors = true, ShowSmartIndent = true, ShowCompletion = true, DefaultToInsertSpaces = true, HideAdvancedMembersByDefault = true, EnableAdvancedMembersOption = true, ShowDropDownOptions = true)]
+#endif
     [ProvideDebugLanguage(NodejsConstants.Nodejs, Guids.NodejsDebugLanguageString, NodeExpressionEvaluatorGuid, AD7Engine.DebugEngineId)]
     [WebSiteProject("JavaScript", "JavaScript")]
     [ProvideProjectFactory(typeof(NodejsProjectFactory), null, null, null, null, ".\\NullPath", LanguageVsTemplate = NodejsConstants.JavaScript, SortPriority=0x17)]   // outer flavor, no file extension
@@ -155,7 +157,7 @@ namespace Microsoft.NodejsTools {
 
         /////////////////////////////////////////////////////////////////////////////
         // Overridden Package Implementation
-        #region Package Members
+#region Package Members
 
         /// <summary>
         /// Initialization of the package; this method is called right after the package is sited, so this is the place
@@ -178,10 +180,10 @@ namespace Microsoft.NodejsTools {
                 delegate { NewProjectFromExistingWizard.IsAddNewProjectCmd = true; },
                 delegate { NewProjectFromExistingWizard.IsAddNewProjectCmd = false; }
             );
-
+#if DEV14
             var langService = new NodejsLanguageInfo(this);
             ((IServiceContainer)this).AddService(langService.GetType(), langService, true);
-
+#endif
             ((IServiceContainer)this).AddService(typeof(ClipboardServiceBase), new ClipboardService(), true);
 
             RegisterProjectFactory(new NodejsProjectFactory(this));
@@ -293,7 +295,7 @@ namespace Microsoft.NodejsTools {
                 window = (IReplWindow2)provider.CreateReplWindow(
                     ReplContentType,
                     "Node.js Interactive Window",
-                    typeof(NodejsLanguageInfo).GUID,
+                    Guids.TypeScriptLanguageInfo,
                     NodejsReplEvaluatorProvider.NodeReplId
                 );
             }
@@ -329,13 +331,13 @@ namespace Microsoft.NodejsTools {
         private IContentType ReplContentType {
             get {
                 if (_contentType == null) {
-                    _contentType = ComponentModel.GetService<IContentTypeRegistryService>().GetContentType(NodejsConstants.Nodejs);
+                    _contentType = ComponentModel.GetService<IContentTypeRegistryService>().GetContentType("TypeScript");
                 }
                 return _contentType;
             }
         }
 
-        #endregion
+#endregion
 
         internal override VisualStudioTools.Navigation.LibraryManager CreateLibraryManager(CommonPackage package) {
             return new NodejsLibraryManager(this);

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -331,7 +331,7 @@ namespace Microsoft.NodejsTools {
         private IContentType ReplContentType {
             get {
                 if (_contentType == null) {
-                    _contentType = ComponentModel.GetService<IContentTypeRegistryService>().GetContentType("TypeScript");
+                    _contentType = ComponentModel.GetService<IContentTypeRegistryService>().GetContentType(NodejsConstants.TypeScript);
                 }
                 return _contentType;
             }

--- a/Nodejs/Product/Nodejs/Repl/VsNodejsReplSite.cs
+++ b/Nodejs/Product/Nodejs/Repl/VsNodejsReplSite.cs
@@ -20,16 +20,26 @@ namespace Microsoft.NodejsTools.Repl {
     class VsNodejsReplSite : INodejsReplSite {
         internal static VsNodejsReplSite Site = new VsNodejsReplSite();
 
-        #region INodejsReplSite Members
+#region INodejsReplSite Members
 
         public CommonProjectNode GetStartupProject() {
-            return NodejsPackage.GetStartupProject(NodejsPackage.Instance);
+            var nodeJsInstance = NodejsPackage.Instance;
+            if (nodeJsInstance == null) {
+                return null;
+            }
+            return NodejsPackage.GetStartupProject(nodeJsInstance);
         }
 
         public bool TryGetStartupFileAndDirectory(out string fileName, out string directory) {
-            return NodejsPackage.TryGetStartupFileAndDirectory(NodejsPackage.Instance, out fileName, out directory);
+            var nodeJsInstance = NodejsPackage.Instance;
+            if (nodeJsInstance == null) {
+                fileName = null;
+                directory = null;
+                return false;
+            }
+            return NodejsPackage.TryGetStartupFileAndDirectory(nodeJsInstance, out fileName, out directory);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/Nodejs/Product/Nodejs/Repl/VsNodejsReplSite.cs
+++ b/Nodejs/Product/Nodejs/Repl/VsNodejsReplSite.cs
@@ -25,6 +25,7 @@ namespace Microsoft.NodejsTools.Repl {
         public CommonProjectNode GetStartupProject() {
             var nodeJsInstance = NodejsPackage.Instance;
             if (nodeJsInstance == null) {
+                // Node.js Tools package has not loaded yet. Expected if no NTVS project is open.
                 return null;
             }
             return NodejsPackage.GetStartupProject(nodeJsInstance);
@@ -33,6 +34,7 @@ namespace Microsoft.NodejsTools.Repl {
         public bool TryGetStartupFileAndDirectory(out string fileName, out string directory) {
             var nodeJsInstance = NodejsPackage.Instance;
             if (nodeJsInstance == null) {
+                // Node.js Tools package has not loaded yet. Expected if no NTVS project is open.
                 fileName = null;
                 directory = null;
                 return false;


### PR DESCRIPTION
**Bug**
We currently register a Node.js language service. This causes a `Text Editor -> Node.js` section to be automatically created in the options panel. These builtin pages don't really do anything and users should use the TypeScript options instead. VS15 makes this more clear by renaming the "Typescript" Text editor section to "JavaScript / Typescript"

**fix**
Use the Typescript language service for the interactive window. This is the only place we still use the old Node language service. This also gets us back syntax highlighting in the interactive window for free.

![image](https://cloud.githubusercontent.com/assets/12821956/19171108/fe5bc862-8bcf-11e6-9b33-8a409d0b8aec.png)


In VS15, delete the node language service entirely. In VS14, we still use some of the submenus for the Node language service, so keep it around for now.

closes #1312 