### PR TITLE
Add Keyboard Navigation Shortcut for Startup File Property

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -53,30 +53,27 @@
             // _nodeExePathLabel
             // 
             this._nodeExePathLabel.AutoSize = true;
-            this._nodeExePathLabel.Location = new System.Drawing.Point(19, 27);
-            this._nodeExePathLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._nodeExePathLabel.Location = new System.Drawing.Point(14, 22);
             this._nodeExePathLabel.Name = "_nodeExePathLabel";
-            this._nodeExePathLabel.Size = new System.Drawing.Size(104, 17);
+            this._nodeExePathLabel.Size = new System.Drawing.Size(80, 13);
             this._nodeExePathLabel.TabIndex = 0;
             this._nodeExePathLabel.Text = "Node.exe &path:";
             // 
             // _nodeArguments
             // 
             this._nodeArguments.AutoSize = true;
-            this._nodeArguments.Location = new System.Drawing.Point(19, 59);
-            this._nodeArguments.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._nodeArguments.Location = new System.Drawing.Point(14, 48);
             this._nodeArguments.Name = "_nodeArguments";
-            this._nodeArguments.Size = new System.Drawing.Size(122, 17);
+            this._nodeArguments.Size = new System.Drawing.Size(93, 13);
             this._nodeArguments.TabIndex = 3;
             this._nodeArguments.Text = "N&ode.exe options:";
             // 
             // _startBrowser
             // 
             this._startBrowser.AutoSize = true;
-            this._startBrowser.Location = new System.Drawing.Point(23, 350);
-            this._startBrowser.Margin = new System.Windows.Forms.Padding(4);
+            this._startBrowser.Location = new System.Drawing.Point(17, 284);
             this._startBrowser.Name = "_startBrowser";
-            this._startBrowser.Size = new System.Drawing.Size(209, 21);
+            this._startBrowser.Size = new System.Drawing.Size(161, 17);
             this._startBrowser.TabIndex = 20;
             this._startBrowser.Text = "St&art web browser on launch";
             this._startBrowser.UseVisualStyleBackColor = true;
@@ -88,10 +85,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this._nodeExePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this._nodeExePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystem;
-            this._nodeExePath.Location = new System.Drawing.Point(180, 23);
-            this._nodeExePath.Margin = new System.Windows.Forms.Padding(4);
+            this._nodeExePath.Location = new System.Drawing.Point(135, 19);
             this._nodeExePath.Name = "_nodeExePath";
-            this._nodeExePath.Size = new System.Drawing.Size(409, 22);
+            this._nodeExePath.Size = new System.Drawing.Size(308, 20);
             this._nodeExePath.TabIndex = 1;
             this._nodeExePath.TextChanged += new System.EventHandler(this.NodeExePathChanged);
             // 
@@ -99,39 +95,35 @@
             // 
             this._nodeExeArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._nodeExeArguments.Location = new System.Drawing.Point(180, 55);
-            this._nodeExeArguments.Margin = new System.Windows.Forms.Padding(4);
+            this._nodeExeArguments.Location = new System.Drawing.Point(135, 45);
             this._nodeExeArguments.Name = "_nodeExeArguments";
-            this._nodeExeArguments.Size = new System.Drawing.Size(452, 22);
+            this._nodeExeArguments.Size = new System.Drawing.Size(340, 20);
             this._nodeExeArguments.TabIndex = 4;
             this._nodeExeArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _nodejsPort
             // 
-            this._nodejsPort.Location = new System.Drawing.Point(180, 217);
-            this._nodejsPort.Margin = new System.Windows.Forms.Padding(4);
+            this._nodejsPort.Location = new System.Drawing.Point(135, 176);
             this._nodejsPort.Name = "_nodejsPort";
-            this._nodejsPort.Size = new System.Drawing.Size(139, 22);
+            this._nodejsPort.Size = new System.Drawing.Size(105, 20);
             this._nodejsPort.TabIndex = 15;
             this._nodejsPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _nodePortLabel
             // 
             this._nodePortLabel.AutoSize = true;
-            this._nodePortLabel.Location = new System.Drawing.Point(19, 220);
-            this._nodePortLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._nodePortLabel.Location = new System.Drawing.Point(14, 179);
             this._nodePortLabel.Name = "_nodePortLabel";
-            this._nodePortLabel.Size = new System.Drawing.Size(89, 17);
+            this._nodePortLabel.Size = new System.Drawing.Size(67, 13);
             this._nodePortLabel.TabIndex = 14;
             this._nodePortLabel.Text = "Node.&js port:";
             // 
             // _scriptArgsLabel
             // 
             this._scriptArgsLabel.AutoSize = true;
-            this._scriptArgsLabel.Location = new System.Drawing.Point(19, 123);
-            this._scriptArgsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._scriptArgsLabel.Location = new System.Drawing.Point(14, 100);
             this._scriptArgsLabel.Name = "_scriptArgsLabel";
-            this._scriptArgsLabel.Size = new System.Drawing.Size(119, 17);
+            this._scriptArgsLabel.Size = new System.Drawing.Size(89, 13);
             this._scriptArgsLabel.TabIndex = 7;
             this._scriptArgsLabel.Text = "Script ar&guments:";
             // 
@@ -139,20 +131,18 @@
             // 
             this._scriptArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptArguments.Location = new System.Drawing.Point(180, 119);
-            this._scriptArguments.Margin = new System.Windows.Forms.Padding(4);
+            this._scriptArguments.Location = new System.Drawing.Point(135, 97);
             this._scriptArguments.Name = "_scriptArguments";
-            this._scriptArguments.Size = new System.Drawing.Size(452, 22);
+            this._scriptArguments.Size = new System.Drawing.Size(340, 20);
             this._scriptArguments.TabIndex = 8;
             this._scriptArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _workingDirLabel
             // 
             this._workingDirLabel.AutoSize = true;
-            this._workingDirLabel.Location = new System.Drawing.Point(19, 155);
-            this._workingDirLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._workingDirLabel.Location = new System.Drawing.Point(14, 126);
             this._workingDirLabel.Name = "_workingDirLabel";
-            this._workingDirLabel.Size = new System.Drawing.Size(123, 17);
+            this._workingDirLabel.Size = new System.Drawing.Size(93, 13);
             this._workingDirLabel.TabIndex = 9;
             this._workingDirLabel.Text = "Working director&y:";
             // 
@@ -160,10 +150,9 @@
             // 
             this._workingDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._workingDir.Location = new System.Drawing.Point(180, 151);
-            this._workingDir.Margin = new System.Windows.Forms.Padding(4);
+            this._workingDir.Location = new System.Drawing.Point(135, 123);
             this._workingDir.Name = "_workingDir";
-            this._workingDir.Size = new System.Drawing.Size(409, 22);
+            this._workingDir.Size = new System.Drawing.Size(308, 20);
             this._workingDir.TabIndex = 10;
             this._workingDir.TextChanged += new System.EventHandler(this.WorkingDirTextChanged);
             // 
@@ -171,20 +160,18 @@
             // 
             this._launchUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._launchUrl.Location = new System.Drawing.Point(180, 185);
-            this._launchUrl.Margin = new System.Windows.Forms.Padding(4);
+            this._launchUrl.Location = new System.Drawing.Point(135, 150);
             this._launchUrl.Name = "_launchUrl";
-            this._launchUrl.Size = new System.Drawing.Size(452, 22);
+            this._launchUrl.Size = new System.Drawing.Size(340, 20);
             this._launchUrl.TabIndex = 13;
             this._launchUrl.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _launchUrlLabel
             // 
             this._launchUrlLabel.AutoSize = true;
-            this._launchUrlLabel.Location = new System.Drawing.Point(19, 188);
-            this._launchUrlLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._launchUrlLabel.Location = new System.Drawing.Point(14, 153);
             this._launchUrlLabel.Name = "_launchUrlLabel";
-            this._launchUrlLabel.Size = new System.Drawing.Size(91, 17);
+            this._launchUrlLabel.Size = new System.Drawing.Size(71, 13);
             this._launchUrlLabel.TabIndex = 12;
             this._launchUrlLabel.Text = "Launch &URL:";
             // 
@@ -192,22 +179,20 @@
             // 
             this._envVars.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._envVars.Location = new System.Drawing.Point(180, 281);
-            this._envVars.Margin = new System.Windows.Forms.Padding(4);
+            this._envVars.Location = new System.Drawing.Point(135, 228);
             this._envVars.Multiline = true;
             this._envVars.Name = "_envVars";
             this._envVars.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this._envVars.Size = new System.Drawing.Size(452, 61);
+            this._envVars.Size = new System.Drawing.Size(340, 50);
             this._envVars.TabIndex = 19;
             this._envVars.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _browsePath
             // 
             this._browsePath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browsePath.Location = new System.Drawing.Point(599, 21);
-            this._browsePath.Margin = new System.Windows.Forms.Padding(4);
+            this._browsePath.Location = new System.Drawing.Point(449, 17);
             this._browsePath.Name = "_browsePath";
-            this._browsePath.Size = new System.Drawing.Size(35, 28);
+            this._browsePath.Size = new System.Drawing.Size(26, 23);
             this._browsePath.TabIndex = 2;
             this._browsePath.Text = "...";
             this._browsePath.UseVisualStyleBackColor = true;
@@ -216,10 +201,9 @@
             // _browseDirectory
             // 
             this._browseDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browseDirectory.Location = new System.Drawing.Point(599, 149);
-            this._browseDirectory.Margin = new System.Windows.Forms.Padding(4);
+            this._browseDirectory.Location = new System.Drawing.Point(449, 121);
             this._browseDirectory.Name = "_browseDirectory";
-            this._browseDirectory.Size = new System.Drawing.Size(35, 28);
+            this._browseDirectory.Size = new System.Drawing.Size(26, 23);
             this._browseDirectory.TabIndex = 11;
             this._browseDirectory.Text = "...";
             this._browseDirectory.UseVisualStyleBackColor = true;
@@ -232,56 +216,51 @@
             // _debuggerPortLabel
             // 
             this._debuggerPortLabel.AutoSize = true;
-            this._debuggerPortLabel.Location = new System.Drawing.Point(19, 252);
-            this._debuggerPortLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._debuggerPortLabel.Location = new System.Drawing.Point(14, 205);
             this._debuggerPortLabel.Name = "_debuggerPortLabel";
-            this._debuggerPortLabel.Size = new System.Drawing.Size(104, 17);
+            this._debuggerPortLabel.Size = new System.Drawing.Size(78, 13);
             this._debuggerPortLabel.TabIndex = 16;
             this._debuggerPortLabel.Text = "&Debugger port:";
             // 
             // _debuggerPort
             // 
-            this._debuggerPort.Location = new System.Drawing.Point(180, 249);
-            this._debuggerPort.Margin = new System.Windows.Forms.Padding(4);
+            this._debuggerPort.Location = new System.Drawing.Point(135, 202);
             this._debuggerPort.Name = "_debuggerPort";
-            this._debuggerPort.Size = new System.Drawing.Size(139, 22);
+            this._debuggerPort.Size = new System.Drawing.Size(105, 20);
             this._debuggerPort.TabIndex = 17;
             this._debuggerPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _envVarsLabel
             // 
             this._envVarsLabel.AutoSize = true;
-            this._envVarsLabel.Location = new System.Drawing.Point(19, 284);
-            this._envVarsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._envVarsLabel.Location = new System.Drawing.Point(14, 231);
             this._envVarsLabel.Name = "_envVarsLabel";
-            this._envVarsLabel.Size = new System.Drawing.Size(154, 17);
+            this._envVarsLabel.Size = new System.Drawing.Size(115, 13);
             this._envVarsLabel.TabIndex = 18;
             this._envVarsLabel.Text = "Environment &Variables:";
             // 
             // _scriptLabel
             // 
             this._scriptLabel.AutoSize = true;
-            this._scriptLabel.Location = new System.Drawing.Point(19, 91);
-            this._scriptLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._scriptLabel.Location = new System.Drawing.Point(14, 74);
             this._scriptLabel.Name = "_scriptLabel";
-            this._scriptLabel.Size = new System.Drawing.Size(128, 17);
+            this._scriptLabel.Size = new System.Drawing.Size(94, 13);
             this._scriptLabel.TabIndex = 5;
-            this._scriptLabel.Text = "Script (startup file):";
+            this._scriptLabel.Text = "&Script (startup file):";
             // 
             // _scriptFile
             // 
             this._scriptFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptFile.Location = new System.Drawing.Point(180, 87);
-            this._scriptFile.Margin = new System.Windows.Forms.Padding(4);
+            this._scriptFile.Location = new System.Drawing.Point(135, 71);
             this._scriptFile.Name = "_scriptFile";
-            this._scriptFile.Size = new System.Drawing.Size(452, 22);
+            this._scriptFile.Size = new System.Drawing.Size(340, 20);
             this._scriptFile.TabIndex = 6;
             this._scriptFile.TextChanged += new System.EventHandler(this.Changed);
             // 
             // NodejsGeneralPropertyPageControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this._scriptLabel);
             this.Controls.Add(this._scriptFile);
@@ -304,10 +283,9 @@
             this.Controls.Add(this._scriptArguments);
             this.Controls.Add(this._nodeExeArguments);
             this.Controls.Add(this._nodeExePath);
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(404, 373);
+            this.MinimumSize = new System.Drawing.Size(303, 303);
             this.Name = "NodejsGeneralPropertyPageControl";
-            this.Size = new System.Drawing.Size(651, 392);
+            this.Size = new System.Drawing.Size(488, 318);
             ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();


### PR DESCRIPTION
Issue #1347

**Bug**
Cannot quickly reach the `Script (startup file)` setting on the project property page using keyboard navigation.

**fix**
Add a shortcut to this element.

Closes #1347