### PR TITLE
Use explicit culture info for string.Format

### DIFF
--- a/Nodejs/Product/LogConverter/EtlNativeMethods.cs
+++ b/Nodejs/Product/LogConverter/EtlNativeMethods.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NodejsTools.LogGeneration {
@@ -187,7 +188,7 @@ namespace Microsoft.NodejsTools.LogGeneration {
         }
 
         public override string ToString() {
-            return String.Format("{0}/{1}/{2} {3}:{4}:{5}.{6}", wYear, wMonth, wDay, wHour, wMinute, wSecond, wMilliseconds);
+            return string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2} {3}:{4}:{5}.{6}", wYear, wMonth, wDay, wHour, wMinute, wSecond, wMilliseconds);
             //return ToDateTime().ToString();
         }
     }

--- a/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
+++ b/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
@@ -604,14 +604,14 @@ namespace Microsoft.NodejsTools.LogParsing {
                             int shift = (_nodeVersion >= v012 ? 1 : 0);
                             var funcInfo = ExtractNamespaceAndMethodName(records[shift + 4]);
                             if (funcInfo.LineNumber != null && !String.IsNullOrWhiteSpace(funcInfo.Filename)) {
-                                pdbCode.Append(String.Format(@"
+                                pdbCode.Append(string.Format(CultureInfo.InvariantCulture, @"
 #line {0} ""{1}""
 public static void X{2:X}() {{
 }}
 ", funcInfo.LineNumber, funcInfo.Filename, methodToken));
                             } else {
                                 // we need to keep outputting methods just to keep tokens lined up.
-                                pdbCode.Append(String.Format(@"
+                                pdbCode.Append(String.Format(CultureInfo.InvariantCulture, @"
 public static void X{0:X}() {{
 }}
 ", methodToken));

--- a/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -79,7 +80,7 @@ namespace Microsoft.NodejsTools.Commands {
             Action<Task<bool>> onAttach = null;
             onAttach = (attachTask) => {
                 if (!attachTask.Result) {
-                    string msg = string.Format(
+                    string msg = string.Format(CultureInfo.CurrentCulture,
                         "Could not attach to node.exe process on Azure Website at {0}.\r\n\r\n" +
                         "Error retrieving websocket debug proxy information from web.config.",
                         webSite.Uri);
@@ -319,7 +320,7 @@ namespace Microsoft.NodejsTools.Commands {
 
             // Prepare a web request to get the publish settings.
             // See http://msdn.microsoft.com/en-us/library/windowsazure/dn166996.aspx
-            string requestPath = string.Format(
+            string requestPath = string.Format(CultureInfo.InvariantCulture,
                 "{0}/services/WebSpaces/{1}/sites/{2}/publishxml",
                 subscription.SubscriptionId,
                 webSite.WebSpace,

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -16,13 +16,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
 using Microsoft.NodejsTools.Logging;
-using Microsoft.NodejsTools.Options;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
 
@@ -216,9 +216,9 @@ namespace Microsoft.NodejsTools.Commands {
             }
 
             var res = new StringBuilder();
-            res.AppendLine(string.Format("Top Level Node Packages ({0}):", modules.Count()));
+            res.AppendLine(string.Format(CultureInfo.InvariantCulture, "Top Level Node Packages ({0}):", modules.Count()));
             foreach (var module in modules) {
-                res.AppendLine(Indent(1, string.Format("{0} {1} ", module.Name, module.Version)));
+                res.AppendLine(Indent(1, string.Format(CultureInfo.InvariantCulture, "{0} {1} ", module.Name, module.Version)));
             }
             return res.ToString();
         }
@@ -258,7 +258,7 @@ namespace Microsoft.NodejsTools.Commands {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().OrderBy(assem => assem.FullName)) {
                 var assemFileVersion = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false).OfType<AssemblyFileVersionAttribute>().FirstOrDefault();
 
-                res.AppendLine(Indent(1, string.Format("{0}, FileVersion={1}",
+                res.AppendLine(Indent(1, string.Format(CultureInfo.InvariantCulture, "{0}, FileVersion={1}",
                     assembly.FullName,
                     assemFileVersion == null ? "(null)" : assemFileVersion.Version)));
             }

--- a/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/DiagnosticsCommand.cs
@@ -187,7 +187,7 @@ namespace Microsoft.NodejsTools.Commands {
                 var matchedExt = _interestingFileExtensions.Where(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
 
                 if (!string.IsNullOrEmpty(matchedExt)) {
-                    var recordKey = string.Format("{0} ({1})", matchedExt, node.Value.ItemNode?.IsExcluded ?? true ? "excluded from project" : "included in project");
+                    var recordKey = string.Format(CultureInfo.InvariantCulture, "{0} ({1})", matchedExt, node.Value.ItemNode?.IsExcluded ?? true ? "excluded from project" : "included in project");
                     FileTypeInfo record;
                     if (!fileTypeInfo.TryGetValue(recordKey, out record)) {
                         record = fileTypeInfo[recordKey] = new FileTypeInfo();

--- a/Nodejs/Product/Nodejs/Commands/OpenRemoteDebugProxyFolderCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/OpenRemoteDebugProxyFolderCommand.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
@@ -46,7 +47,7 @@ namespace Microsoft.NodejsTools.Commands {
             if (!File.Exists(filePath)) {
                 MessageBox.Show(SR.GetString(SR.RemoteDebugProxyFileDoesNotExist, filePath), SR.ProductName);
             } else {
-                Process.Start("explorer", string.Format("/e,/select,{0}", filePath));
+                Process.Start("explorer", string.Format(CultureInfo.InvariantCulture, "/e,/select,{0}", filePath));
             }
         }
 

--- a/Nodejs/Product/Nodejs/Debugger/Commands/ChangeLiveCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/ChangeLiveCommand.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NodejsTools.Debugger.Commands {
@@ -23,7 +24,7 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
 
         public ChangeLiveCommand(int id, NodeModule module) : base(id, "changelive") {
             // Wrap script contents as following https://github.com/joyent/node/blob/v0.10.26-release/src/node.js#L880
-            string source = string.Format("{0}{1}{2}",
+            string source = string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}",
                 NodeConstants.ScriptWrapBegin,
                 module.Source,
                 NodeConstants.ScriptWrapEnd);

--- a/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Commands/SetBreakpointCommand.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NodejsTools.Debugger.Commands {
     sealed class SetBreakpointCommand : DebuggerCommand {
-        private static string _pathSeperatorCharacterGroup = string.Format("[{0}{1}]", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        private static string _pathSeperatorCharacterGroup = string.Format(CultureInfo.InvariantCulture, "[{0}{1}]", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         private readonly Dictionary<string, object> _arguments;
         private readonly NodeBreakpoint _breakpoint;
@@ -127,11 +127,11 @@ namespace Microsoft.NodejsTools.Debugger.Commands {
         private static string CreateRemoteScriptRegExp(string filePath) {
             string fileName = Path.GetFileName(filePath) ?? string.Empty;
             string start = fileName == filePath ? "^" : _pathSeperatorCharacterGroup;
-            return string.Format("{0}{1}$", start, CreateCaseInsensitiveRegExpFromString(fileName));
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}$", start, CreateCaseInsensitiveRegExpFromString(fileName));
         }
 
         public static string CreateLocalScriptRegExp(string filePath) {
-            return string.Format("^{0}$", CreateCaseInsensitiveRegExpFromString(filePath));
+            return string.Format(CultureInfo.InvariantCulture, "^{0}$", CreateCaseInsensitiveRegExpFromString(filePath));
         }
 
         /// <summary>

--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerClient.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -135,7 +136,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                     break;
 
                 default:
-                    Debug.Fail(string.Format("Unrecognized type '{0}' in message: {1}", messageType, message));
+                    Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Unrecognized type '{0}' in message: {1}", messageType, message));
                     break;
             }
         }
@@ -179,7 +180,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
                     break;
 
                 default:
-                    Debug.Fail(string.Format("Unrecognized type '{0}' in event message: {1}", eventType, message));
+                    Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Unrecognized type '{0}' in event message: {1}", eventType, message));
                     break;
             }
         }
@@ -195,7 +196,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
             if (_messages.TryGetValue(messageId, out promise)) {
                 promise.SetResult(message);
             } else {
-                Debug.Fail(string.Format("Invalid response identifier '{0}'", messageId));
+                Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Invalid response identifier '{0}'", messageId));
             }
         }
     }

--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -76,7 +77,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
             LiveLogger.WriteLine("Request: " + message, typeof(DebuggerConnection));
 
             var messageBody = _encoding.GetBytes(message);
-            var messageHeader = _encoding.GetBytes(string.Format("Content-Length: {0}\r\n\r\n", messageBody.Length));
+            var messageHeader = _encoding.GetBytes(string.Format(CultureInfo.InvariantCulture, "Content-Length: {0}\r\n\r\n", messageBody.Length));
             _packetsToSend.Add(messageHeader);
             _packetsToSend.Add(messageBody);
         }
@@ -297,11 +298,11 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
             } catch (ObjectDisposedException) {
             } catch (InvalidOperationException) {
             } catch (DecoderFallbackException ex) {
-                LiveLogger.WriteLine(string.Format("Error decoding response body: {0}", ex), typeof(DebuggerConnection));
+                LiveLogger.WriteLine(string.Format(CultureInfo.InvariantCulture, "Error decoding response body: {0}", ex), typeof(DebuggerConnection));
             } catch (JsonReaderException ex) {
-                LiveLogger.WriteLine(string.Format("Error parsing JSON response: {0}", ex), typeof(DebuggerConnection));
+                LiveLogger.WriteLine(string.Format(CultureInfo.InvariantCulture, "Error parsing JSON response: {0}", ex), typeof(DebuggerConnection));
             } catch (Exception ex) {
-                LiveLogger.WriteLine(string.Format("Message processing failed: {0}", ex), typeof(DebuggerConnection));
+                LiveLogger.WriteLine(string.Format(CultureInfo.InvariantCulture, "Message processing failed: {0}", ex), typeof(DebuggerConnection));
                 throw;
             } finally {
                 LiveLogger.WriteLine("Connection was closed.", typeof(DebuggerConnection));

--- a/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Communication/DebuggerConnection.cs
@@ -189,7 +189,7 @@ namespace Microsoft.NodejsTools.Debugger.Communication {
             } catch (InvalidOperationException) {
             } catch (IOException) {
             } catch (Exception e) {
-                LiveLogger.WriteLine(string.Format("Failed to write message {0}.", e), typeof(DebuggerConnection));
+                LiveLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Failed to write message {0}.", e), typeof(DebuggerConnection));
                 throw;
             }
         }

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -528,7 +529,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                                     if (dirMapping == null) {
                                         dirMapping = new List<string[]>();
                                     }
-                                    LiveLogger.WriteLine(string.Format("Mapping dir {0} to {1}", dirs[0], dirs[1]));
+                                    LiveLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Mapping dir {0} to {1}", dirs[0], dirs[1]));
                                     dirMapping.Add(dirs);
                                 }
                                 break;

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -528,7 +528,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                                     if (dirMapping == null) {
                                         dirMapping = new List<string[]>();
                                     }
-                                    LiveLogger.WriteLine(String.Format("Mapping dir {0} to {1}", dirs[0], dirs[1]));
+                                    LiveLogger.WriteLine(string.Format("Mapping dir {0} to {1}", dirs[0], dirs[1]));
                                     dirMapping.Add(dirs);
                                 }
                                 break;

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Property.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Property.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,7 +65,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
 
             if (dwFields.HasFlag(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_VALUE)) {
                 string value = radix == 16 ? _evaluationResult.HexValue ?? _evaluationResult.StringValue : _evaluationResult.StringValue;
-                propertyInfo.bstrValue = _evaluationResult.Type.HasFlag(NodeExpressionType.String) ? string.Format("\"{0}\"", value) : value;
+                propertyInfo.bstrValue = _evaluationResult.Type.HasFlag(NodeExpressionType.String) ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", value) : value;
                 propertyInfo.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_VALUE;
             }
 
@@ -262,7 +263,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                     .WaitAsync(timeout, tokenSource.Token);
             }
 
-            string expression = string.Format("{0} = {1}", _evaluationResult.FullName, value);
+            string expression = string.Format(CultureInfo.InvariantCulture, "{0} = {1}", _evaluationResult.FullName, value);
             return _evaluationResult.Frame.ExecuteTextAsync(expression, tokenSource.Token).WaitAsync(timeout, tokenSource.Token);
         }
 

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.NodejsTools.Debugger.Serialization;
@@ -90,13 +91,13 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
                     }
                 } else {
                     if (_stackFrame.FileName != "<unknown>") {
-                        funcName = string.Format("{0} [{1}]", funcName, Path.GetFileName(_stackFrame.FileName));
+                        funcName = string.Format(CultureInfo.InvariantCulture, "{0} [{1}]", funcName, Path.GetFileName(_stackFrame.FileName));
                     } else {
                         funcName = funcName + " in <unknown>";
                     }
                 }
 
-                frameInfo.m_bstrFuncName = string.Format("{0} Line {1}", funcName, _stackFrame.Line + 1);
+                frameInfo.m_bstrFuncName = string.Format(CultureInfo.InvariantCulture, "{0} Line {1}", funcName, _stackFrame.Line + 1);
                 frameInfo.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_FUNCNAME;
             }
 
@@ -296,7 +297,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
         // that refers to this exact evaluation context. For example, in C++ the name is as follows: 
         // "{ function-name, source-file-name, module-file-name }"
         int IDebugExpressionContext2.GetName(out string pbstrName) {
-            pbstrName = string.Format("{{ {0} {1} }}", _stackFrame.FunctionName, _stackFrame.FileName);
+            pbstrName = string.Format(CultureInfo.InvariantCulture, "{{ {0} {1} }}", _stackFrame.FunctionName, _stackFrame.FileName);
             return VSConstants.S_OK;
         }
 

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7StackFrame.cs
@@ -296,7 +296,7 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine {
         // that refers to this exact evaluation context. For example, in C++ the name is as follows: 
         // "{ function-name, source-file-name, module-file-name }"
         int IDebugExpressionContext2.GetName(out string pbstrName) {
-            pbstrName = String.Format("{{ {0} {1} }}", _stackFrame.FunctionName, _stackFrame.FileName);
+            pbstrName = string.Format("{{ {0} {1} }}", _stackFrame.FunctionName, _stackFrame.FileName);
             return VSConstants.S_OK;
         }
 

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -87,7 +88,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
 
                         // Send "disconnect" request.
                         string request = @"{""command"":""disconnect"",""seq"":1,""type"":""request"",""arguments"":null}";
-                        request = string.Format("Content-Length: {0}\r\n\r\n{1}", request.Length, request);
+                        request = string.Format(CultureInfo.InvariantCulture, "Content-Length: {0}\r\n\r\n{1}", request.Length, request);
                         buffer = Encoding.UTF8.GetBytes(request);
                         stream.WriteAsync(buffer, 0, buffer.Length, new CancellationTokenSource(5000).Token).GetAwaiter().GetResult();
 
@@ -136,7 +137,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                     }
                 }
 
-                string errText = string.Format(
+                string errText = string.Format(CultureInfo.CurrentCulture,
                     "Could not attach to Node.js process at {0}{1}\r\n\r\n",
                     port.Uri,
                     exception != null ? ":\r\n\r\n" + exception.Message : ".");
@@ -146,7 +147,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                             "Make sure that the Azure web site is deployed in the Debug configuration, and web sockets " +
                             "are enabled for it in the Azure management portal.";
                     } else {
-                        errText += string.Format(
+                        errText += string.Format(CultureInfo.CurrentCulture,
                             "Make sure that the process is running behind the remote debug proxy (RemoteDebug.js), " +
                             "and the debugger port (default {0}) is open on the target host.",
                             NodejsConstants.DefaultDebuggerPort);

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -101,7 +101,7 @@ namespace Microsoft.NodejsTools.Debugger {
             _debuggerEndpointUri = new UriBuilder { Scheme = "tcp", Host = "localhost", Port = debuggerPortOrDefault }.Uri;
 
             // Node usage: node [options] [ -e script | script.js ] [arguments]
-            string allArgs = String.Format(
+            string allArgs = string.Format(
                 "--debug-brk={0} --nolazy {1} {2}",
                 debuggerPortOrDefault,
                 interpreterOptions,

--- a/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeDebugger.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
@@ -101,7 +102,7 @@ namespace Microsoft.NodejsTools.Debugger {
             _debuggerEndpointUri = new UriBuilder { Scheme = "tcp", Host = "localhost", Port = debuggerPortOrDefault }.Uri;
 
             // Node usage: node [options] [ -e script | script.js ] [arguments]
-            string allArgs = string.Format(
+            string allArgs = string.Format(CultureInfo.InvariantCulture,
                 "--debug-brk={0} --nolazy {1} {2}",
                 debuggerPortOrDefault,
                 interpreterOptions,
@@ -725,7 +726,7 @@ namespace Microsoft.NodejsTools.Debugger {
             DebuggerClient.RunWithRequestExceptionsHandled(async () => {
                 string exceptionName = exceptionEvent.ExceptionName;
                 if (!string.IsNullOrEmpty(errorCode)) {
-                    exceptionName = string.Format("{0}({1})", exceptionName, errorCode);
+                    exceptionName = string.Format(CultureInfo.InvariantCulture, "{0}({1})", exceptionName, errorCode);
                 }
 
                 // UNDONE Handle break on unhandled, once just my code is supported
@@ -1138,7 +1139,7 @@ namespace Microsoft.NodejsTools.Debugger {
         internal async Task<bool> TestPredicateAsync(string expression, CancellationToken cancellationToken = new CancellationToken()) {
             DebugWriteCommand("TestPredicate: " + expression);
 
-            string predicateExpression = string.Format("Boolean({0})", expression);
+            string predicateExpression = string.Format(CultureInfo.InvariantCulture, "Boolean({0})", expression);
             var evaluateCommand = new EvaluateCommand(CommandId, _resultFactory, predicateExpression);
 
             return await TrySendRequestAsync(evaluateCommand, cancellationToken).ConfigureAwait(false) &&

--- a/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
@@ -17,6 +17,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Microsoft.VisualStudioTools.Project;
@@ -61,7 +62,7 @@ namespace Microsoft.NodejsTools.Debugger {
 
             if (waitMode != null) {
                 var pidFile = Path.GetTempFileName();
-                _psi.Arguments = string.Format("{0} {1} {2} {3}",
+                _psi.Arguments = string.Format(CultureInfo.InvariantCulture, "{0} {1} {2} {3}",
                     waitMode,
                     ProcessOutput.QuoteSingleArgument(pidFile),
                     ProcessOutput.QuoteSingleArgument(_psi.FileName),

--- a/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeProcess.cs
@@ -61,7 +61,7 @@ namespace Microsoft.NodejsTools.Debugger {
 
             if (waitMode != null) {
                 var pidFile = Path.GetTempFileName();
-                _psi.Arguments = String.Format("{0} {1} {2} {3}",
+                _psi.Arguments = string.Format("{0} {1} {2} {3}",
                     waitMode,
                     ProcessOutput.QuoteSingleArgument(pidFile),
                     ProcessOutput.QuoteSingleArgument(_psi.FileName),

--- a/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudioTools.Project;
 
@@ -59,7 +60,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
                     typeName = NodeVariableType.Number;
                     int intValue;
                     if (int.TryParse(stringValue, out intValue)) {
-                        hexValue = string.Format("0x{0:x}", intValue);
+                        hexValue = string.Format(CultureInfo.InvariantCulture, "0x{0:x}", intValue);
                     }
                     break;
 
@@ -76,7 +77,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
                     break;
 
                 case "function":
-                    stringValue = string.IsNullOrEmpty(variable.Text) ? string.Format("{{{0}}}", NodeVariableType.Function) : variable.Text;
+                    stringValue = string.IsNullOrEmpty(variable.Text) ? string.Format(CultureInfo.InvariantCulture, "{{{0}}}", NodeVariableType.Function) : variable.Text;
                     typeName = NodeVariableType.Function;
                     type |= NodeExpressionType.Function | NodeExpressionType.Expandable;
                     break;
@@ -132,7 +133,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
             }
 
             // Generates a full name
-            fullName = string.Format(VariableNameValidator.IsMatch(name) ? @"{0}.{1}" : @"{0}[""{1}""]", parentName, name);
+            fullName = string.Format(CultureInfo.InvariantCulture, VariableNameValidator.IsMatch(name) ? @"{0}.{1}" : @"{0}[""{1}""]", parentName, name);
 
             if (parent.TypeName != NodeVariableType.Object) {
                 return fullName;

--- a/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
+++ b/Nodejs/Product/Nodejs/Debugger/Serialization/EvaluationResultFactory.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
                     break;
 
                 case "object":
-                    stringValue = variable.Class == NodeVariableType.Object ? "{...}" : string.Format("{{{0}}}", variable.Class);
+                    stringValue = variable.Class == NodeVariableType.Object ? "{...}" : string.Format(CultureInfo.InvariantCulture, "{{{0}}}", variable.Class);
                     typeName = NodeVariableType.Object;
                     type |= NodeExpressionType.Expandable;
                     break;
@@ -142,7 +142,7 @@ namespace Microsoft.NodejsTools.Debugger.Serialization {
             // Checks whether name points on array element
             int indexer;
             if (int.TryParse(name, out indexer)) {
-                name = string.Format("[{0}]", indexer);
+                name = string.Format(CultureInfo.InvariantCulture, "[{0}]", indexer);
                 fullName = parent.FullName + name;
             }
 

--- a/Nodejs/Product/Nodejs/Jade/IdleTimeAsyncTask.cs
+++ b/Nodejs/Product/Nodejs/Jade/IdleTimeAsyncTask.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -158,7 +159,7 @@ namespace Microsoft.NodejsTools.Jade {
                             result = _taskAction();
                         } catch (Exception ex) {
                             Debug.Fail(
-                                String.Format("Background task exception {0}. Inner exception: {1}",
+                                string.Format(CultureInfo.CurrentCulture, "Background task exception {0}. Inner exception: {1}",
                                                            ex.Message,
                                                            ex.InnerException != null ? ex.InnerException.Message : "(none)")
                             );
@@ -184,7 +185,7 @@ namespace Microsoft.NodejsTools.Jade {
                 }
             } catch (Exception ex) {
                 Debug.Fail(
-                    String.Format("Background task UI thread callback exception {0}. Inner exception: {1}",
+                    string.Format(CultureInfo.CurrentCulture, "Background task UI thread callback exception {0}. Inner exception: {1}",
                                   ex.Message, ex.InnerException != null ? ex.InnerException.Message : "(none)"));
             }
 

--- a/Nodejs/Product/Nodejs/Jade/Text/CharacterStream.cs
+++ b/Nodejs/Product/Nodejs/Jade/Text/CharacterStream.cs
@@ -233,7 +233,7 @@ namespace Microsoft.NodejsTools.Jade {
         [ExcludeFromCodeCoverage]
         [DebuggerStepThrough]
         public override string ToString() {
-            return String.Format(CultureInfo.InvariantCulture, "@{0} ({1})", Position, _text[Position]);
+            return string.Format(CultureInfo.InvariantCulture, "@{0} ({1})", Position, _text[Position]);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Jade/Text/TextRange.cs
+++ b/Nodejs/Product/Nodejs/Jade/Text/TextRange.cs
@@ -196,7 +196,7 @@ namespace Microsoft.NodejsTools.Jade {
 
         [ExcludeFromCodeCoverage]
         public override string ToString() {
-            return String.Format(CultureInfo.InvariantCulture, "[{0}...{1}]", Start, End);
+            return string.Format(CultureInfo.InvariantCulture, "[{0}...{1}]", Start, End);
         }
 
         /// <summary>

--- a/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
+++ b/Nodejs/Product/Nodejs/Logging/LiveLogger.cs
@@ -18,6 +18,7 @@ using Microsoft.NodejsTools.Options;
 using Microsoft.VisualStudioTools.Project;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Logging {
 
@@ -64,12 +65,12 @@ namespace Microsoft.NodejsTools.Logging {
         }
 
         public static void WriteLine(string message) {
-            var str = String.Format("[{0}] {1}", DateTime.UtcNow.TimeOfDay, message);
+            var str = string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", DateTime.UtcNow.TimeOfDay, message);
             Instance.LogMessage(str);
         }
 
         public static void WriteLine(string format, params object[] args) {
-            var str = String.Format(format, args);
+            var str = string.Format(CultureInfo.InvariantCulture, format, args);
             WriteLine(str);
         }
 

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -524,7 +524,7 @@ namespace Microsoft.NodejsTools {
                 case SurveyNewsPolicy.CheckOnceMonth:
                     return elapsedTime.TotalDays >= 30;
                 default:
-                    Debug.Assert(false, String.Format("Unexpected SurveyNewsPolicy: {0}.", options.SurveyNewsCheck));
+                    Debug.Assert(false, string.Format(CultureInfo.CurrentCulture, "Unexpected SurveyNewsPolicy: {0}.", options.SurveyNewsCheck));
                     return false;
             }
         }
@@ -569,7 +569,7 @@ namespace Microsoft.NodejsTools {
                     throw;
                 }
 
-                Debug.WriteLine(string.Format("Failed to obtain TypeScript tools version: {0}", ex.ToString()));
+                Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Failed to obtain TypeScript tools version: {0}", ex.ToString()));
             }
 
             return toolsVersion;

--- a/Nodejs/Product/Nodejs/NodejsProject.cs
+++ b/Nodejs/Product/Nodejs/NodejsProject.cs
@@ -934,7 +934,7 @@ namespace Microsoft.NodejsTools {
             var ns = new XmlNamespaceManager(doc.NameTable);
             ns.AddNamespace("sd", "http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition");
 
-            var role = nav.SelectSingleNode(string.Format(
+            var role = nav.SelectSingleNode(string.Format(CultureInfo.InvariantCulture,
                 "/sd:ServiceDefinition/sd:{0}Role[@name='{1}']", roleType, projectName
             ), ns);
 
@@ -953,7 +953,7 @@ namespace Microsoft.NodejsTools {
                 throw new InvalidOperationException("Missing Startup entry");
             }
 
-            startup.ReplaceSelf(string.Format(@"<Startup>
+            startup.ReplaceSelf(string.Format(CultureInfo.InvariantCulture, @"<Startup>
   <Task commandLine=""setup_{0}.cmd &gt; log.txt"" executionContext=""elevated"" taskType=""simple"">
     <Environment>
       <Variable name=""EMULATED"">

--- a/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -169,7 +170,7 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
 
         public void QueueCommand(string command, string arguments) {
-            QueueCommand(string.Format("{0} {1}", command, arguments));
+            QueueCommand(string.Format(CultureInfo.InvariantCulture, "{0} {1}", command, arguments));
         }
 
         public void QueueInstallPackage(

--- a/Nodejs/Product/Nodejs/Options/NodejsNpmOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsNpmOptionsControl.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Windows.Forms;
 using Microsoft.NodejsTools.Project;
@@ -60,7 +61,7 @@ namespace Microsoft.NodejsTools.Options {
                 // To handle long paths, nuke the directory contents with robocopy
                 string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(tempDirectory);
-                var psi = new ProcessStartInfo("cmd.exe", string.Format(@"/C robocopy /mir ""{0}"" ""{1}""", tempDirectory, cachePath)) {
+                var psi = new ProcessStartInfo("cmd.exe", string.Format(CultureInfo.InvariantCulture, @"/C robocopy /mir ""{0}"" ""{1}""", tempDirectory, cachePath)) {
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };

--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
 using Microsoft.NodejsTools.Npm;
@@ -229,7 +230,7 @@ namespace Microsoft.NodejsTools.Project {
                         } catch (Exception ex) {
                             if (ex is InvalidOperationException || ex is Win32Exception) {
                                 MessageBox.Show(
-                                    String.Format("Path to module does not exist:\n {0}", path),
+                                    string.Format(CultureInfo.CurrentCulture, "Path to module does not exist:\n {0}", path),
                                     SR.ProductName,
                                     MessageBoxButtons.OK,
                                     MessageBoxIcon.Error);

--- a/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
+++ b/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
@@ -39,7 +40,7 @@ namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
             }
 
             if (templateFileName == null) {
-                Debug.Fail(String.Format("Invalid file type: {0}", fileType));
+                Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Invalid file type: {0}", fileType));
             }
 
             return NodejsToolsInstallPath.GetFile("FileTemplates\\NewItem\\" + templateFileName);
@@ -57,7 +58,7 @@ namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
                 case NodejsConstants.CSS:
                     return "CSS.css";
                 default:
-                    Debug.Fail(String.Format("Invalid file type: {0}", fileType));
+                    Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Invalid file type: {0}", fileType));
                     return null;
             }
         }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.NodejsTools.Npm;
@@ -204,7 +205,7 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             if (!activity.Contains("npm")) {
-                activity = string.Format("npm: {0}", activity);
+                activity = string.Format(CultureInfo.CurrentCulture, "npm: {0}", activity);
             }
 
             var statusBar = (IVsStatusbar)_projectNode.GetService(typeof(SVsStatusbar));

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -19,6 +19,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -191,9 +192,9 @@ namespace Microsoft.NodejsTools.Project {
 
         private void LaunchDebugger(IServiceProvider provider, VsDebugTargetInfo dbgInfo) {
             if (!Directory.Exists(dbgInfo.bstrCurDir)) {
-                MessageBox.Show(String.Format("Working directory \"{0}\" does not exist.", dbgInfo.bstrCurDir), SR.ProductName);
+                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, "Working directory \"{0}\" does not exist.", dbgInfo.bstrCurDir), SR.ProductName);
             } else if (!File.Exists(dbgInfo.bstrExe)) {
-                MessageBox.Show(String.Format("Interpreter \"{0}\" does not exist.", dbgInfo.bstrExe), SR.ProductName);
+                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, "Interpreter \"{0}\" does not exist.", dbgInfo.bstrExe), SR.ProductName);
             } else if (DoesProjectSupportDebugging()) {
                 VsShellUtilities.LaunchDebugger(provider, dbgInfo);
             }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -764,7 +765,7 @@ namespace Microsoft.NodejsTools.Project {
                 var longPaths = await Task.Factory.StartNew(() =>
                     GetLongSubPaths(ProjectHome)
                     .Concat(GetLongSubPaths(_intermediateOutputPath))
-                    .Select(lpi => string.Format("• {1}\u00A0<a href=\"{0}\">{2}</a>", lpi.FullPath, lpi.RelativePath, SR.GetString(SR.LongPathClickToCopy)))
+                    .Select(lpi => string.Format(CultureInfo.InvariantCulture, "• {1}\u00A0<a href=\"{0}\">{2}</a>", lpi.FullPath, lpi.RelativePath, SR.GetString(SR.LongPathClickToCopy)))
                     .ToArray());
                 if (longPaths.Length == 0) {
                     return;

--- a/Nodejs/Product/Nodejs/ProvideEditorExtension2Attribute.cs
+++ b/Nodejs/Product/Nodejs/ProvideEditorExtension2Attribute.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NodejsTools {
             else if (factoryType is Guid)
                 this._factory = (Guid)factoryType;
             else
-                throw new ArgumentException(string.Format("invalid factory type: {0}", factoryType));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "invalid factory type: {0}", factoryType));
 
             _extension = extension;
             _priority = priority;

--- a/Nodejs/Product/Nodejs/Repl/NodejsReplEvaluator.cs
+++ b/Nodejs/Product/Nodejs/Repl/NodejsReplEvaluator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -364,7 +365,7 @@ namespace Microsoft.NodejsTools.Repl {
                             break;
 #if DEBUG
                         default:
-                            Debug.WriteLine(String.Format("Unknown command: {0}", response.Body));
+                            Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Unknown command: {0}", response.Body));
                             break;
 #endif
                     }

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -51,7 +52,7 @@ namespace Microsoft.NodejsTools.Repl {
 
             // Include spaces on either side of npm arguments so that we can more simply detect arguments
             // at beginning and end of string (e.g. '--global')
-            npmArguments = string.Format(" {0} ", npmArguments);
+            npmArguments = string.Format(CultureInfo.InvariantCulture, " {0} ", npmArguments);
 
             // Prevent running `npm init` without the `-y` flag since it will freeze the repl window,
             // waiting for user input that will never come.
@@ -225,7 +226,7 @@ namespace Microsoft.NodejsTools.Repl {
                     } else {
                         process.Kill();
                         if (redirector != null) {
-                            redirector.WriteErrorLine(string.Format(
+                            redirector.WriteErrorLine(string.Format(CultureInfo.CurrentCulture,
                             "\r\n===={0}====\r\n\r\n",
                             "npm command cancelled"));
                         }

--- a/Nodejs/Product/Nodejs/Repl/SaveReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/SaveReplCommand.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Text;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Repl {
 #if INTERACTIVE_WINDOW
@@ -37,7 +38,7 @@ namespace Microsoft.NodejsTools.Repl {
                 window.WriteError("save requires a filename");
                 return ExecutionResult.Failed;
             }else if(arguments.IndexOfAny(Path.GetInvalidPathChars()) != -1) {
-                window.WriteError(String.Format("Invalid filename: {0}", arguments));
+                window.WriteError(string.Format(CultureInfo.CurrentCulture, "Invalid filename: {0}", arguments));
                 return ExecutionResult.Failed;
             }
 
@@ -66,9 +67,9 @@ namespace Microsoft.NodejsTools.Repl {
 
             try {
                 File.WriteAllText(arguments, text.ToString());
-                window.WriteLine(String.Format("Session saved to: {0}", arguments));
+                window.WriteLine(string.Format(CultureInfo.CurrentCulture, "Session saved to: {0}", arguments));
             } catch {
-                window.WriteError(String.Format("Failed to save: {0}", arguments));
+                window.WriteError(string.Format(CultureInfo.CurrentCulture, "Failed to save: {0}", arguments));
             }
             return ExecutionResult.Succeeded;
         }

--- a/Nodejs/Product/Nodejs/TypingsAcquisition.cs
+++ b/Nodejs/Product/Nodejs/TypingsAcquisition.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Globalization;
 using System.IO;
 using System.Security;
 using System.Text;
@@ -174,7 +175,7 @@ namespace Microsoft.NodejsTools {
             using (var commander = _npmController.CreateNpmCommander()) {
                 return await commander.InstallPackageToFolderByVersionAsync(
                     NodejsConstants.ExternalToolsPath,
-                    string.Format(@"""{0}""", LocalTypingsToolPath),
+                    string.Format(CultureInfo.InvariantCulture, @"""{0}""", LocalTypingsToolPath),
                     string.Empty,
                     false);
             }

--- a/Nodejs/Product/Npm/FilePackageJsonSource.cs
+++ b/Nodejs/Product/Npm/FilePackageJsonSource.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 
@@ -54,8 +55,8 @@ namespace Microsoft.NodejsTools.Npm {
             string fullPathToFile,
             Exception ex) {
             throw new PackageJsonException(
-                        string.Format(@"Error reading package.json at '{0}': {1}", fullPathToFile, ex.Message),
-                        ex);
+                string.Format(CultureInfo.CurrentCulture, @"Error reading package.json at '{0}': {1}", fullPathToFile, ex.Message),
+                ex);
         }
 
         public dynamic Package { get { return null == _source ? null : _source.Package; } }

--- a/Nodejs/Product/Npm/NpmArgumentBuilder.cs
+++ b/Nodejs/Product/Npm/NpmArgumentBuilder.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm {
     public static class NpmArgumentBuilder {
@@ -44,12 +45,12 @@ namespace Microsoft.NodejsTools.Npm {
 
             otherArguments = otherArguments.TrimStart(' ', '\t');
             if (otherArguments.StartsWith("@", StringComparison.Ordinal)) {
-                return string.Format("install {0}{1} {2}", packageName, otherArguments, dependencyArguments);
+                return string.Format(CultureInfo.InvariantCulture, "install {0}{1} {2}", packageName, otherArguments, dependencyArguments);
             } else if (!string.IsNullOrEmpty(versionRange)) {
-                return string.Format("install {0}@\"{1}\" {2} {3}", packageName, versionRange, dependencyArguments, otherArguments);
+                return string.Format(CultureInfo.InvariantCulture, "install {0}@\"{1}\" {2} {3}", packageName, versionRange, dependencyArguments, otherArguments);
             }
 
-            return string.Format("install {0} {1} {2}", packageName, dependencyArguments, otherArguments);
+            return string.Format(CultureInfo.InvariantCulture, "install {0} {1} {2}", packageName, dependencyArguments, otherArguments);
         }
     }
 }

--- a/Nodejs/Product/Npm/NpmCommandCompletedEventArgs.cs
+++ b/Nodejs/Product/Npm/NpmCommandCompletedEventArgs.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm {
 
@@ -32,7 +33,7 @@ namespace Microsoft.NodejsTools.Npm {
         public string Arguments { get; private set; }
 
         public string CommandText {
-            get { return string.IsNullOrEmpty(Arguments) ? "npm" : string.Format("npm {0}", Arguments); }
+            get { return string.IsNullOrEmpty(Arguments) ? "npm" : string.Format(CultureInfo.InvariantCulture, "npm {0}", Arguments); }
         }
 
         /// <summary>

--- a/Nodejs/Product/Npm/NpmHelpers.cs
+++ b/Nodejs/Product/Npm/NpmHelpers.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -64,15 +65,15 @@ namespace Microsoft.NodejsTools.Npm {
                             standardOutputLines = process.StandardOutputLines.ToList();
                         }
                         if (redirector != null) {
-                            redirector.WriteLine(string.Format(
+                            redirector.WriteLine(string.Format(CultureInfo.InvariantCulture,
                                 "\r\n===={0}====\r\n\r\n",
-                                string.Format(Resources.NpmCommandCompletedWithExitCode, process.ExitCode ?? -1)
+                                string.Format(CultureInfo.InvariantCulture, Resources.NpmCommandCompletedWithExitCode, process.ExitCode ?? -1)
                                 ));
                         }
                     } else {
                         process.Kill();
                         if (redirector != null) {
-                            redirector.WriteErrorLine(string.Format(
+                            redirector.WriteErrorLine(string.Format(CultureInfo.InvariantCulture,
                             "\r\n===={0}====\r\n\r\n",
                             Resources.NpmCommandCancelled));
                         }
@@ -98,7 +99,7 @@ namespace Microsoft.NodejsTools.Npm {
 
             if (string.IsNullOrEmpty(path)) {
                 throw new NpmNotFoundException(
-                    string.Format(
+                    string.Format(CultureInfo.CurrentCulture,
                         "Cannot find {0} in the registry, your path, or under " +
                         "program files in the nodejs folder.  Ensure Node.js is installed.",
                         executable

--- a/Nodejs/Product/Npm/ReaderPackageJsonSource.cs
+++ b/Nodejs/Product/Npm/ReaderPackageJsonSource.cs
@@ -18,6 +18,7 @@ using System;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm {
     public class ReaderPackageJsonSource : IPackageJsonSource {
@@ -40,7 +41,7 @@ namespace Microsoft.NodejsTools.Npm {
                 WrapExceptionAndRethrow(fe);
             } catch (ArgumentException ae) {
                 throw new PackageJsonException(
-                    string.Format(@"Error reading package.json. The file may be parseable JSON but may contain objects with duplicate properties.
+                    string.Format(CultureInfo.CurrentCulture, @"Error reading package.json. The file may be parseable JSON but may contain objects with duplicate properties.
 
 The following error occurred:
 
@@ -52,7 +53,7 @@ The following error occurred:
         private void WrapExceptionAndRethrow(
             Exception ex) {
             throw new PackageJsonException(
-                string.Format(@"Unable to read package.json. Please ensure the file is valid JSON.
+                string.Format(CultureInfo.CurrentCulture, @"Unable to read package.json. Please ensure the file is valid JSON.
 
 Reading failed because the following error occurred:
 

--- a/Nodejs/Product/Npm/SPI/DatabasePackageCatalogFilter.cs
+++ b/Nodejs/Product/Npm/SPI/DatabasePackageCatalogFilter.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.NodejsTools.Npm.SQLiteTables;
 using SQLite;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class DatabasePackageCatalogFilter : IPackageCatalogFilter {
@@ -40,11 +41,11 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             using (var db = new SQLiteConnection(_dbFilename)) {
                 if (filterString.Length >= 3) {
                     return db.Query<CatalogEntry>(
-                        string.Format("SELECT * from CatalogEntry WHERE CatalogEntry MATCH 'name:{0}* OR description:{0}* OR keywords:{0}*' COLLATE NOCASE", escapedFilterString)).
+                        string.Format(CultureInfo.InvariantCulture, "SELECT * from CatalogEntry WHERE CatalogEntry MATCH 'name:{0}* OR description:{0}* OR keywords:{0}*' COLLATE NOCASE", escapedFilterString)).
                         OrderBy(entry => entry, new CatalogEntryComparer(filterString)).AsEnumerable().Select(entry => entry.ToPackage());
                 } else if (filterString.Length >= 1) {
                     return db.Query<CatalogEntry>(
-                        string.Format("SELECT * from CatalogEntry WHERE name MATCH '{0}*' COLLATE NOCASE", escapedFilterString)).
+                        string.Format(CultureInfo.InvariantCulture, "SELECT * from CatalogEntry WHERE name MATCH '{0}*' COLLATE NOCASE", escapedFilterString)).
                         OrderBy(entry => entry, new CatalogEntryComparer(filterString)).AsEnumerable().Select(entry => entry.ToPackage());
                 }
 

--- a/Nodejs/Product/Npm/SPI/NpmCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommand.cs
@@ -20,6 +20,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudioTools.Project;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal abstract class NpmCommand : AbstractNpmLogSource {
@@ -82,8 +83,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                 return false;
             }
             redirector.WriteLine(
-                string.Format("===={0}====\r\n\r\n",
-                string.Format(Resources.ExecutingCommand, Arguments)));
+                string.Format(CultureInfo.InvariantCulture, "===={0}====\r\n\r\n",
+                string.Format(CultureInfo.InvariantCulture, Resources.ExecutingCommand, Arguments)));
 
             var cancelled = false;
             try {

--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -239,7 +240,7 @@ etc.
                         try {
                             builder.LatestVersion = SemverVersion.Parse(latestVersion);
                         } catch (SemverVersionFormatException) {
-                            OnOutputLogged(String.Format(
+                            OnOutputLogged(string.Format(
                                 Resources.InvalidPackageSemVersion,
                                 latestVersion,
                                 builder.Name));
@@ -261,7 +262,7 @@ etc.
                 // Occurs if a JValue appears where we expect JProperty
                 return null;
             } catch (ArgumentException) {
-                OnOutputLogged(string.Format(Resources.ParsingError, builder.Name));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.ParsingError, builder.Name));
                 return null;
             }
             return package;
@@ -350,14 +351,14 @@ etc.
             string relativeUri, filename;
 
             if (refreshStartKey > 0) {
-                relativeUri = String.Format("-/all/since?stale=update_after&startkey={0}", refreshStartKey);
+                relativeUri = string.Format("-/all/since?stale=update_after&startkey={0}", refreshStartKey);
                 filename = Path.Combine(cachePath, "since_packages.json");
             } else {
                 relativeUri = "-/all";
                 filename = Path.Combine(cachePath, "all_packages.json");
             }
 
-            OnOutputLogged(string.Format(Resources.InfoPackageCacheWriteLocation, filename));
+            OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoPackageCacheWriteLocation, filename));
 
             Uri packageUri;
             if (!Uri.TryCreate(registry, relativeUri, out packageUri)) {
@@ -379,7 +380,7 @@ etc.
                     totalLength = -1;
                 }
 
-                var progress = string.Format(Resources.PackagesDownloadStarting, packageUri.AbsoluteUri);
+                var progress = string.Format(CultureInfo.CurrentCulture, Resources.PackagesDownloadStarting, packageUri.AbsoluteUri);
                 OnOutputLogged(progress);
                 if (_progress != null) {
                     _progress.Report(progress);
@@ -468,7 +469,7 @@ etc.
                 }
 
                 Uri registryUrl = await GetRegistryUrl();
-                OnOutputLogged(string.Format(Resources.InfoRegistryUrl, registryUrl));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoRegistryUrl, registryUrl));
 
                 try {
                     DbVersion version = null;
@@ -522,7 +523,7 @@ etc.
 
                     if (catalogUpdated) {
                         var fileInfo = new FileInfo(filename);
-                        OnOutputLogged(String.Format(Resources.InfoReadingBytesFromPackageCache, fileInfo.Length, filename, fileInfo.LastWriteTime));
+                        OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoReadingBytesFromPackageCache, fileInfo.Length, filename, fileInfo.LastWriteTime));
 
                         using (var reader = new StreamReader(filename)) {
                             await Task.Run(() => ParseResultsAndAddToDatabase(reader, registryCacheFilePath, registryUrl.ToString()));
@@ -545,11 +546,11 @@ etc.
                     throw;
                 } finally {
                     if (ResultsCount == null) {
-                        OnOutputLogged(string.Format(Resources.DownloadOrParsingFailed, CachePath));
+                        OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.DownloadOrParsingFailed, CachePath));
                         SafeDeleteFolder(registryCacheDirectory);
                     } else if (ResultsCount <= 0) {
                         // Database file exists, but is corrupt. Delete database, so that we can download the file next time arround.
-                        OnOutputLogged(string.Format(Resources.DatabaseCorrupt, dbFilename));
+                        OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.DatabaseCorrupt, dbFilename));
                         SafeDeleteFolder(registryCacheDirectory);
                     }
 
@@ -559,10 +560,10 @@ etc.
 
             LastRefreshed = File.GetLastWriteTime(registryCacheFilePath);
 
-            OnOutputLogged(String.Format(Resources.InfoCurrentTime, DateTime.Now));
-            OnOutputLogged(String.Format(Resources.InfoLastRefreshed, LastRefreshed));
+            OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoCurrentTime, DateTime.Now));
+            OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoLastRefreshed, LastRefreshed));
             if (ResultsCount != null) {
-                OnOutputLogged(String.Format(Resources.InfoNumberOfResults, ResultsCount));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoNumberOfResults, ResultsCount));
             }
 
             return true;
@@ -588,18 +589,18 @@ etc.
 
         private bool SafeDeleteFolder(string filename) {
             try {
-                OnOutputLogged(string.Format(Resources.InfoDeletingFile, filename));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.InfoDeletingFile, filename));
                 Directory.Delete(filename, true);
             } catch (DirectoryNotFoundException) {
                 // File has already been deleted. Do nothing.
             } catch (IOException exception) {
                 // files are in use or path is too long
                 OnOutputLogged(exception.Message);
-                OnOutputLogged(string.Format(Resources.FailedToDeleteFile, filename));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.FailedToDeleteFile, filename));
                 return false;
             } catch (Exception exception) {
                 OnOutputLogged(exception.ToString());
-                OnOutputLogged(string.Format(Resources.FailedToDeleteFile, filename));
+                OnOutputLogged(string.Format(CultureInfo.CurrentCulture, Resources.FailedToDeleteFile, filename));
                 return false;
             }
             return true;
@@ -611,7 +612,7 @@ etc.
 
         private async Task<string> UpdatePackageCache(Uri registry, string cachePath, long refreshStartKey = 0) {
             string pathToNpm = GetPathToNpm();
-            OnOutputLogged(String.Format(Resources.InfoNpmPathLocation, pathToNpm));
+            OnOutputLogged(string.Format(CultureInfo.InvariantCulture, Resources.InfoNpmPathLocation, pathToNpm));
 
             string filename = await DownloadPackageJsonCache(registry, cachePath, refreshStartKey);
             return filename;

--- a/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmGetCatalogCommand.cs
@@ -240,7 +240,7 @@ etc.
                         try {
                             builder.LatestVersion = SemverVersion.Parse(latestVersion);
                         } catch (SemverVersionFormatException) {
-                            OnOutputLogged(string.Format(
+                            OnOutputLogged(string.Format(CultureInfo.InvariantCulture,
                                 Resources.InvalidPackageSemVersion,
                                 latestVersion,
                                 builder.Name));
@@ -351,7 +351,7 @@ etc.
             string relativeUri, filename;
 
             if (refreshStartKey > 0) {
-                relativeUri = string.Format("-/all/since?stale=update_after&startkey={0}", refreshStartKey);
+                relativeUri = string.Format(CultureInfo.InvariantCulture, "-/all/since?stale=update_after&startkey={0}", refreshStartKey);
                 filename = Path.Combine(cachePath, "since_packages.json");
             } else {
                 relativeUri = "-/all";
@@ -397,13 +397,13 @@ etc.
 
                         if (totalDownloaded > nextNotification * ONE_MB) {
                             if (totalLength > 0) {
-                                progress = string.Format(
+                                progress = string.Format(CultureInfo.InvariantCulture,
                                     Resources.PackagesDownloadedXOfYMB,
                                     nextNotification,
                                     totalLength / ONE_MB + 1
                                 );
                             } else {
-                                progress = string.Format(
+                                progress = string.Format(CultureInfo.InvariantCulture,
                                     Resources.PackagesDownloadedXMB,
                                     nextNotification
                                 );

--- a/Nodejs/Product/Npm/SPI/NpmUninstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmUninstallCommand.cs
@@ -14,6 +14,8 @@
 //
 //*********************************************************//
 
+using System.Globalization;
+
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class NpmUninstallCommand : NpmCommand {
         public NpmUninstallCommand(
@@ -25,8 +27,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             bool useFallbackIfNpmNotFound = true)
             : base(fullPathToRootPackageDirectory, pathToNpm) {
             Arguments = global
-                            ? string.Format("uninstall {0} --g", packageName)
-                            : string.Format(
+                            ? string.Format(CultureInfo.InvariantCulture, "uninstall {0} --g", packageName)
+                            : string.Format(CultureInfo.InvariantCulture,
                                 "uninstall {0} --{1}",
                                 packageName,
                                 (type == DependencyType.Standard

--- a/Nodejs/Product/Npm/SPI/Package.cs
+++ b/Nodejs/Product/Npm/SPI/Package.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -97,7 +98,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         }
 
         public override string ToString() {
-            return string.Format("{0} {1}", Name, Version);
+            return string.Format(CultureInfo.InvariantCulture, "{0} {1}", Name, Version);
         }
     }
 }

--- a/Nodejs/Product/Npm/SPI/PackageJson.cs
+++ b/Nodejs/Product/Npm/SPI/PackageJson.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System.Globalization;
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.CSharp.RuntimeBinder;
@@ -42,7 +43,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         private static PackageJsonException WrapRuntimeBinderException(string errorProperty, RuntimeBinderException rbe) {
             return new PackageJsonException(
-                string.Format(@"Exception occurred retrieving {0} from package.json. The file may be invalid: you should edit it to correct an errors.
+                string.Format(CultureInfo.CurrentCulture,@"Exception occurred retrieving {0} from package.json. The file may be invalid: you should edit it to correct an errors.
 
 The following error occurred:
 

--- a/Nodejs/Product/Npm/SPI/PkgStringArray.cs
+++ b/Nodejs/Product/Npm/SPI/PkgStringArray.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -71,7 +72,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
                 if (index > Count) {
                     throw new IndexOutOfRangeException(
-                        string.Format(
+                        string.Format(CultureInfo.CurrentCulture,
                             "Cannot retrieve value from index '{0}' in a package.json string array containing only 1 item.",
                             index));
                 }

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Microsoft.CSharp.RuntimeBinder;
 
@@ -34,7 +35,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                 }
             } catch (RuntimeBinderException rbe) {
                 throw new PackageJsonException(
-                    string.Format(@"Error processing package.json at '{0}'. The file was successfully read, and may be valid JSON, but the objects may not match the expected form for a package.json file.
+                    string.Format(CultureInfo.CurrentCulture, @"Error processing package.json at '{0}'. The file was successfully read, and may be valid JSON, but the objects may not match the expected form for a package.json file.
 
 The following error was reported:
 

--- a/Nodejs/Product/Npm/SemverVersion.cs
+++ b/Nodejs/Product/Npm/SemverVersion.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -43,7 +44,7 @@ namespace Microsoft.NodejsTools.Npm {
             var matches = RegexSemver.Matches(versionString);
             if (matches.Count != 1) {
                 throw new SemverVersionFormatException(
-                    string.Format(
+                    string.Format(CultureInfo.CurrentCulture,
                         "Invalid semantic version: '{0}'. The version number must consist of three non-negative numeric parts of the form MAJOR.MINOR.PATCH, with optional pre-release and/or build metadata. The optional parts may only contain characters in the set [0-9A-Za-z-].",
                         versionString));
             }
@@ -68,7 +69,7 @@ namespace Microsoft.NodejsTools.Npm {
                     buildMetadata.Success ? buildMetadata.Value : null);
             } catch (OverflowException oe) {
                 throw new SemverVersionFormatException(
-                    string.Format(
+                    string.Format(CultureInfo.CurrentCulture,
                         "Invalid semantic version: '{0}'. One or more of the integer parts is large enough to overflow a 64-bit int.",
                         versionString),
                     oe);
@@ -92,7 +93,7 @@ namespace Microsoft.NodejsTools.Npm {
             string buildMetadata = null) : this() {
             if (!IsValidOptionalFragment(preReleaseVersion)) {
                 throw new ArgumentException(
-                    string.Format(
+                    string.Format(CultureInfo.CurrentCulture,
                         "Invalid pre-release version: '{0}'. Must be a dot separated sequence of identifiers containing only characters [0-9A-Za-z-].",
                         preReleaseVersion),
                     "preReleaseVersion");
@@ -100,7 +101,7 @@ namespace Microsoft.NodejsTools.Npm {
 
             if (!IsValidOptionalFragment(buildMetadata)) {
                 throw new ArgumentException(
-                    string.Format(
+                    string.Format(CultureInfo.CurrentCulture,
                         "Invalid build metadata: '{0}'. Must be a dot separated sequence of identifiers containing only characters [0-9A-Za-z-].",
                         preReleaseVersion),
                     "buildMetadata");
@@ -141,7 +142,7 @@ namespace Microsoft.NodejsTools.Npm {
         }
 
         public override string ToString() {
-            var builder = new StringBuilder(string.Format("{0}.{1}.{2}", Major, Minor, Patch));
+            var builder = new StringBuilder(string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch));
 
             if (HasPreReleaseVersion) {
                 builder.Append('-');

--- a/Nodejs/Product/Profiling/Profiling/AutomationProfiling.cs
+++ b/Nodejs/Product/Profiling/Profiling/AutomationProfiling.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
@@ -65,7 +66,7 @@ namespace Microsoft.NodejsTools.Profiling {
             if (interpreter.IndexOfAny(Path.GetInvalidPathChars()) == -1 && File.Exists(interpreter)) {
                 target.StandaloneTarget.InterpreterPath = interpreter;
             } else {
-                throw new InvalidOperationException(String.Format("Invalid interpreter: {0}", interpreter));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid interpreter: {0}", interpreter));
             }
 
             return NodejsProfilingPackage.Instance.ProfileTarget(target, openReport).GetAutomationObject();

--- a/Nodejs/Product/Profiling/Profiling/CompareReportsView.cs
+++ b/Nodejs/Product/Profiling/Profiling/CompareReportsView.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 
 namespace Microsoft.NodejsTools.Profiling {
@@ -50,7 +51,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <returns></returns>
         public string GetComparisonUri() {
             if (IsValid) {
-                return String.Format(
+                return string.Format(CultureInfo.InvariantCulture,
                     "vsp://diff/?baseline={0}&comparison={1}",
                     Uri.EscapeDataString(BaselineFile),
                     Uri.EscapeDataString(ComparisonFile)

--- a/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -38,7 +39,7 @@ namespace Microsoft.NodejsTools.Profiling {
 
         public ProfiledProcess(string exe, string interpreterArgs, string script, string scriptArgs, string dir, Dictionary<string, string> envVars, ProcessorArchitecture arch, string launchUrl, int? port, bool startBrowser, bool justMyCode) {
             if (arch != ProcessorArchitecture.X86 && arch != ProcessorArchitecture.Amd64) {
-                throw new InvalidOperationException(String.Format("Unsupported architecture: {0}", arch));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Unsupported architecture: {0}", arch));
             }
             if (dir.EndsWith("\\", StringComparison.Ordinal)) {
                 dir = dir.Substring(0, dir.Length - 1);
@@ -80,7 +81,7 @@ namespace Microsoft.NodejsTools.Profiling {
                 }
             }
 
-            processInfo.Arguments = String.Format("{1} --prof \"{0}\" {2}", script, interpreterArgs, scriptArgs);
+            processInfo.Arguments = string.Format(CultureInfo.InvariantCulture, "{1} --prof \"{0}\" {2}", script, interpreterArgs, scriptArgs);
             _process = new Process();
             _process.StartInfo = processInfo;
         }

--- a/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -142,7 +142,7 @@ namespace Microsoft.NodejsTools.Profiling {
                             .Reverse()
                             .FirstOrDefault();
                         if (v8log == null) {
-                            MessageBox.Show(string.Format(Resources.FailedToSaveV8LogMessageText, v8log));
+                            MessageBox.Show(string.Format(CultureInfo.CurrentCulture, Resources.FailedToSaveV8LogMessageText, v8log));
                             return;
                         }
                     }
@@ -177,7 +177,7 @@ namespace Microsoft.NodejsTools.Profiling {
                 } catch {
                     // file in use, multiple node.exe's running, user trying
                     // to profile multiple times, etc...
-                    MessageBox.Show(string.Format(Resources.UnableToDeleteV8Log, v8log));
+                    MessageBox.Show(string.Format(CultureInfo.CurrentCulture, Resources.UnableToDeleteV8Log, v8log));
                 }
             };
 

--- a/Nodejs/Product/Profiling/Profiling/ProfilingSessionEditorFactory.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfilingSessionEditorFactory.cs
@@ -182,10 +182,10 @@ namespace Microsoft.NodejsTools.Profiling {
                     fs.Close();
                 }
             } catch (IOException e) {
-                MessageBox.Show(string.Format(Resources.FailedToOpenFileErrorMessageText, e.Message), Resources.NodejsToolsForVS);
+                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, Resources.FailedToOpenFileErrorMessageText, e.Message), Resources.NodejsToolsForVS);
                 return VSConstants.E_FAIL;
             } catch (InvalidOperationException e) {
-                MessageBox.Show(string.Format(Resources.FailedToReadPerformanceSessionMessageText, e.Message), Resources.NodejsToolsForVS);
+                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, Resources.FailedToReadPerformanceSessionMessageText, e.Message), Resources.NodejsToolsForVS);
                 return VSConstants.E_FAIL;
             }
 

--- a/Nodejs/Product/Profiling/Profiling/SessionNode.cs
+++ b/Nodejs/Product/Profiling/Profiling/SessionNode.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -293,7 +294,7 @@ namespace Microsoft.NodejsTools.Profiling {
             var item = GetReport(itemid);
 
             if (!File.Exists(item.Filename)) {
-                MessageBox.Show(string.Format(Resources.PerformanceReportNoLongerExistsMessageText, item.Filename), Resources.NodejsToolsForVS);
+                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, Resources.PerformanceReportNoLongerExistsMessageText, item.Filename), Resources.NodejsToolsForVS);
             } else {
                 var dte = (EnvDTE.DTE)NodejsProfilingPackage.GetGlobalService(typeof(EnvDTE.DTE));
                 dte.ItemOperations.OpenFile(item.Filename);

--- a/Nodejs/Product/Profiling/Profiling/SessionsNode.cs
+++ b/Nodejs/Product/Profiling/Profiling/SessionsNode.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudioTools.Project;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Profiling {
     /// <summary>
@@ -102,7 +103,7 @@ namespace Microsoft.NodejsTools.Profiling {
         internal SessionNode OpenTarget(ProfilingTarget target, string filename) {
             for (int i = 0; i < _sessions.Count; i++) {
                 if (_sessions[i].Filename == filename) {
-                    throw new InvalidOperationException(String.Format("Performance '{0}' session is already open", filename));
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Performance '{0}' session is already open", filename));
                 }
             }
 

--- a/Nodejs/Product/ProjectWizard/SettingsManagerCreator.cs
+++ b/Nodejs/Product/ProjectWizard/SettingsManagerCreator.cs
@@ -22,6 +22,7 @@ using Microsoft.Win32;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell.Settings;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+using System.Globalization;
 
 namespace Microsoft.VisualStudioTools {
     static class SettingsManagerCreator {
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudioTools {
             if (settings == null) {
                 if (!File.Exists(devenvPath)) {
                     using (var root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
-                    using (var key = root.OpenSubKey(string.Format(@"Software\Microsoft\VisualStudio\{0}\Setup\VS", VSVersion))) {
+                    using (var key = root.OpenSubKey(string.Format(CultureInfo.InvariantCulture, @"Software\Microsoft\VisualStudio\{0}\Setup\VS", VSVersion))) {
                         if (key == null) {
                             throw new InvalidOperationException("Cannot find settings store for Visual Studio " + VSVersion);
                         }

--- a/Nodejs/Product/TestAdapter/TestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscoverer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -115,7 +116,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     proj.GetPropertyValue(NodejsConstants.NodeExePath));
 
             if (!File.Exists(nodeExePath)) {
-                logger.SendMessage(TestMessageLevel.Error, String.Format("Node.exe was not found.  Please install Node.js before running tests."));
+                logger.SendMessage(TestMessageLevel.Error, string.Format(CultureInfo.CurrentCulture, "Node.exe was not found.  Please install Node.js before running tests."));
                 return;
             }
 
@@ -123,19 +124,19 @@ namespace Microsoft.NodejsTools.TestAdapter {
             foreach (string testFx in testItems.Keys) {
                 TestFrameworks.TestFramework testFramework = GetTestFrameworkObject(testFx);
                 if (testFramework == null) {
-                    logger.SendMessage(TestMessageLevel.Warning, String.Format("Ignoring unsupported test framework {0}", testFx));
+                    logger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, "Ignoring unsupported test framework {0}", testFx));
                     continue;
                 }
 
                 List<TestFileEntry> fileList = testItems[testFx];
                 string files = string.Join(";", fileList.Select(p=>p.File));
-                logger.SendMessage(TestMessageLevel.Informational, String.Format("Processing: {0}", files));
+                logger.SendMessage(TestMessageLevel.Informational, string.Format(CultureInfo.CurrentCulture, "Processing: {0}", files));
 
                 List<TestFrameworks.NodejsTestInfo> discoveredTestCases = testFramework.FindTests(fileList.Select(p => p.File), nodeExePath, logger, projectHome);
                 testCount += discoveredTestCases.Count;
                 foreach (TestFrameworks.NodejsTestInfo discoveredTest in discoveredTestCases) {
                     string qualifiedName = discoveredTest.FullyQualifiedName;
-                    logger.SendMessage(TestMessageLevel.Informational, String.Format("  " /*indent*/ + "Creating TestCase:{0}", qualifiedName));
+                    logger.SendMessage(TestMessageLevel.Informational, string.Format(CultureInfo.CurrentCulture, "  " /*indent*/ + "Creating TestCase:{0}", qualifiedName));
                     //figure out the test source info such as line number
                     string filePath = discoveredTest.ModulePath;
                     TestFileEntry entry = fileList.Find(p => p.File.Equals(filePath, StringComparison.OrdinalIgnoreCase));
@@ -154,10 +155,10 @@ namespace Microsoft.NodejsTools.TestAdapter {
                         });
 
                 }
-                logger.SendMessage(TestMessageLevel.Informational, string.Format("Processing finished for framework of {0}", testFx));
+                logger.SendMessage(TestMessageLevel.Informational, string.Format(CultureInfo.CurrentCulture, "Processing finished for framework of {0}", testFx));
             }
             if (testCount == 0) {
-                logger.SendMessage(TestMessageLevel.Warning, String.Format("Discovered 0 testcases."));
+                logger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, "Discovered 0 testcases."));
             }
         }
 

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
 using MSBuild = Microsoft.Build.Evaluation;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.TestAdapter {
     [ExtensionUri(TestExecutor.ExecutorUriString)]
@@ -193,7 +194,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     try {
                         //the '#ping=0' is a special flag to tell VS node debugger not to connect to the port,
                         //because a connection carries the consequence of setting off --debug-brk, and breakpoints will be missed.
-                        string qualifierUri = string.Format("tcp://localhost:{0}#ping=0", port);
+                        string qualifierUri = string.Format(CultureInfo.InvariantCulture, "tcp://localhost:{0}#ping=0", port);
                         while (!app.AttachToProcess(_nodeProcess, NodejsRemoteDebugPortSupplierUnsecuredId, qualifierUri)) {
                             if (_nodeProcess.Wait(TimeSpan.FromMilliseconds(500))) {
                                 break;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -152,14 +153,14 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
 
                     process.WaitForExit();
 #if DEBUG
-                    logger.SendMessage(TestMessageLevel.Informational, String.Format("  Process exited: {0}", process.ExitCode));
+                    logger.SendMessage(TestMessageLevel.Informational, string.Format(CultureInfo.InvariantCulture, "  Process exited: {0}", process.ExitCode));
 #endif
                 }
 #if DEBUG
-                logger.SendMessage(TestMessageLevel.Informational, String.Format("  StdOut:{0}", stdout));
+                logger.SendMessage(TestMessageLevel.Informational, string.Format(CultureInfo.InvariantCulture, "  StdOut:{0}", stdout));
 #endif
             } catch (FileNotFoundException e) {
-                logger.SendMessage(TestMessageLevel.Error, String.Format("Error starting node.exe.\n {0}", e));
+                logger.SendMessage(TestMessageLevel.Error, string.Format(CultureInfo.InvariantCulture, "Error starting node.exe.\n {0}", e));
             }
 
             return stdout;

--- a/Nodejs/Tests/NpmTests/SemverVersionTestHelper.cs
+++ b/Nodejs/Tests/NpmTests/SemverVersionTestHelper.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System.Globalization;
 using System.Text;
 using Microsoft.NodejsTools.Npm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -38,7 +39,7 @@ namespace NpmTests {
             Assert.AreEqual(null != expectedBuildMetadata, actual.HasBuildMetadata, "Build metadata presence mismatch.");
             Assert.AreEqual(expectedBuildMetadata, actual.BuildMetadata, "Build metadata mismatch.");
 
-            var expected = new StringBuilder(string.Format("{0}.{1}.{2}", expectedMajor, expectedMinor, expectedPatch));
+            var expected = new StringBuilder(string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", expectedMajor, expectedMinor, expectedPatch));
             if (null != expectedPreRelease) {
                 expected.Append('-');
                 expected.Append(expectedPreRelease);

--- a/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
+++ b/Nodejs/Tests/Profiling.UI/ProfilingTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -78,7 +79,7 @@ namespace ProfilingUITests {
                 destName = originalDestName;
 
                 while (File.Exists(destName)) {
-                    destName = string.Format("{0} {1}{2}",
+                    destName = string.Format(CultureInfo.InvariantCulture, "{0} {1}{2}",
                         Path.GetFileNameWithoutExtension(originalDestName),
                         Guid.NewGuid(),
                         Path.GetExtension(originalDestName)


### PR DESCRIPTION
**Bug**
FxCop warns when we do not pass in an explicit format provider for `string.Format`.

**Fix**
Switch all user messages and most error messages to use `CultureInfo.CurrentCulture`. Switch all internal strings to use `CultureInfo.InvariantCulture`.