### PR TITLE
Delete Unused Conditional Code

### DIFF
--- a/Nodejs/Product/Nodejs/Jade/ServiceManager.cs
+++ b/Nodejs/Product/Nodejs/Jade/ServiceManager.cs
@@ -292,19 +292,6 @@ namespace Microsoft.NodejsTools.Jade {
             if (_propertyOwner != null) {
                 _propertyOwner.Properties.RemoveProperty(ServiceManagerId);
 
-#if NOT
-                var properties = _propertyOwner.Properties.PropertyList;
-                var sb = new StringBuilder();
-
-                foreach (var prop in properties)
-                {
-                    sb.Append(prop.Value.GetType().ToString());
-                    sb.Append("\r\n");
-                }
-
-                Debug.Assert(properties.Count == 0, String.Format("There are still {0} services attached to the buffer:\r\n {1}", properties.Count, sb.ToString()));
-#endif
-
                 _servicesByGuid.Clear();
                 _servicesByType.Clear();
                 _servicesByContentType.Clear();

--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -16,9 +16,13 @@
 
 using System;
 using System.IO;
+#if !NO_WINDOWS
 using System.Windows.Forms;
+#endif
 using Microsoft.Win32;
+#if !NO_WINDOWS
 using Microsoft.NodejsTools.Project;
+#endif
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.NodejsTools {
@@ -115,6 +119,7 @@ namespace Microsoft.NodejsTools {
             return null;
         }
 
+#if !NO_WINDOWS
         public static void ShowNodejsNotInstalled() {
             MessageBox.Show(
                 SR.GetString(SR.NodejsNotInstalled),
@@ -132,5 +137,6 @@ namespace Microsoft.NodejsTools {
                 MessageBoxIcon.Error
             );
         }
+#endif
     }
 }

--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -16,13 +16,9 @@
 
 using System;
 using System.IO;
-#if !NO_WINDOWS
 using System.Windows.Forms;
-#endif
 using Microsoft.Win32;
-#if !NO_WINDOWS
 using Microsoft.NodejsTools.Project;
-#endif
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.NodejsTools {
@@ -119,7 +115,6 @@ namespace Microsoft.NodejsTools {
             return null;
         }
 
-#if !NO_WINDOWS
         public static void ShowNodejsNotInstalled() {
             MessageBox.Show(
                 SR.GetString(SR.NodejsNotInstalled),
@@ -137,6 +132,5 @@ namespace Microsoft.NodejsTools {
                 MessageBoxIcon.Error
             );
         }
-#endif
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -198,39 +198,6 @@ namespace Microsoft.NodejsTools.Project {
                 NpmOutputPane?.ShowAndActivate();
             }
         }
-
-#if INTEGRATE_WITH_ERROR_LIST
-        private ErrorListProvider _errorListProvider;
-
-        private ErrorListProvider GetErrorListProvider() {
-            if (null == _errorListProvider) {
-                _errorListProvider = new ErrorListProvider(_projectNode.ProjectMgr.Site);
-            }
-            return _errorListProvider;
-        }
-
-        private void WriteNpmErrorsToErrorList(NpmLogEventArgs args) {
-            var provider = GetErrorListProvider();
-            foreach (var line in args.LogText.Split(new[] {'\n' })) {
-                var trimmed = line.Trim();
-                if (trimmed.StartsWith("npm ERR!")) {
-                    provider.Tasks.Add(new ErrorTask() {
-                        Category = TaskCategory.User,
-                        ErrorCategory = TaskErrorCategory.Error,
-                        Text = trimmed
-                    });
-                } else if (trimmed.StartsWith("npm WARN")) {
-                    provider.Tasks.Add(new ErrorTask() {
-                        Category = TaskCategory.User,
-                        ErrorCategory = TaskErrorCategory.Warning,
-                        Text = trimmed
-                    });
-                }
-            }
-        }
-
-#endif
-
         private void ForceUpdateStatusBarWithNpmActivity(string activity) {
             if (string.IsNullOrEmpty(activity) || string.IsNullOrEmpty(activity.Trim())) {
                 return;
@@ -279,10 +246,6 @@ namespace Microsoft.NodejsTools.Project {
 
         private void WriteNpmLogToOutputWindow(string logText) {
             NpmOutputPane?.WriteLine(logText);
-
-#if INTEGRATE_WITH_ERROR_LIST
-            WriteNpmErrorsToErrorList(args);
-#endif
         }
 
         private void WriteNpmLogToOutputWindow(NpmLogEventArgs args) {

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -34,11 +34,6 @@ using SR = Microsoft.NodejsTools.Project.SR;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.NodejsTools.Repl {
-#if INTERACTIVE_WINDOW
-    using IReplCommand = IInteractiveWindowCommand;
-    using IReplWindow = IInteractiveWindow;    
-#endif
-
     [Export(typeof(IReplCommand))]
     class NpmReplCommand : IReplCommand {
         #region IReplCommand Members


### PR DESCRIPTION
Deletes a few sections of conditional code that is not used in any of our current builds. This includes guards for:

`INTERACTIVE_WINDOW`
`NO_WINDOWS`
`INTEGRATE_WITH_ERROR_LIST`