### PR TITLE
Fix New File Context Menu

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
+++ b/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
@@ -17,37 +17,12 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
     internal static class NewFileUtilities {
-        public static string GetTemplateFile(string fileType) {
-            string templateFileName = null;
-
-            switch (fileType) {
-                case NodejsConstants.JavaScript:
-                    templateFileName = "EmptyJs.js";
-                    break;
-                case NodejsConstants.TypeScript:
-                    templateFileName = "EmptyTs.ts";
-                    break;
-                case NodejsConstants.HTML:
-                    templateFileName = "EmptyHTML.html";
-                    break;
-                case NodejsConstants.CSS:
-                    templateFileName = "EmptyCSS.css";
-                    break;
-            }
-
-            if (templateFileName == null) {
-                Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Invalid file type: {0}", fileType));
-            }
-
-            return NodejsToolsInstallPath.GetFile("FileTemplates\\NewItem\\" + templateFileName);
-        }
-
         private static string GetInitialName(string fileType) {
-
             switch (fileType) {
                 case NodejsConstants.JavaScript:
                     return "JavaScript.js";
@@ -74,12 +49,9 @@ namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
                         VSADDITEMOPERATION.VSADDITEMOP_CLONEFILE,    // Indicate that we want to create this new file by cloning a template file.
                         itemName,
                         1,                                           // Number of templates in the next parameter. Must be 1 if using VSADDITEMOP_CLONEFILE.
-                        new string[] { GetTemplateFile(fileType) },  // Array contains the template file path.
+                        new string[] { Path.GetTempFileName() },     // Array contains the template file path.
                         IntPtr.Zero,                                 // Handle to the Add Item dialog box. Must be Zero if using VSADDITEMOP_CLONEFILE.
-                        pResult
-                    );
-
-                    // TODO: Do we need to check if result[0] = VSADDRESULT.ADDRESULT_Success here?
+                        pResult);
                 }
             }
         }


### PR DESCRIPTION
**Bug**
#1328 broke the `right click -> New -> JavaScript file flows`. The root cause is that all of our templates now live in a new location inside or zip files. The code was trying to lookup the templates from their old spot.

**Fix**
Remove the template lookup logic entirely and instead just create a blank file of the requested type