### PR TITLE
Fix build project in VS 15 Preview 5

### DIFF
--- a/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
+++ b/Nodejs/Product/Nodejs/Microsoft.NodejsTools.targets
@@ -168,7 +168,7 @@
     <PublishPipelineCollectFilesCore>$(PublishPipelineCollectFilesCore);CollectNodejsFiles</PublishPipelineCollectFilesCore>
   </PropertyGroup>
 
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != '' and Exists('$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets')" />
 
   <!--- Detects if we're deploying via web deploy, and sets _NodejsDeploymentMethod appropriately.
         Otherwise we'll assume we're deploying to cloud service. -->


### PR DESCRIPTION
Issue #1321 

##### Bug
Test Explorer does not show the list of the tests

##### Fix
Don't expect that WebApplication.targets file present on the user machine

##### Testing

This should fix #1321, which cause Test Explorer be unusabe. Right now NTVS has dependency on WebApplications which not always the case with New installer Experience