### PR TITLE
Don't Add typings.json to Project Templates in Dev15

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/ExpressApp.njsproj
@@ -35,7 +35,9 @@
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />
+$if$ ($dev14$ == true)
     <Content Include="typings.json" />
+$endif$
     <Content Include="views\index.pug" />
     <Content Include="views\layout.pug" />
     <Content Include="views\error.pug" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/ExpressApp.njsproj
@@ -35,7 +35,9 @@
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />
+$if$ ($dev14$ == true)
     <Content Include="typings.json" />
+$endif$
     <Content Include="views\index.pug" />
     <Content Include="views\layout.pug" />
     <Content Include="views\error.pug" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
@@ -41,7 +41,9 @@
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />
+$if$ ($dev14$ == true)
     <Content Include="typings.json" />
+$endif$
     <Content Include="views\index.pug" />
     <Content Include="views\layout.pug" />
     <Content Include="Web.config" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
@@ -42,7 +42,9 @@
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />
+$if$ ($dev14$ == true)
     <Content Include="typings.json" />
+$endif$
     <Content Include="views\index.pug" />
     <Content Include="views\layout.pug" />
   </ItemGroup>

--- a/Nodejs/Product/ProjectWizard/NpmWizardExtension.cs
+++ b/Nodejs/Product/ProjectWizard/NpmWizardExtension.cs
@@ -43,12 +43,15 @@ namespace Microsoft.NodejsTools.ProjectWizard {
         }
 
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams) {
+#if DEV14
+            replacementsDictionary.Add("$dev14$", "true");
+#endif
         }
 
         public bool ShouldAddProjectItem(string filePath) {
             return true;
         }
 
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Issue #1225

**Bug**
The `typings.json` file in our project templates was added to support rich intellisense in dev14. It is not required in dev15.

**fix**
Exclude these files from project templates in dev15

Closes #1225