### PR TITLE
Change "Add Js/Css/..." to Generic Add File Command

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsTools.vsct
+++ b/Nodejs/Product/Nodejs/NodejsTools.vsct
@@ -95,34 +95,13 @@
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node or set it to <Icon guid="guidOfficeIcon" id="msotcidNoIcon" /> -->
         
-      <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewJavaScriptFileCommand" priority="0x0550" type="Button">
+      <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewFileCommand" priority="0x0550" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
         <Strings>
-          <ButtonText>JavaScript File...</ButtonText>
+          <ButtonText>New File...</ButtonText>
         </Strings>
       </Button>
-
-      <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewTypeScriptFileCommand" priority="0x0551" type="Button">
-        <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
-        <Strings>
-          <ButtonText>TypeScript File...</ButtonText>
-        </Strings>
-      </Button>
-
-      <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewHTMLFileCommand" priority="0x0552" type="Button">
-        <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
-        <Strings>
-          <ButtonText>HTML File...</ButtonText>
-        </Strings>
-      </Button>
-
-      <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewCSSFileCommand" priority="0x0553" type="Button">
-        <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
-        <Strings>
-          <ButtonText>CSS File...</ButtonText>
-        </Strings>
-      </Button>
-
+      
       <Button guid="guidNodeToolsCmdSet" id="cmdidSetAsNodejsStartupFile" priority="0x0300" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="CodeFileGroup"/>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -388,10 +367,7 @@
       <IDSymbol name="cmdidOpenRemoteDebugDocumentation" value="0x0206" />
       <IDSymbol name="cmdidAzureExplorerAttachNodejsDebugger" value="0x0207" />
       <IDSymbol name="cmdidDiagnostics" value="0x0208" />
-      <IDSymbol name="cmdidAddNewJavaScriptFileCommand" value="0x0211" />
-      <IDSymbol name="cmdidAddNewTypeScriptFileCommand" value="0x0212" />
-      <IDSymbol name="cmdidAddNewHTMLFileCommand" value="0x0213" />
-      <IDSymbol name="cmdidAddNewCSSFileCommand" value="0x0214" />
+      <IDSymbol name="cmdidAddNewFileCommand" value="0x0211" />
       <IDSymbol name="cmdidSendFeedback" value="0x0215" />
       <IDSymbol name="cmdidDocumentation" value="0x0216" />
 

--- a/Nodejs/Product/Nodejs/PkgCmdId.cs
+++ b/Nodejs/Product/Nodejs/PkgCmdId.cs
@@ -29,10 +29,7 @@ namespace Microsoft.NodejsTools {
         public const uint cmdidAzureExplorerAttachNodejsDebugger = 0x207;
 
         public const int cmdidDiagnostics                   = 0x208;
-        public const int cmdidAddNewJavaScriptFileCommand   = 0x211;
-        public const int cmdidAddNewTypeScriptFileCommand   = 0x212;
-        public const int cmdidAddNewHTMLFileCommand         = 0x213;
-        public const int cmdidAddNewCSSFileCommand          = 0x214;
+        public const int cmdidAddFileCommand                = 0x211;
         public const int cmdidSendFeedback                  = 0x215;
         public const int cmdidShowDocumentation             = 0x216;
 

--- a/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
+++ b/Nodejs/Product/Nodejs/Project/NewFileMenuGroup/NewFileUtilities.cs
@@ -15,33 +15,19 @@
 //*********************************************************//
 
 using System;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
     internal static class NewFileUtilities {
-        private static string GetInitialName(string fileType) {
-            switch (fileType) {
-                case NodejsConstants.JavaScript:
-                    return "JavaScript.js";
-                case NodejsConstants.TypeScript:
-                    return "TypeScript.ts";
-                case NodejsConstants.HTML:
-                    return "HTML.html";
-                case NodejsConstants.CSS:
-                    return "CSS.css";
-                default:
-                    Debug.Fail(string.Format(CultureInfo.CurrentCulture, "Invalid file type: {0}", fileType));
-                    return null;
-            }
-        }
-
-        private static void CreateNewFile(NodejsProjectNode projectNode, uint containerId, string fileType) {
-            using (var dialog = new NewFileNameForm(GetInitialName(fileType))) {
+        internal static void CreateNewFile(NodejsProjectNode projectNode, uint containerId) {
+            using (var dialog = new NewFileNameForm("")) {
                 if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK) {
                     string itemName = dialog.TextBox.Text;
+                    if (string.IsNullOrWhiteSpace(itemName)) {
+                        return;
+                    }
+                    itemName = itemName.Trim();
 
                     VSADDRESULT[] pResult = new VSADDRESULT[1];
                     projectNode.AddItem(
@@ -54,22 +40,6 @@ namespace Microsoft.NodejsTools.Project.NewFileMenuGroup {
                         pResult);
                 }
             }
-        }
-
-        internal static void CreateNewJavaScriptFile(NodejsProjectNode projectNode, uint containerId) {
-            CreateNewFile(projectNode, containerId, NodejsConstants.JavaScript);
-        }
-
-        internal static void CreateNewTypeScriptFile(NodejsProjectNode projectNode, uint containerId) {
-            CreateNewFile(projectNode, containerId, NodejsConstants.TypeScript);
-        }
-
-        internal static void CreateNewHTMLFile(NodejsProjectNode projectNode, uint containerId) {
-            CreateNewFile(projectNode, containerId, NodejsConstants.HTML);
-        }
-
-        internal static void CreateNewCSSFile(NodejsProjectNode projectNode, uint containerId) {
-            CreateNewFile(projectNode, containerId, NodejsConstants.CSS);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -927,10 +927,7 @@ namespace Microsoft.NodejsTools.Project {
                             }
                         }
                         break;
-                    case PkgCmdId.cmdidAddNewJavaScriptFileCommand: 
-                    case PkgCmdId.cmdidAddNewTypeScriptFileCommand: 
-                    case PkgCmdId.cmdidAddNewHTMLFileCommand: 
-                    case PkgCmdId.cmdidAddNewCSSFileCommand: 
+                    case PkgCmdId.cmdidAddFileCommand:
                         return QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED; 
                 }
             }
@@ -1002,26 +999,10 @@ namespace Microsoft.NodejsTools.Project {
                         handled = true;
                         return VSConstants.S_OK;
 
-                    case PkgCmdId.cmdidAddNewJavaScriptFileCommand:
-                        NewFileMenuGroup.NewFileUtilities.CreateNewJavaScriptFile(projectNode: this, containerId: selectedNodes[0].ID);
+                    case PkgCmdId.cmdidAddFileCommand:
+                        NewFileMenuGroup.NewFileUtilities.CreateNewFile(projectNode: this, containerId: selectedNodes[0].ID);
                         handled = true;
                         return VSConstants.S_OK;
-
-                    case PkgCmdId.cmdidAddNewTypeScriptFileCommand:
-                        NewFileMenuGroup.NewFileUtilities.CreateNewTypeScriptFile(projectNode: this, containerId: selectedNodes[0].ID);
-                        handled = true;
-                        return VSConstants.S_OK;
-
-                    case PkgCmdId.cmdidAddNewHTMLFileCommand:
-                        NewFileMenuGroup.NewFileUtilities.CreateNewHTMLFile(projectNode: this, containerId: selectedNodes[0].ID);
-                        handled = true;
-                        return VSConstants.S_OK;
-
-                    case PkgCmdId.cmdidAddNewCSSFileCommand:
-                        NewFileMenuGroup.NewFileUtilities.CreateNewCSSFile(projectNode: this, containerId: selectedNodes[0].ID);
-                        handled = true;
-                        return VSConstants.S_OK;
-
                 }
             }
 


### PR DESCRIPTION
**Bug**
VS makes creating an empty file much more difficult than it should be. We currently provide shortcuts that create js/css/html/ts files, but we will never be able to support all the various file types people use in node projects.

**Fix**
Replace the specific create file operations with a more general `New File` command. This just creates an empty file with a given name. This makes it much quicker and easier to create blank `*.pug` or `*.sass` files