### PR TITLE
Remove Show All Files Setting from Project Templates

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureExpress4App/ExpressApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/AzureNodejsApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/AzureNodejsApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/Worker.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsWorker/Worker.njsproj
@@ -18,7 +18,6 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <RoleType>Worker</RoleType>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/ExpressApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/FromExistingCode/FromExistingCode.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/FromExistingCode/FromExistingCode.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
   </PropertyGroup>
 

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/NodejsConsoleApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsConsoleApp/NodejsConsoleApp.njsproj
@@ -18,7 +18,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>
 

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/NodejsWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/NodejsWebApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/Worker.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/Worker.njsproj
@@ -18,7 +18,6 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <RoleType>Worker</RoleType>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/Worker.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/Worker.njsproj
@@ -18,7 +18,6 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <RoleType>Worker</RoleType>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
@@ -18,7 +18,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/TypeScriptWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/TypeScriptWebApp.njsproj
@@ -18,7 +18,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
@@ -18,7 +18,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
     <EnableTypeScript>true</EnableTypeScript>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptFromExistingCode/FromExistingCode.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptFromExistingCode/FromExistingCode.njsproj
@@ -17,7 +17,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
@@ -18,7 +18,6 @@
     <OutputPath>.</OutputPath>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <ProjectView>ShowAllFiles</ProjectView>
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>


### PR DESCRIPTION
**Bug**
The `ProjectView` setting is saved inside the `nsjproj` files in our templates. This means that when user alters the soltuion explorer view, the `njsproj` file is also updated. Since this file may be managed by git, this behavior can be annoying.

**Fix**
Remove the `ProjectView` element from the template. If a user turns on 'show all items' now, the setting is saved to a `njsproj.user` file instead.

Closes #1344, Closes #250