### PR TITLE
String Method FxCop Error Mop Up

### DIFF
--- a/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
+++ b/Nodejs/Product/LogConverter/LogParsing/LogConverter.cs
@@ -511,7 +511,7 @@ namespace Microsoft.NodejsTools.LogParsing {
             // To cover them all, we just repeatedly strip the tail of the string after the last ':',
             // so long as it can be parsed as an integer.
             int colon;
-            while ((colon = location.LastIndexOf(':')) != -1) {
+            while ((colon = location.LastIndexOf(":", StringComparison.Ordinal)) != -1) {
                 string tail = location.Substring(colon + 1, location.Length - (colon + 1));
                 int number;
                 if (!Int32.TryParse(tail, out number)) {

--- a/Nodejs/Product/Nodejs/Commands/ImportWizardCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/ImportWizardCommand.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using System.Threading;
@@ -48,7 +49,7 @@ namespace Microsoft.NodejsTools.Commands {
                             ".njsproj"
                         );
                         dlg.ImportSettings.SourcePath = argItems[1];
-                        commandIdToRaise = int.Parse(argItems[2]);
+                        commandIdToRaise = int.Parse(argItems[2], CultureInfo.InvariantCulture);
                     }
                 }
             }

--- a/Nodejs/Product/Nodejs/Debugger/NodeEvaluationResult.cs
+++ b/Nodejs/Product/Nodejs/Debugger/NodeEvaluationResult.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -113,7 +114,7 @@ namespace Microsoft.NodejsTools.Debugger {
                 return stringValue.Length;
             }
 
-            return int.Parse(match.Groups[1].Value);
+            return int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/JsonListener.cs
+++ b/Nodejs/Product/Nodejs/JsonListener.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -81,7 +82,7 @@ namespace Microsoft.NodejsTools {
                         string body = String.Empty;
                         string contentLen;
                         if (headers.TryGetValue("Content-Length", out contentLen)) {
-                            int lengthRemaining = Int32.Parse(contentLen);
+                            int lengthRemaining = int.Parse(contentLen, CultureInfo.InvariantCulture);
                             if (lengthRemaining != 0) {
                                 StringBuilder bodyBuilder = new StringBuilder();
 

--- a/Nodejs/Product/Npm/PackageComparer.cs
+++ b/Nodejs/Product/Npm/PackageComparer.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.NodejsTools.Npm {
@@ -27,7 +28,7 @@ namespace Microsoft.NodejsTools.Npm {
                 return 1;
             }
             //  TODO: should take into account versions!
-            return x.Name.CompareTo(y.Name);
+            return string.Compare(x.Name, y.Name, StringComparison.Ordinal);
         }
     }
 

--- a/Nodejs/Product/Npm/SPI/DatabasePackageCatalogFilter.cs
+++ b/Nodejs/Product/Npm/SPI/DatabasePackageCatalogFilter.cs
@@ -73,8 +73,8 @@ namespace Microsoft.NodejsTools.Npm.SPI {
             }
 
             private int? CompareEntryStrings(string x, string y) {
-                var xIndex = string.IsNullOrEmpty(x) ? -1 : x.ToLower().IndexOf(_filterText, StringComparison.OrdinalIgnoreCase);
-                var yIndex = string.IsNullOrEmpty(y) ? -1 : y.ToLower().IndexOf(_filterText, StringComparison.OrdinalIgnoreCase);
+                var xIndex = string.IsNullOrEmpty(x) ? -1 : x.ToLower(CultureInfo.InvariantCulture).IndexOf(_filterText, StringComparison.OrdinalIgnoreCase);
+                var yIndex = string.IsNullOrEmpty(y) ? -1 : y.ToLower(CultureInfo.InvariantCulture).IndexOf(_filterText, StringComparison.OrdinalIgnoreCase);
 
                 int? xEqualsY = null;
                 const int xBeforeY = -1;

--- a/Nodejs/Product/Npm/SPI/DependencyUrl.cs
+++ b/Nodejs/Product/Npm/SPI/DependencyUrl.cs
@@ -14,6 +14,8 @@
 //
 //*********************************************************//
 
+using System;
+
 namespace Microsoft.NodejsTools.Npm.SPI {
     internal class DependencyUrl : IDependencyUrl {
         public DependencyUrl(string address) {
@@ -24,7 +26,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         public DependencyUrlType Type {
             get {
-                var index = Address.IndexOf("://");
+                var index = Address.IndexOf("://", StringComparison.Ordinal);
                 if (index < 0) {
                     return DependencyUrlType.GitHub;
                 } else {

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
 
         public override int GetDepth(string filepath) {
             var lastNodeModules = filepath.LastIndexOf(NodejsConstants.NodeModulesFolder + "\\", StringComparison.Ordinal);
-            var directoryToSearch = filepath.IndexOf("\\", lastNodeModules + NodejsConstants.NodeModulesFolder.Length + 1);
+            var directoryToSearch = filepath.IndexOf("\\", lastNodeModules + NodejsConstants.NodeModulesFolder.Length + 1, StringComparison.Ordinal);
             var directorySubString = directoryToSearch == -1 ? filepath : filepath.Substring(0, directoryToSearch);
 
             ModuleInfo value = null;

--- a/Nodejs/Product/Npm/SPI/NodeModules.cs
+++ b/Nodejs/Product/Npm/SPI/NodeModules.cs
@@ -75,7 +75,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
                             break;
                         }
 
-                        var parentNodeModulesIndex = moduleDir.LastIndexOf(NodejsConstants.NodeModulesFolder, Math.Max(0, moduleDir.Length - NodejsConstants.NodeModulesFolder.Length - dependency.Name.Length - 1));
+                        var parentNodeModulesIndex = moduleDir.LastIndexOf(NodejsConstants.NodeModulesFolder, Math.Max(0, moduleDir.Length - NodejsConstants.NodeModulesFolder.Length - dependency.Name.Length - 1), StringComparison.Ordinal);
                         moduleDir = moduleDir.Substring(0, parentNodeModulesIndex + NodejsConstants.NodeModulesFolder.Length);
                     } while (moduleDir.Contains(NodejsConstants.NodeModulesFolder));
                 }
@@ -140,7 +140,7 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         }
 
         public override int GetDepth(string filepath) {
-            var lastNodeModules = filepath.LastIndexOf(NodejsConstants.NodeModulesFolder + "\\");
+            var lastNodeModules = filepath.LastIndexOf(NodejsConstants.NodeModulesFolder + "\\", StringComparison.Ordinal);
             var directoryToSearch = filepath.IndexOf("\\", lastNodeModules + NodejsConstants.NodeModulesFolder.Length + 1);
             var directorySubString = directoryToSearch == -1 ? filepath : filepath.Substring(0, directoryToSearch);
 

--- a/Nodejs/Product/Npm/SPI/NpmSearchFilterStringComparer.cs
+++ b/Nodejs/Product/Npm/SPI/NpmSearchFilterStringComparer.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.NodejsTools.Npm.SPI {
@@ -26,15 +27,15 @@ namespace Microsoft.NodejsTools.Npm.SPI {
         }
 
         private int GetExactKeywordMatchCount(IPackage source) {
-            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower() == _filterString);
+            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower(CultureInfo.InvariantCulture) == _filterString);
         }
 
         private int GetStartsWithMatchCount(IPackage source) {
-            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower().StartsWith(_filterString));
+            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower(CultureInfo.InvariantCulture).StartsWith(_filterString, StringComparison.Ordinal));
         }
 
         private int GetPartialKeywordMatchCount(IPackage source) {
-            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower().Contains(_filterString));
+            return source.Keywords == null ? 0 : source.Keywords.Count(keyword => keyword.ToLower(CultureInfo.InvariantCulture).Contains(_filterString));
         }
 
         private new int CompareBasedOnKeywords(IPackage x, IPackage y) {

--- a/Nodejs/Product/Npm/SemverVersion.cs
+++ b/Nodejs/Product/Npm/SemverVersion.cs
@@ -62,9 +62,9 @@ namespace Microsoft.NodejsTools.Npm {
                 // /Hack
 
                 return new SemverVersion(
-                    ulong.Parse(match.Groups["major"].Value),
-                    ulong.Parse(match.Groups["minor"].Value),
-                    ulong.Parse(patch),
+                    ulong.Parse(match.Groups["major"].Value, CultureInfo.InvariantCulture),
+                    ulong.Parse(match.Groups["minor"].Value, CultureInfo.InvariantCulture),
+                    ulong.Parse(patch, CultureInfo.InvariantCulture),
                     preRelease.Success ? preRelease.Value : null,
                     buildMetadata.Success ? buildMetadata.Value : null);
             } catch (OverflowException oe) {

--- a/Nodejs/Product/Npm/SemverVersionComparer.cs
+++ b/Nodejs/Product/Npm/SemverVersionComparer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.NodejsTools.Npm {
 
@@ -63,7 +64,7 @@ namespace Microsoft.NodejsTools.Npm {
                 if (xn) {
                     if (yn) {
                         // Compare numeric identifiers in the expected way
-                        var result = int.Parse(xs[index]).CompareTo(int.Parse(ys[index]));
+                        var result = int.Parse(xs[index], CultureInfo.InvariantCulture).CompareTo(int.Parse(ys[index], CultureInfo.InvariantCulture));
                         if (0 != result) {
                             return result;
                         }

--- a/Nodejs/Product/Profiling/NodejsProfilingPackage.cs
+++ b/Nodejs/Product/Profiling/NodejsProfilingPackage.cs
@@ -435,7 +435,7 @@ namespace Microsoft.NodejsTools.Profiling {
             var process = new ProfiledProcess(interpreter, interpreterArgs, script, scriptArgs, workingDir, env, arch, launchUrl, port, startBrowser, jmc);
 
             string baseName = Path.GetFileNameWithoutExtension(session.Filename);
-            string date = DateTime.Now.ToString("yyyyMMdd");
+            string date = DateTime.Now.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
             string outPath = Path.Combine(Path.GetDirectoryName(session.Filename), baseName + "_" + date + ".vspx");
 
             int count = 1;

--- a/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfiledProcess.cs
@@ -152,11 +152,11 @@ namespace Microsoft.NodejsTools.Profiling {
                                 Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
                                 "Microsoft.NodejsTools.NodeLogConverter.exe"
                             ),
-                            (_justMyCode ? "/jmc " : String.Empty) + 
-                            (is012 ? "/v:0.12 " : String.Empty) + 
+                            (_justMyCode ? "/jmc " : string.Empty) + 
+                            (is012 ? "/v:0.12 " : string.Empty) + 
                             "\"" + v8log + "\" " +
                             "\"" + filename + "\" " +
-                            "\"" + _process.StartTime.ToString() + "\" " +
+                            "\"" + _process.StartTime.ToString(CultureInfo.InvariantCulture) + "\" " +
                             "\"" + executionTime.ToString() + "\""
                         );
 

--- a/Nodejs/Product/Profiling/Profiling/SessionNode.cs
+++ b/Nodejs/Product/Profiling/Profiling/SessionNode.cs
@@ -120,7 +120,7 @@ namespace Microsoft.NodejsTools.Profiling {
             switch (prop) {
                 case __VSHPROPID.VSHPROPID_Expanded:
                     if (itemid == ReportsItemId) {
-                        _isReportsExpanded = Convert.ToBoolean(var);
+                        _isReportsExpanded = Convert.ToBoolean(var, CultureInfo.InvariantCulture);
                         break;
                     }
                     break;

--- a/Nodejs/Tests/Core/Debugger/Commands/ChangeBreakpointCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/ChangeBreakpointCommandTests.cs
@@ -16,6 +16,7 @@
 
 using Microsoft.NodejsTools.Debugger.Commands;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
 
 namespace NodejsTests.Debugger.Commands {
     [TestClass]
@@ -55,7 +56,7 @@ namespace NodejsTests.Debugger.Commands {
             Assert.AreEqual(
                 string.Format(
                     "{{\"command\":\"changebreakpoint\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"breakpoint\":{1},\"enabled\":{2},\"condition\":\"{3}\",\"ignoreCount\":{4}}}}}",
-                    commandId, breakpointId, enabled.ToString().ToLower(), condition, ignoreCount),
+                    commandId, breakpointId, enabled.ToString().ToLower(CultureInfo.InvariantCulture), condition, ignoreCount),
                 changeBreakpointCommand.ToString());
         }
     }

--- a/Nodejs/Tests/Core/Debugger/Commands/ContinueCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/ContinueCommandTests.cs
@@ -17,6 +17,7 @@
 using Microsoft.NodejsTools.Debugger;
 using Microsoft.NodejsTools.Debugger.Commands;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
 
 namespace NodejsTests.Debugger.Commands {
     [TestClass]
@@ -35,7 +36,7 @@ namespace NodejsTests.Debugger.Commands {
             Assert.AreEqual(
                 string.Format(
                     "{{\"command\":\"continue\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"stepaction\":\"{1}\",\"stepcount\":1}}}}",
-                    commandId, stepping.ToString().ToLower()),
+                    commandId, stepping.ToString().ToLower(CultureInfo.InvariantCulture)),
                 continueCommand.ToString());
         }
 
@@ -54,7 +55,7 @@ namespace NodejsTests.Debugger.Commands {
             Assert.AreEqual(
                 string.Format(
                     "{{\"command\":\"continue\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"stepaction\":\"{1}\",\"stepcount\":{2}}}}}",
-                    commandId, stepping.ToString().ToLower(), stepCount),
+                    commandId, stepping.ToString().ToLower(CultureInfo.InvariantCulture), stepCount),
                 continueCommand.ToString());
         }
     }

--- a/Nodejs/Tests/Core/Debugger/Commands/ScriptsCommandTests.cs
+++ b/Nodejs/Tests/Core/Debugger/Commands/ScriptsCommandTests.cs
@@ -14,6 +14,7 @@
 //
 //*********************************************************//
 
+using System.Globalization;
 using Microsoft.NodejsTools.Debugger;
 using Microsoft.NodejsTools.Debugger.Commands;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -54,7 +55,7 @@ namespace NodejsTests.Debugger.Commands {
             Assert.AreEqual(
                 string.Format(
                     "{{\"command\":\"scripts\",\"seq\":{0},\"type\":\"request\",\"arguments\":{{\"includeSource\":{1},\"ids\":[{2}]}}}}",
-                    commandId, includeSource.ToString().ToLower(), moduleId),
+                    commandId, includeSource.ToString().ToLower(CultureInfo.InvariantCulture), moduleId),
                 scriptsCommand.ToString());
         }
 


### PR DESCRIPTION
**Bug**
Various FxCop warnings about strings, such as using the implicit overloads vs explicit ones.

**Fix**

- Make `Parse` methods use invariant culture.
- Fix a few more `StartsWith` calls
- Fix a few more format and tostring calls.
- Fix a few calls to `ToLower`