### PR TITLE
modifications to mocha.js and some TestExecutor logic

### DIFF
--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -424,7 +424,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 if (_process.StartInfo.RedirectStandardInput) {
                     // Close standard input so that we don't get stuck trying to read input from the user.
                     try {
-                        _process.StandardInput.Close();
+                        //_process.StandardInput.Close();
                     } catch (InvalidOperationException) {
                         // StandardInput not available
                     }
@@ -496,6 +496,19 @@ namespace Microsoft.VisualStudioTools.Project {
         public string Arguments {
             get {
                 return _arguments;
+            }
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public StreamWriter StandardInput {
+            get
+            {
+                if (_process == null) {
+                    return null;
+                }
+                return _process.StandardInput;
             }
         }
 

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -415,10 +415,10 @@ namespace Microsoft.VisualStudioTools.Project {
 
             if (_process != null) {
                 if (_process.StartInfo.RedirectStandardOutput) {
-                    _process.BeginOutputReadLine();
+                    //_process.BeginOutputReadLine();
                 }
                 if (_process.StartInfo.RedirectStandardError) {
-                    _process.BeginErrorReadLine();
+                    //_process.BeginErrorReadLine();
                 }
                 
                 if (_process.StartInfo.RedirectStandardInput) {
@@ -509,6 +509,20 @@ namespace Microsoft.VisualStudioTools.Project {
                     return null;
                 }
                 return _process.StandardInput;
+            }
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public StreamReader StandardOutput {
+            get
+            {
+                if(_process == null || !_process.StartInfo.RedirectStandardOutput || _process.StartInfo.UseShellExecute) {
+                    return null;
+                }
+
+                return _process.StandardOutput;
             }
         }
 

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -500,7 +500,8 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         /// <summary>
-        /// TODO
+        /// The StandardInput stream of the process or null if the process hasn't
+        /// started yet.
         /// </summary>
         public StreamWriter StandardInput {
             get
@@ -513,7 +514,8 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         /// <summary>
-        /// TODO
+        /// The StandardOutput stream of the process or null if process hasn't started
+        /// or if conditions are not correct to use the stream.
         /// </summary>
         public StreamReader StandardOutput {
             get

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudioTools.Project {
             return result;
         }
 
-        private static string GetArguments(IEnumerable<string> arguments, bool quoteArgs) {
+        public static string GetArguments(IEnumerable<string> arguments, bool quoteArgs) {
             if (quoteArgs) {
                 return string.Join(" ", arguments.Where(a => a != null).Select(QuoteSingleArgument));
             } else {
@@ -335,7 +335,7 @@ namespace Microsoft.VisualStudioTools.Project {
             }
         }
 
-        internal static string QuoteSingleArgument(string arg) {
+        public static string QuoteSingleArgument(string arg) {
             if (string.IsNullOrEmpty(arg)) {
                 return "\"\"";
             }

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -415,16 +415,16 @@ namespace Microsoft.VisualStudioTools.Project {
 
             if (_process != null) {
                 if (_process.StartInfo.RedirectStandardOutput) {
-                    //_process.BeginOutputReadLine();
+                    _process.BeginOutputReadLine();
                 }
                 if (_process.StartInfo.RedirectStandardError) {
-                    //_process.BeginErrorReadLine();
+                    _process.BeginErrorReadLine();
                 }
                 
                 if (_process.StartInfo.RedirectStandardInput) {
                     // Close standard input so that we don't get stuck trying to read input from the user.
                     try {
-                        //_process.StandardInput.Close();
+                        _process.StandardInput.Close();
                     } catch (InvalidOperationException) {
                         // StandardInput not available
                     }
@@ -496,35 +496,6 @@ namespace Microsoft.VisualStudioTools.Project {
         public string Arguments {
             get {
                 return _arguments;
-            }
-        }
-
-        /// <summary>
-        /// The StandardInput stream of the process or null if the process hasn't
-        /// started yet.
-        /// </summary>
-        public StreamWriter StandardInput {
-            get
-            {
-                if (_process == null) {
-                    return null;
-                }
-                return _process.StandardInput;
-            }
-        }
-
-        /// <summary>
-        /// The StandardOutput stream of the process or null if process hasn't started
-        /// or if conditions are not correct to use the stream.
-        /// </summary>
-        public StreamReader StandardOutput {
-            get
-            {
-                if(_process == null || !_process.StartInfo.RedirectStandardOutput || _process.StartInfo.UseShellExecute) {
-                    return null;
-                }
-
-                return _process.StandardOutput;
             }
         }
 

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -6,24 +6,6 @@ var result = {
     "stdOut": "",
     "stdErr": ""
 };
-var rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-});
-
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
-
-rl.on('line', (line) => {
-    var data = JSON.parse(line);
-    console.log(JSON.stringify(data));
-    result.title = data.testName.replace(' ', '::');
-    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
-});
 
 process.stdout.write = (function (write) {
     return function (string, encoding, fileDescriptor) {
@@ -38,6 +20,29 @@ process.stderr.write = (function (write) {
         write.apply(process.stderr, arguments);
     };
 })(process.stderr.write);
+
+var rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+rl.on('line', (line) => {
+    var data = JSON.parse(line);
+    result.title = data.testName.replace(' ', '::');
+    // get rid of leftover quotations from C#
+    for(var s in data) {
+        data[s] = data[s].replace(/['"]+/g, '');
+    }
+    // run the test
+    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+});
+
+try {
+    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
+} catch (exception) {
+    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+    process.exit(1);
+}
 
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,25 +1,5 @@
 var framework;
 var readline = require('readline');
-var result = {
-    "title": "",
-    "passed": false,
-    "stdOut": "",
-    "stdErr": ""
-};
-
-process.stdout.write = (function (write) {
-    return function (string, encoding, fileDescriptor) {
-        result.stdOut += string;
-        write.apply(process.stdout, arguments);
-    };
-})(process.stdout.write);
-
-process.stderr.write = (function (write) {
-    return function (string, encoding, fileDescriptor) {
-        result.stdErr += string;
-        write.apply(process.stderr, arguments);
-    };
-})(process.stderr.write);
 
 var rl = readline.createInterface({
     input: process.stdin,
@@ -28,8 +8,7 @@ var rl = readline.createInterface({
 
 rl.on('line', (line) => {
     var testInfo = JSON.parse(line);
-    result.title = testInfo.testName.replace(' ', '::');
-    // get rid of leftover quotations from C#
+    // get rid of leftover quotations from C# (necessary?)
     for(var s in testInfo) {
         testInfo[s] = testInfo[s].replace(/["]+/g, '');
     }
@@ -45,12 +24,4 @@ rl.on('line', (line) => {
 
     // close readline interface
     rl.close();
-});
-
-process.on('exit', (code) => {
-    result.passed = code === 0 ? true : false;
-    console.log(JSON.stringify(result));
-    // clear stdOut and stdErr
-    result.stdErr = "";
-    result.stdOut = "";
 });

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -42,6 +42,9 @@ rl.on('line', (line) => {
     }
     // run the test
     framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder);
+
+    // close readline interface
+    rl.close();
 });
 
 process.on('exit', (code) => {

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,6 +1,7 @@
 var framework;
 var readline = require('readline');
-
+var old_stdout = process.stdout.write;
+var old_stderr = process.stderr.write;
 var rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -19,9 +20,16 @@ rl.on('line', (line) => {
         console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
         process.exit(1);
     }
+    
+    function sendResult(result) {
+        process.stdout.write = old_stdout;
+        process.stderr.write = old_stderr;
+        console.log(JSON.stringify(result));
+        process.exit(0);
+    }
     // run the test
-    framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder);
-
+    framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder, sendResult);
+    
     // close readline interface
     rl.close();
 });

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,10 +1,29 @@
 var framework;
+var readline = require('readline');
 var result = {
     "title": "",
     "passed": false,
     "stdOut": "",
     "stdErr": ""
 };
+var rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+try {
+    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
+} catch (exception) {
+    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+    process.exit(1);
+}
+
+rl.on('line', (line) => {
+    var data = JSON.parse(line);
+    console.log(JSON.stringify(data));
+    result.title = data.testName.replace(' ', '::');
+    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+});
 
 process.stdout.write = (function (write) {
     return function (string, encoding, fileDescriptor) {
@@ -20,18 +39,10 @@ process.stderr.write = (function (write) {
     };
 })(process.stderr.write);
 
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
-
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;
     console.log(JSON.stringify(result));
+    // clear stdOut and stdErr
+    result.stdErr = "";
+    result.stdOut = "";
 });
-
-result.title = process.argv[3].replace(' ', '::');
-
-framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,4 +1,25 @@
 var framework;
+var result = {
+    "title": "",
+    "passed": false,
+    "stdOut": "",
+    "stdErr": ""
+};
+
+process.stdout.write = (function (write) {
+    return function (string, encoding, fileDescriptor) {
+        result.stdOut += string;
+        write.apply(process.stdout, arguments);
+    };
+})(process.stdout.write);
+
+process.stderr.write = (function (write) {
+    return function (string, encoding, fileDescriptor) {
+        result.stdErr += string;
+        write.apply(process.stderr, arguments);
+    };
+})(process.stderr.write);
+
 try {
     framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
 } catch (exception) {
@@ -6,5 +27,11 @@ try {
     process.exit(1);
 }
 
-framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);
+process.on('exit', (code) => {
+    result.passed = code === 0 ? true : false;
+    console.log(JSON.stringify(result));
+});
 
+result.title = process.argv[3].replace(' ', '::');
+
+framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -27,22 +27,22 @@ var rl = readline.createInterface({
 });
 
 rl.on('line', (line) => {
-    var data = JSON.parse(line);
-    result.title = data.testName.replace(' ', '::');
+    var testInfo = JSON.parse(line);
+    result.title = testInfo.testName.replace(' ', '::');
     // get rid of leftover quotations from C#
-    for(var s in data) {
-        data[s] = data[s].replace(/['"]+/g, '');
+    for(var s in testInfo) {
+        testInfo[s] = testInfo[s].replace(/['"]+/g, '');
+    }
+
+    try {
+        framework = require('./' + testInfo.framework + '/' + testInfo.framework + '.js');
+    } catch (exception) {
+        console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+        process.exit(1);
     }
     // run the test
-    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+    framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder);
 });
-
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
 
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -31,7 +31,7 @@ rl.on('line', (line) => {
     result.title = testInfo.testName.replace(' ', '::');
     // get rid of leftover quotations from C#
     for(var s in testInfo) {
-        testInfo[s] = testInfo[s].replace(/['"]+/g, '');
+        testInfo[s] = testInfo[s].replace(/["]+/g, '');
     }
 
     try {

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -206,7 +206,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 frameworkHandle.SendMessage(TestMessageLevel.Informational, _nodeProcess.Arguments);
 #endif
                 // send test to run_tests.js
-                TestCaseObject testObject = new TestCaseObject(args[2], args[3], args[4], args[5]);
+                TestCaseObject testObject = new TestCaseObject(args[1], args[2], args[3], args[4], args[5]);
                 _nodeProcess.StandardInput.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(testObject));
 
                 _nodeProcess.Wait(TimeSpan.FromMilliseconds(500));
@@ -335,18 +335,21 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
         class TestCaseObject {
             public TestCaseObject() {
+                framework = String.Empty;
                 testName = String.Empty;
                 testFile = String.Empty;
                 workingFolder = String.Empty;
                 projectFolder = String.Empty;
             }
 
-            public TestCaseObject(string testName, string testFile, string workingFolder, string projectFolder) {
+            public TestCaseObject(string framework, string testName, string testFile, string workingFolder, string projectFolder) {
+                this.framework = framework;
                 this.testName = testName;
                 this.testFile = testFile;
                 this.workingFolder = workingFolder;
                 this.projectFolder = projectFolder;
             }
+            public string framework { get; set; }
             public string testName { get; set; }
             public string testFile { get; set; }
             public string workingFolder { get; set; }

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -144,10 +144,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     var workingDir = Path.GetDirectoryName(CommonUtils.GetAbsoluteFilePath(settings.WorkingDir, testInfo.ModulePath));
                     args.AddRange(GetInterpreterArgs(firstTest, workingDir, settings.ProjectRootDir));
 
-                    foreach (string s in args) {
-                        Console.WriteLine(s);
-                    }
-
                     // launch node process
                     _psi = new ProcessStartInfo("cmd.exe") {
                         Arguments = string.Format(@"/S /C pushd {0} & {1} {2}",

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -236,18 +236,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 }
             }
             WaitHandle.WaitAll(new WaitHandle[] { _nodeProcess.WaitHandle });
-            // at this point the test is definitely done executing
-            ResultObject result = null;
-
-            using (StreamReader sr = _nodeProcess.StandardOutput) {
-                while(sr.Peek() >= 0) {
-                    result = ParseTestResult(sr.ReadLine());
-                    if(result == null) {
-                        continue;
-                    }
-                    break;
-                }
-            }
+            var result = GetTestResultFromProcess();
 
             bool runCancelled = _cancelRequested.WaitOne(0);
             RecordEnd(frameworkHandle, test, testResult,
@@ -265,6 +254,20 @@ namespace Microsoft.NodejsTools.TestAdapter {
             catch (Exception) {
             }
             return jsonResult;
+        }
+
+        private ResultObject GetTestResultFromProcess() {
+            ResultObject result = null;
+            using (StreamReader sr = _nodeProcess.StandardOutput) {
+                while (sr.Peek() >= 0) {
+                    result = ParseTestResult(sr.ReadLine());
+                    if (result == null) {
+                        continue;
+                    }
+                    break;
+                }
+            }
+            return result;
         }
 
         private NodejsProjectSettings LoadProjectSettings(string projectFile) {

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -57,6 +57,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
         private readonly ManualResetEvent _cancelRequested = new ManualResetEvent(false);
 
+        private static readonly char[] _needToBeQuoted = new[] { ' ', '"' };
         private ProcessStartInfo _psi;
         private Process _nodeProcess;
         private object _syncObject = new object();

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -210,6 +210,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 // send test to run_tests.js
                 TestCaseObject testObject = new TestCaseObject(args[1], args[2], args[3], args[4], args[5]);
                 _nodeProcess.StandardInput.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(testObject));
+                _nodeProcess.StandardInput.Close();
 
                 _nodeProcess.Wait(TimeSpan.FromMilliseconds(500));
                 if (runContext.IsBeingDebugged && app != null) {

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -290,10 +290,15 @@ namespace Microsoft.NodejsTools.TestAdapter {
             var result = GetTestResultFromProcess();
 
             bool runCancelled = _cancelRequested.WaitOne(0);
-            RecordEnd(frameworkHandle, test, testResult,
-                result.stdout,
-                result.stderr,
-                (!runCancelled && result.passed) ? TestOutcome.Passed : TestOutcome.Failed);
+            result = null;
+            if (result != null) {
+                RecordEnd(frameworkHandle, test, testResult,
+                    result.stdout,
+                    result.stderr,
+                    (!runCancelled && result.passed) ? TestOutcome.Passed : TestOutcome.Failed);
+            } else {
+                frameworkHandle.SendMessage(TestMessageLevel.Error, "Failed to obtain result for " + test.DisplayName + " from TestRunner");
+            }
         }
 
         private ResultObject ParseTestResult(string line) {

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -162,8 +162,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
                     try {
                         RunTestCase(app, frameworkHandle, runContext, test, sourceToSettings);
-                    }
-                    catch (Exception ex) {
+                    } catch (Exception ex) {
                         frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
                     }
                 }
@@ -221,8 +220,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 return;
             }
 
-
-
             NodejsTestInfo testInfo = new NodejsTestInfo(test.FullyQualifiedName);
             List<string> args = new List<string>();
             int port = 0;
@@ -266,17 +263,16 @@ namespace Microsoft.NodejsTools.TestAdapter {
                         //    }
                         //}
 #if DEBUG
-                    }
-                    catch (COMException ex) {
+                    } catch (COMException ex) {
                         frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
                         frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
                         KillNodeProcess();
                     }
 #else
-                                    } catch (COMException) {
-                                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
-                                        KillNodeProcess();
-                                    }
+                    } catch (COMException) {
+                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
+                        KillNodeProcess();
+                    }
 #endif
                 }
             }
@@ -301,9 +297,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
             ResultObject jsonResult = null;
             try {
                 jsonResult = JsonConvert.DeserializeObject<ResultObject>(line);
-            }
-            catch (Exception) {
-            }
+            } catch (Exception) { }
             return jsonResult;
         }
 
@@ -323,9 +317,9 @@ namespace Microsoft.NodejsTools.TestAdapter {
         private void LaunchNodeProcess(string workingDir, string nodeExePath, List<string> args) {
             _psi = new ProcessStartInfo("cmd.exe") {
                 Arguments = string.Format(@"/S /C pushd {0} & {1} {2}",
-                QuoteSingleArgument(workingDir),
-                QuoteSingleArgument(nodeExePath),
-                GetArguments(args, true)),
+                ProcessOutput.QuoteSingleArgument(workingDir),
+                ProcessOutput.QuoteSingleArgument(nodeExePath),
+                ProcessOutput.GetArguments(args, true)),
                 CreateNoWindow = true,
                 UseShellExecute = false
             };
@@ -352,52 +346,6 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     proj.GetPropertyValue(NodejsConstants.NodeExePath));
 
             return projSettings;
-        }
-
-        private static string GetArguments(IEnumerable<string> arguments, bool quoteArgs) {
-            if (quoteArgs) {
-                return string.Join(" ", arguments.Where(a => a != null).Select(QuoteSingleArgument));
-            }
-            else {
-                return string.Join(" ", arguments.Where(a => a != null));
-            }
-        }
-
-        internal static string QuoteSingleArgument(string arg) {
-            if (string.IsNullOrEmpty(arg)) {
-                return "\"\"";
-            }
-            if (arg.IndexOfAny(_needToBeQuoted) < 0) {
-                return arg;
-            }
-
-            if (arg.StartsWith("\"") && arg.EndsWith("\"")) {
-                bool inQuote = false;
-                int consecutiveBackslashes = 0;
-                foreach (var c in arg) {
-                    if (c == '"') {
-                        if (consecutiveBackslashes % 2 == 0) {
-                            inQuote = !inQuote;
-                        }
-                    }
-
-                    if (c == '\\') {
-                        consecutiveBackslashes += 1;
-                    }
-                    else {
-                        consecutiveBackslashes = 0;
-                    }
-                }
-                if (!inQuote) {
-                    return arg;
-                }
-            }
-
-            var newArg = arg.Replace("\"", "\\\"");
-            if (newArg.EndsWith("\\")) {
-                newArg += "\\";
-            }
-            return "\"" + newArg + "\"";
         }
 
         private static void RecordEnd(IFrameworkHandle frameworkHandle, TestCase test, TestResult result, string stdout, string stderr, TestOutcome outcome) {

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
 using Newtonsoft.Json.Linq;
 using MSBuild = Microsoft.Build.Evaluation;
+using Newtonsoft.Json;
 
 namespace Microsoft.NodejsTools.TestAdapter {
 
@@ -257,13 +258,13 @@ namespace Microsoft.NodejsTools.TestAdapter {
         }
 
         private ResultObject ParseTestResult(string line) {
-            JObject jsonResult = null;
+            ResultObject jsonResult = null;
             try {
-                jsonResult = JObject.Parse(line);
+                jsonResult = JsonConvert.DeserializeObject<ResultObject>(line);
             }
             catch (Exception) {
             }
-            return jsonResult != null ? jsonResult.ToObject<ResultObject>() : null;
+            return jsonResult;
         }
 
         private NodejsProjectSettings LoadProjectSettings(string projectFile) {


### PR DESCRIPTION
Hi again.
This is kind of a big, messy PR but I'd like to get your feedback on the changes before I continue further. I've moved the logic for determining test pass/failure and sending results to `mocha.js`. It is much easier to determine if we are using mocha API's `runner` events. This works really nicely if we are running mocha tests, but my main concern is how to make `run_tests` work among all frameworks with this new logic. I'd like your feedback on these changes and if they are viable.

I've also changed some logic in `TestExecutor`. The code is currently in a working state, so only running one test per node process, but I've moved much of the setup logic to `RunTests`, and eventually launching/disposing the process logic will be moved there, as well. I've added some comments with my thought process-- if you need more info I can elaborate.

My biggest concern would be making `run_tests` work among all testing frameworks, any info on how I can make this work would be greatly appreciated. Using mocha's `runner` events is really great because I would be able to determine pass/fail easily, record start and end times and include much more data in the result than was available before. If `tape` and `ExportRunner` don't have a similar feature (I am unfamiliar with these frameworks) then I'm not sure how viable these changes will be.

Either way, when you have time to review I'd love to hear your opinion.
Thanks!