### PR TITLE
Use Explicit StringCompare Mode for StartsWith and EndsWith

### DIFF
--- a/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
+++ b/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
@@ -380,7 +380,7 @@ namespace Microsoft.NodejsTools.LogParsing {
 
         private static ulong ParseAddress(string address) {
             ulong res;
-            if (address.StartsWith("0x") || address.StartsWith("0X")) {
+            if (address.StartsWith("0x", StringComparison.Ordinal) || address.StartsWith("0X", StringComparison.Ordinal)) {
                 if (UInt64.TryParse(address.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out res)) {
                     return res;
                 }
@@ -440,7 +440,7 @@ namespace Microsoft.NodejsTools.LogParsing {
             string methodName = location;
             List<int> pos = null;
 
-            if (location.Length >= 2 && location.StartsWith("\"") && location.EndsWith("\"")) {
+            if (location.Length >= 2 && location.StartsWith("\"", StringComparison.Ordinal) && location.EndsWith("\"", StringComparison.Ordinal)) {
                 // v8 usually includes quotes, strip them
                 location = location.Substring(1, location.Length - 2);
             }

--- a/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
+++ b/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
@@ -380,7 +380,7 @@ namespace Microsoft.NodejsTools.LogParsing {
 
         private static ulong ParseAddress(string address) {
             ulong res;
-            if (address.StartsWith("0x", StringComparison.Ordinal) || address.StartsWith("0X", StringComparison.Ordinal)) {
+            if (address.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) {
                 if (UInt64.TryParse(address.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out res)) {
                     return res;
                 }

--- a/Nodejs/Product/Nodejs/Azure/WebSiteServiceShims.cs
+++ b/Nodejs/Product/Nodejs/Azure/WebSiteServiceShims.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Web.WindowsAzure.Contracts.Shims {
 
         static ContractShim() {
             string shimName = typeof(T).FullName;
-            Debug.Assert(shimName.StartsWith("Microsoft.VisualStudio.Web.WindowsAzure.Contracts.Shims."));
+            Debug.Assert(shimName.StartsWith("Microsoft.VisualStudio.Web.WindowsAzure.Contracts.Shims.", StringComparison.Ordinal));
             string realName = shimName.Replace(".Shims.", ".");
             _interface = contractAssembly.GetType(realName, throwOnError: true);
         }

--- a/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
@@ -255,7 +255,7 @@ namespace Microsoft.NodejsTools.Commands {
 
             // Get web.config for the site via FTP.
 
-            if (!publishUrl.EndsWith("/")) {
+            if (!publishUrl.EndsWith("/", StringComparison.Ordinal)) {
                 publishUrl += "/";
             }
             publishUrl += "web.config";

--- a/Nodejs/Product/Nodejs/Debugger/Commands/ScriptsCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/ScriptsCommand.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -52,8 +53,8 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
                 var id = (int)module["id"];
                 var source = (string)module["source"];
                 if (!string.IsNullOrEmpty(source) &&
-                    source.StartsWith(NodeConstants.ScriptWrapBegin) &&
-                    source.EndsWith(NodeConstants.ScriptWrapEnd)) {
+                    source.StartsWith(NodeConstants.ScriptWrapBegin, StringComparison.Ordinal) &&
+                    source.EndsWith(NodeConstants.ScriptWrapEnd, StringComparison.Ordinal)) {
                     source = source.Substring(
                         NodeConstants.ScriptWrapBegin.Length,
                         source.Length - NodeConstants.ScriptWrapBegin.Length - NodeConstants.ScriptWrapEnd.Length);

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
@@ -83,7 +83,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                 if (funcName == "<module>") {
                     if (_stackFrame.FileName.IndexOfAny(Path.GetInvalidPathChars()) == -1) {
                         funcName = Path.GetFileName(_stackFrame.FileName) + " module";
-                    } else if (_stackFrame.FileName.EndsWith("<string>")) {
+                    } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
                         funcName = "<exec or eval>";
                     } else {
                         funcName = _stackFrame.FileName + " unknown code";
@@ -110,7 +110,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
             if ((dwFieldSpec & enum_FRAMEINFO_FLAGS.FIF_MODULE) != 0) {
                 if (_stackFrame.FileName.IndexOfAny(Path.GetInvalidPathChars()) == -1) {
                     frameInfo.m_bstrModule = Path.GetFileName(_stackFrame.FileName);
-                } else if (_stackFrame.FileName.EndsWith("<string>")) {
+                } else if (_stackFrame.FileName.EndsWith("<string>", StringComparison.Ordinal)) {
                     frameInfo.m_bstrModule = "<exec/eval>";
                 } else {
                     frameInfo.m_bstrModule = "<unknown>";

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -751,7 +751,7 @@ namespace Microsoft.NodejsTools.Debugger {
                 }
 
                 string description = exceptionEvent.Description;
-                if (description.StartsWith("#<") && description.EndsWith(">")) {
+                if (description.StartsWith("#<", StringComparison.Ordinal) && description.EndsWith(">", StringComparison.Ordinal)) {
                     // Serialize exception object to get a proper description
                     var tokenSource = new CancellationTokenSource(_timeout);
                     var evaluateCommand = new EvaluateCommand(CommandId, _resultFactory, exceptionEvent.ExceptionId);
@@ -1202,7 +1202,7 @@ namespace Microsoft.NodejsTools.Debugger {
 
             if (string.IsNullOrEmpty(javaScriptFileName) ||
                 javaScriptFileName == NodeVariableType.UnknownModule ||
-                javaScriptFileName.StartsWith("binding:")) {
+                javaScriptFileName.StartsWith("binding:", StringComparison.Ordinal)) {
                 return false;
             }
 

--- a/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudioTools.Project;
 
@@ -94,7 +95,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
 
                 case "error":
                     stringValue = variable.Value ?? variable.Text;
-                    if (!string.IsNullOrEmpty(stringValue) && stringValue.StartsWith("Error: ")) {
+                    if (!string.IsNullOrEmpty(stringValue) && stringValue.StartsWith("Error: ", StringComparison.Ordinal)) {
                         stringValue = stringValue.Substring(7);
                     }
                     typeName = NodeVariableType.Error;
@@ -126,7 +127,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
             // Generates a parent name
             const string prototypeSuffix = "." + NodeVariableType.Prototype;
             var parentName = parent.FullName;
-            if (parentName.EndsWith(prototypeSuffix)) {
+            if (parentName.EndsWith(prototypeSuffix, StringComparison.Ordinal)) {
                 parentName = parentName.Remove(parentName.Length - prototypeSuffix.Length);
             }
 

--- a/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
@@ -239,7 +239,7 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
 
         private string Preprocess(string source) {
-            return source.EndsWith(Environment.NewLine) ? source.Substring(0, source.Length - Environment.NewLine.Length) : source;
+            return source.EndsWith(Environment.NewLine, StringComparison.Ordinal) ? source.Substring(0, source.Length - Environment.NewLine.Length) : source;
         }
 
         private void WriteLines(string text, bool forceError) {

--- a/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsFormattingDialogPage.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NodejsTools.Options {
         }
 
         private static string GetKeyName(string name) {
-            if (name.EndsWith("_TEMP")) {
+            if (name.EndsWith("_TEMP", StringComparison.Ordinal)) {
                 name = name.Remove(name.Length - 5);
             }
             return TypeScriptBaseName + name;

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -454,7 +454,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard {
             }
 
             var res = files
-                .Where(path => path.StartsWith(source))
+                .Where(path => path.StartsWith(source, StringComparison.Ordinal))
                 .Select(path => path.Substring(source.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
                 .Distinct(StringComparer.OrdinalIgnoreCase);
 

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -234,10 +234,10 @@ namespace Microsoft.NodejsTools.Project {
                 return string.Empty;
             }
 
-            if (text.EndsWith("\r\n")) {
+            if (text.EndsWith("\r\n", StringComparison.Ordinal)) {
                 return text.Remove(text.Length - 2);
             }
-            if (text.EndsWith("\r") || text.EndsWith("\n")) {
+            if (text.EndsWith("\r", StringComparison.Ordinal) || text.EndsWith("\n", StringComparison.Ordinal)) {
                 return text.Remove(text.Length - 1);
             }
 

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NodejsTools.Repl {
             string npmArguments = arguments.Trim(' ', '\t');
 
             // Parse project name/directory in square brackets
-            if (npmArguments.StartsWith("[")) {
+            if (npmArguments.StartsWith("[", StringComparison.Ordinal)) {
                 var match = Regex.Match(npmArguments, @"(?:[[]\s*\""?\s*)(.*?)(?:\s*\""?\s*[]]\s*)");
                 projectPath = match.Groups[1].Value;
                 npmArguments = npmArguments.Substring(match.Length);
@@ -264,11 +264,11 @@ namespace Microsoft.NodejsTools.Repl {
                 var substring = string.Empty;
                 string outputString = string.Empty;
 
-                if (decodedString.StartsWith(ErrorText)) {
+                if (decodedString.StartsWith(ErrorText, StringComparison.Ordinal)) {
                     outputString += ErrorAnsiColor + decodedString.Substring(0, ErrorText.Length);
                     substring = decodedString.Length > ErrorText.Length ? decodedString.Substring(ErrorText.Length) : string.Empty;
                     this.HasErrors = true;
-                } else if (decodedString.StartsWith(WarningText)) {
+                } else if (decodedString.StartsWith(WarningText, StringComparison.Ordinal)) {
                     outputString += WarnAnsiColor + decodedString.Substring(0, WarningText.Length);
                     substring = decodedString.Length > WarningText.Length ? decodedString.Substring(WarningText.Length) : string.Empty;
                 } else {

--- a/Nodejs/Product/Nodejs/Repl/SaveReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/SaveReplCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NodejsTools.Repl {
             positions.Sort((x, y) => x.Key.CompareTo(y.Key));
             foreach (var buffer in positions) {
                 var bufferText = buffer.Value.CurrentSnapshot.GetText();
-                if (!bufferText.StartsWith(".")) {
+                if (!bufferText.StartsWith(".", StringComparison.Ordinal)) {
                     text.Append(bufferText);
                     text.Append(Environment.NewLine);
                 }

--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -197,7 +197,7 @@ namespace Microsoft.NodejsTools {
             try {
                 foreach (var file in Directory.EnumerateFiles(typingsDirectoryPath, "*.d.ts", SearchOption.AllDirectories)) {
                     var directory = Directory.GetParent(file);
-                    if (directory.FullName != typingsDirectoryPath && Path.GetFullPath(directory.FullName).StartsWith(typingsDirectoryPath)) {
+                    if (directory.FullName != typingsDirectoryPath && Path.GetFullPath(directory.FullName).StartsWith(typingsDirectoryPath, StringComparison.OrdinalIgnoreCase)) {
                         packages.Add(directory.Name);
                     }
                 }

--- a/Nodejs/Product/Npm/NpmArgumentBuilder.cs
+++ b/Nodejs/Product/Npm/NpmArgumentBuilder.cs
@@ -14,6 +14,8 @@
 //
 //*********************************************************//
 
+using System;
+
 namespace Microsoft.NodejsTools.Npm {
     public static class NpmArgumentBuilder {
         public static string GetNpmInstallArguments(string packageName,
@@ -41,7 +43,7 @@ namespace Microsoft.NodejsTools.Npm {
             }
 
             otherArguments = otherArguments.TrimStart(' ', '\t');
-            if (otherArguments.StartsWith("@")) {
+            if (otherArguments.StartsWith("@", StringComparison.Ordinal)) {
                 return string.Format("install {0}{1} {2}", packageName, otherArguments, dependencyArguments);
             } else if (!string.IsNullOrEmpty(versionRange)) {
                 return string.Format("install {0}@\"{1}\" {2} {3}", packageName, versionRange, dependencyArguments, otherArguments);

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -47,7 +47,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                         // All dependencies in npm v3 will have at least one element present in _requiredBy.
                         // _requiredBy dependencies that begin with hash characters represent top-level dependencies
                         foreach (var requiredBy in packageJson.RequiredBy) {
-                            if (requiredBy.StartsWith("#") || requiredBy == "/") {
+                            if (requiredBy.StartsWith("#", StringComparison.Ordinal) || requiredBy == "/") {
                                 AddTopLevelModule(parent, showMissingDevOptionalSubPackages, moduleDir, depth, maxDepth);
                                 break;
                             }
@@ -166,7 +166,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
             // Go through every directory in node_modules, and see if it's required as a top-level dependency
             foreach (var moduleDir in topLevelDirectories) {
-                if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !_ignoredDirectories.Any(toIgnore => moduleDir.EndsWith(toIgnore))) {
+                if (moduleDir.Length < NativeMethods.MAX_FOLDER_PATH && !_ignoredDirectories.Any(toIgnore => moduleDir.EndsWith(toIgnore, StringComparison.Ordinal))) {
                     IPackageJson json = null;
                     try {
                         json = PackageJsonFactory.Create(new DirectoryPackageJsonSource(moduleDir));

--- a/Nodejs/Product/Npm/SPI/NpmSearchFilterStringComparer.cs
+++ b/Nodejs/Product/Npm/SPI/NpmSearchFilterStringComparer.cs
@@ -105,8 +105,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             }
 
             // Matches at the beginning are better than matches in the string
-            if (x.Name.StartsWith(_filterString)) {
-                if (y.Name.StartsWith(_filterString)) {
+            if (x.Name.StartsWith(_filterString, StringComparison.CurrentCulture)) {
+                if (y.Name.StartsWith(_filterString, StringComparison.CurrentCulture)) {
                     var result = string.Compare(x.Name, y.Name, StringComparison.CurrentCulture);
                     return 0 == result ? CompareBasedOnDescriptions(x, y) : result;
                 }
@@ -114,7 +114,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                 return -1;
             }
                 
-            if (y.Name.StartsWith(_filterString)) {
+            if (y.Name.StartsWith(_filterString, StringComparison.CurrentCulture)) {
                 return 1;
             }
                 

--- a/Nodejs/Product/Npm/SemverVersion.cs
+++ b/Nodejs/Product/Npm/SemverVersion.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NodejsTools.Npm {
             try {
                 // Hack: To deal with patch truncation - e.g., seen with 'classy' package in npm v1.4.3 onwards
                 var patch = match.Groups["patch"].Value;
-                while (!string.IsNullOrEmpty(patch) && patch.EndsWith("…")) {
+                while (!string.IsNullOrEmpty(patch) && patch.EndsWith("…", StringComparison.Ordinal)) {
                     patch = patch.Length == 1 ? "0" : patch.Substring(0, patch.Length - 1);
                 }
                 // /Hack

--- a/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NodejsTools.Profiling {
             if (arch != ProcessorArchitecture.X86 && arch != ProcessorArchitecture.Amd64) {
                 throw new InvalidOperationException(String.Format("Unsupported architecture: {0}", arch));
             }
-            if (dir.EndsWith("\\")) {
+            if (dir.EndsWith("\\", StringComparison.Ordinal)) {
                 dir = dir.Substring(0, dir.Length - 1);
             }
             if (String.IsNullOrEmpty(dir)) {

--- a/Nodejs/Product/Profiling/Profiling/SessionsNode.cs
+++ b/Nodejs/Product/Profiling/Profiling/SessionsNode.cs
@@ -54,7 +54,7 @@ namespace Microsoft.NodejsTools.Profiling {
         }
 
         internal SessionNode AddTarget(ProfilingTarget target, string filename, bool save) {
-            Debug.Assert(filename.EndsWith(NodejsProfilingPackage.PerfFileType));
+            Debug.Assert(filename.EndsWith(NodejsProfilingPackage.PerfFileType, StringComparison.Ordinal));
 
             // ensure a unique name
             string newBaseName = Path.GetFileNameWithoutExtension(filename);

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -105,7 +105,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
         }
 
         private string WrapWithQuotes(string path) {
-            if (!path.StartsWith("\"") && !path.StartsWith("\'")) {
+            if (!path.StartsWith("\"", StringComparison.Ordinal) && !path.StartsWith("\'", StringComparison.Ordinal)) {
                 path = "\"" + path + "\"";
             }
             return path;

--- a/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
+++ b/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
@@ -994,7 +994,7 @@ namespace ProfilingUITests {
                     perfTarget = new NodejsPerfTarget(app.WaitForDialog());
                     Assert.AreEqual(NodeExePath, perfTarget.InterpreterPath);
                     Assert.AreEqual("", perfTarget.Arguments);
-                    Assert.IsTrue(perfTarget.ScriptName.EndsWith("program.js"));
+                    Assert.IsTrue(perfTarget.ScriptName.EndsWith("program.js", StringComparison.Ordinal));
                     Assert.IsTrue(perfTarget.ScriptName.StartsWith(perfTarget.WorkingDir));
                 } finally {
                     if (perfTarget != null) {


### PR DESCRIPTION
**Bug**
FxCop flags string methods such as `StartsWith` and `EndsWith` that do no use an explicit string compare mode.

**Fix**
Almost all of these operations should use `StringComparidion.Ordinal`. This is different from the explicit behavior which is both case and culture sensitive, to instead be culture insensitive but still case sensitive . Updates startswith and endswith callers in the Node.js codebase to pass this mode in explicitly.