### PR TITLE
Move Project Property Constants to Own Class

### DIFF
--- a/Nodejs/Product/Nodejs/BaseNodeProjectFactory.cs
+++ b/Nodejs/Product/Nodejs/BaseNodeProjectFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NodejsTools {
         }
 
         protected override ProjectUpgradeState UpgradeProjectCheck(ProjectRootElement projectXml, ProjectRootElement userProjectXml, Action<__VSUL_ERRORLEVEL, string> log, ref Guid projectFactory, ref __VSPPROJECTUPGRADEVIAFACTORYFLAGS backupSupport) {
-            var envVarsProp = projectXml.Properties.FirstOrDefault(p => p.Name == NodejsConstants.EnvironmentVariables);
+            var envVarsProp = projectXml.Properties.FirstOrDefault(p => p.Name == NodeProjectProperty.EnvironmentVariables);
             if (envVarsProp != null && !string.IsNullOrEmpty(envVarsProp.Value)) {
                 return ProjectUpgradeState.OneWayUpgrade;
             }
@@ -45,10 +45,10 @@ namespace Microsoft.NodejsTools {
         }
 
         protected override void UpgradeProject(ref ProjectRootElement projectXml, ref ProjectRootElement userProjectXml, Action<__VSUL_ERRORLEVEL, string> log) {
-            var envVarsProp = projectXml.Properties.FirstOrDefault(p => p.Name == NodejsConstants.EnvironmentVariables);
+            var envVarsProp = projectXml.Properties.FirstOrDefault(p => p.Name == NodeProjectProperty.EnvironmentVariables);
             if (envVarsProp != null) {
                 var globals = projectXml.PropertyGroups.FirstOrDefault() ?? projectXml.AddPropertyGroup();
-                AddOrSetProperty(globals, NodejsConstants.Environment, envVarsProp.Value.Replace(";", "\r\n"));
+                AddOrSetProperty(globals, NodeProjectProperty.Environment, envVarsProp.Value.Replace(";", "\r\n"));
                 envVarsProp.Parent.RemoveChild(envVarsProp);
                 log(__VSUL_ERRORLEVEL.VSUL_INFORMATIONAL, SR.GetString(SR.UpgradedEnvironmentVariables));
             }

--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -32,16 +32,7 @@ namespace Microsoft.NodejsTools {
 
         internal const string IssueTrackerUrl = "https://go.microsoft.com/fwlink/?LinkId=507637";
 
-        internal const string DebuggerPort = "DebuggerPort";
-        internal const string Environment = "Environment";
-        internal const string EnvironmentVariables = "EnvironmentVariables";
-        internal const string LaunchUrl = "LaunchUrl";
-        internal const string NodeExePath = "NodeExePath";
-        internal const string NodeExeArguments = "NodeExeArguments";
-        internal const string NodejsPort = "NodejsPort";
         internal const string ProjectFileFilter = "Node.js Project File (*.njsproj)\n*.njsproj\nAll Files (*.*)\n*.*\n";
-        internal const string ScriptArguments = "ScriptArguments";
-        internal const string StartWebBrowser = "StartWebBrowser";
 
         internal const string NodeModulesFolder = "node_modules";
         internal const string NodeModulesStagingFolder = "node_modules\\.staging\\";
@@ -105,5 +96,17 @@ namespace Microsoft.NodejsTools {
             return tmp.IndexOf("\\" + NodeModulesFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0
                 || tmp.IndexOf("\\" + BowerComponentsFolder + "\\", StringComparison.OrdinalIgnoreCase) >= 0;
         }
+    }
+
+    internal class NodeProjectProperty {
+        internal const string DebuggerPort = "DebuggerPort";
+        internal const string Environment = "Environment";
+        internal const string EnvironmentVariables = "EnvironmentVariables";
+        internal const string LaunchUrl = "LaunchUrl";
+        internal const string NodeExePath = "NodeExePath";
+        internal const string NodeExeArguments = "NodeExeArguments";
+        internal const string NodejsPort = "NodejsPort";
+        internal const string ScriptArguments = "ScriptArguments";
+        internal const string StartWebBrowser = "StartWebBrowser";
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
@@ -47,35 +47,35 @@ namespace Microsoft.NodejsTools.Project {
             }
         }
         public override void Apply() {
-            Project.SetProjectProperty(NodejsConstants.NodeExePath, _control.NodeExePath);
-            Project.SetProjectProperty(NodejsConstants.NodeExeArguments, _control.NodeExeArguments);
+            Project.SetProjectProperty(NodeProjectProperty.NodeExePath, _control.NodeExePath);
+            Project.SetProjectProperty(NodeProjectProperty.NodeExeArguments, _control.NodeExeArguments);
             Project.SetProjectProperty(CommonConstants.StartupFile, _control.ScriptFile);
-            Project.SetProjectProperty(NodejsConstants.ScriptArguments, _control.ScriptArguments);
-            Project.SetProjectProperty(NodejsConstants.NodejsPort, _control.NodejsPort);
-            Project.SetProjectProperty(NodejsConstants.StartWebBrowser, _control.StartWebBrowser.ToString());
+            Project.SetProjectProperty(NodeProjectProperty.ScriptArguments, _control.ScriptArguments);
+            Project.SetProjectProperty(NodeProjectProperty.NodejsPort, _control.NodejsPort);
+            Project.SetProjectProperty(NodeProjectProperty.StartWebBrowser, _control.StartWebBrowser.ToString());
             Project.SetProjectProperty(CommonConstants.WorkingDirectory, _control.WorkingDirectory);
-            Project.SetProjectProperty(NodejsConstants.LaunchUrl, _control.LaunchUrl);
-            Project.SetProjectProperty(NodejsConstants.DebuggerPort, _control.DebuggerPort);
-            Project.SetProjectProperty(NodejsConstants.Environment, _control.Environment);
+            Project.SetProjectProperty(NodeProjectProperty.LaunchUrl, _control.LaunchUrl);
+            Project.SetProjectProperty(NodeProjectProperty.DebuggerPort, _control.DebuggerPort);
+            Project.SetProjectProperty(NodeProjectProperty.Environment, _control.Environment);
             IsDirty = false;
         }
 
         public override void LoadSettings() {
             Loading = true;
             try {
-                _control.NodeExeArguments = Project.GetUnevaluatedProperty(NodejsConstants.NodeExeArguments);
-                _control.NodeExePath = Project.GetUnevaluatedProperty(NodejsConstants.NodeExePath);
+                _control.NodeExeArguments = Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExeArguments);
+                _control.NodeExePath = Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExePath);
                 _control.ScriptFile = Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
-                _control.ScriptArguments = Project.GetUnevaluatedProperty(NodejsConstants.ScriptArguments);
+                _control.ScriptArguments = Project.GetUnevaluatedProperty(NodeProjectProperty.ScriptArguments);
                 _control.WorkingDirectory = Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
-                _control.LaunchUrl = Project.GetUnevaluatedProperty(NodejsConstants.LaunchUrl);
-                _control.NodejsPort = Project.GetUnevaluatedProperty(NodejsConstants.NodejsPort);
-                _control.DebuggerPort = Project.GetUnevaluatedProperty(NodejsConstants.DebuggerPort);
-                _control.Environment = Project.GetUnevaluatedProperty(NodejsConstants.Environment);
+                _control.LaunchUrl = Project.GetUnevaluatedProperty(NodeProjectProperty.LaunchUrl);
+                _control.NodejsPort = Project.GetUnevaluatedProperty(NodeProjectProperty.NodejsPort);
+                _control.DebuggerPort = Project.GetUnevaluatedProperty(NodeProjectProperty.DebuggerPort);
+                _control.Environment = Project.GetUnevaluatedProperty(NodeProjectProperty.Environment);
                 
                 // Attempt to parse the boolean.  If we fail, assume it is true.
                 bool startWebBrowser;
-                if (!Boolean.TryParse(Project.GetUnevaluatedProperty(NodejsConstants.StartWebBrowser), out startWebBrowser)) {
+                if (!Boolean.TryParse(Project.GetUnevaluatedProperty(NodeProjectProperty.StartWebBrowser), out startWebBrowser)) {
                     startWebBrowser = true;
                 }
                 _control.StartWebBrowser = startWebBrowser;

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NodejsTools.Project {
         public NodejsProjectLauncher(NodejsProjectNode project) {
             _project = project;
 
-            var portNumber = _project.GetProjectProperty(NodejsConstants.NodejsPort);
+            var portNumber = _project.GetProjectProperty(NodeProjectProperty.NodejsPort);
             int portNum;
             if (Int32.TryParse(portNumber, out portNum)) {
                 _testServerPort = portNum;
@@ -118,13 +118,13 @@ namespace Microsoft.NodejsTools.Project {
         private string GetFullArguments(string file, bool includeNodeArgs = true) {
             string res = String.Empty;
             if (includeNodeArgs) {
-                var nodeArgs = _project.GetProjectProperty(NodejsConstants.NodeExeArguments);
+                var nodeArgs = _project.GetProjectProperty(NodeProjectProperty.NodeExeArguments);
                 if (!String.IsNullOrWhiteSpace(nodeArgs)) {
                     res = nodeArgs + " ";
                 }
             }
             res += "\"" + file + "\"";
-            var scriptArgs = _project.GetProjectProperty(NodejsConstants.ScriptArguments);
+            var scriptArgs = _project.GetProjectProperty(NodeProjectProperty.ScriptArguments);
             if (!String.IsNullOrWhiteSpace(scriptArgs)) {
                 res += " " + scriptArgs;
             }
@@ -132,14 +132,14 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         private string GetNodePath() {
-            var overridePath = _project.GetProjectProperty(NodejsConstants.NodeExePath);
+            var overridePath = _project.GetProjectProperty(NodeProjectProperty.NodeExePath);
             return Nodejs.GetAbsoluteNodeExePath(_project.ProjectHome, overridePath);
         }
 
         #endregion
 
         private string GetFullUrl() {
-            var host = _project.GetProjectProperty(NodejsConstants.LaunchUrl);
+            var host = _project.GetProjectProperty(NodeProjectProperty.LaunchUrl);
 
             try {
                 return GetFullUrl(host, TestServerPort);
@@ -233,7 +233,7 @@ namespace Microsoft.NodejsTools.Project {
             dbgInfo.bstrCurDir = _project.GetWorkingDirectory();
             dbgInfo.bstrArg = GetFullArguments(startupFile, includeNodeArgs: false);    // we need to supply node args via options
             dbgInfo.bstrRemoteMachine = null;
-            var nodeArgs = _project.GetProjectProperty(NodejsConstants.NodeExeArguments);
+            var nodeArgs = _project.GetProjectProperty(NodeProjectProperty.NodeExeArguments);
             if (!String.IsNullOrWhiteSpace(nodeArgs)) {
                 AppendOption(ref dbgInfo, AD7Engine.InterpreterOptions, nodeArgs);
             }
@@ -243,7 +243,7 @@ namespace Microsoft.NodejsTools.Project {
                 AppendOption(ref dbgInfo, AD7Engine.WebBrowserUrl, url);
             }
 
-            var debuggerPort = _project.GetProjectProperty(NodejsConstants.DebuggerPort);
+            var debuggerPort = _project.GetProjectProperty(NodeProjectProperty.DebuggerPort);
             if (!String.IsNullOrWhiteSpace(debuggerPort)) {
                 AppendOption(ref dbgInfo, AD7Engine.DebuggerPort, debuggerPort);
             }
@@ -296,7 +296,7 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         private bool ShouldStartBrowser() {
-            var startBrowser = _project.GetProjectProperty(NodejsConstants.StartWebBrowser);
+            var startBrowser = _project.GetProjectProperty(NodeProjectProperty.StartWebBrowser);
             bool fStartBrowser;
             if (!String.IsNullOrEmpty(startBrowser) &&
                 Boolean.TryParse(startBrowser, out fStartBrowser)) {
@@ -307,7 +307,7 @@ namespace Microsoft.NodejsTools.Project {
         }
 
         private IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables() {
-            var envVars = _project.GetProjectProperty(NodejsConstants.Environment);
+            var envVars = _project.GetProjectProperty(NodeProjectProperty.Environment);
             if (envVars != null) {
                 foreach (var envVar in envVars.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
                     var nameValue = envVar.Split(new[] { '=' }, 2);

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -513,31 +513,31 @@ namespace Microsoft.NodejsTools.Project {
             var propPage = GeneralPropertyPageControl;
             if (propPage != null) {
                 switch (propertyName) {
-                    case NodejsConstants.Environment:
+                    case NodeProjectProperty.Environment:
                         propPage.Environment = newValue;
                         break;
-                    case NodejsConstants.DebuggerPort:
+                    case NodeProjectProperty.DebuggerPort:
                         propPage.DebuggerPort = newValue;
                         break;
-                    case NodejsConstants.NodejsPort:
+                    case NodeProjectProperty.NodejsPort:
                         propPage.NodejsPort = newValue;
                         break;
-                    case NodejsConstants.NodeExePath:
+                    case NodeProjectProperty.NodeExePath:
                         propPage.NodeExePath = newValue;
                         break;
-                    case NodejsConstants.NodeExeArguments:
+                    case NodeProjectProperty.NodeExeArguments:
                         propPage.NodeExeArguments = newValue;
                         break;
                     case CommonConstants.StartupFile:
                         propPage.ScriptFile = newValue;
                         break;
-                    case NodejsConstants.ScriptArguments:
+                    case NodeProjectProperty.ScriptArguments:
                         propPage.ScriptArguments = newValue;
                         break;
-                    case NodejsConstants.LaunchUrl:
+                    case NodeProjectProperty.LaunchUrl:
                         propPage.LaunchUrl = newValue;
                         break;
-                    case NodejsConstants.StartWebBrowser:
+                    case NodeProjectProperty.StartWebBrowser:
                         bool value;
                         if (Boolean.TryParse(newValue, out value)) {
                             propPage.StartWebBrowser = value;
@@ -950,7 +950,7 @@ namespace Microsoft.NodejsTools.Project {
                     NpmHelpers.GetPathToNpm(
                         Nodejs.GetAbsoluteNodeExePath(
                             ProjectHome,
-                            Project.GetNodejsProject().GetProjectProperty(NodejsConstants.NodeExePath)
+                            Project.GetNodejsProject().GetProjectProperty(NodeProjectProperty.NodeExePath)
                     ));
                 } catch (NpmNotFoundException) {
                     Nodejs.ShowNodejsNotInstalled();
@@ -966,7 +966,7 @@ namespace Microsoft.NodejsTools.Project {
                     NpmHelpers.GetPathToNpm(
                         Nodejs.GetAbsoluteNodeExePath(
                             ProjectHome,
-                            Project.GetNodejsProject().GetProjectProperty(NodejsConstants.NodeExePath)
+                            Project.GetNodejsProject().GetProjectProperty(NodeProjectProperty.NodeExePath)
                     ));
                 } catch (NpmNotFoundException) {
                     Nodejs.ShowNodejsNotInstalled();

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNodeProperties.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNodeProperties.cs
@@ -62,12 +62,12 @@ namespace Microsoft.NodejsTools.Project {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
                     return Nodejs.GetAbsoluteNodeExePath(
                         ProjectHome,
-                        Node.ProjectMgr.GetProjectProperty(NodejsConstants.NodeExePath, true));
+                        Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.NodeExePath, true));
                 });
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.NodeExePath, value);
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.NodeExePath, value);
                 });
             }
         }
@@ -78,12 +78,12 @@ namespace Microsoft.NodejsTools.Project {
         public string NodeExeArguments {
             get {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    return this.Node.ProjectMgr.GetProjectProperty(NodejsConstants.NodeExeArguments, true);
+                    return this.Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.NodeExeArguments, true);
                 });
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.NodeExeArguments, value);
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.NodeExeArguments, value);
                 });
             }
         }
@@ -94,12 +94,12 @@ namespace Microsoft.NodejsTools.Project {
         public string ScriptArguments {
             get {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    return this.Node.ProjectMgr.GetProjectProperty(NodejsConstants.ScriptArguments, true);
+                    return this.Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.ScriptArguments, true);
                 });
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.ScriptArguments, value);
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.ScriptArguments, value);
                 });
             }
         }
@@ -111,7 +111,7 @@ namespace Microsoft.NodejsTools.Project {
             get {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke((Func<int?>)(() => {
                     int port;
-                    if (Int32.TryParse(Node.ProjectMgr.GetProjectProperty(NodejsConstants.NodejsPort, true), out port)) {
+                    if (Int32.TryParse(Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.NodejsPort, true), out port)) {
                         return port;
                     }
                     return null;
@@ -119,7 +119,7 @@ namespace Microsoft.NodejsTools.Project {
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.NodejsPort, value != null ? value.ToString() : String.Empty);
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.NodejsPort, value != null ? value.ToString() : String.Empty);
                 });
             }
         }
@@ -130,12 +130,12 @@ namespace Microsoft.NodejsTools.Project {
         public string LaunchUrl {
             get {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    return this.Node.ProjectMgr.GetProjectProperty(NodejsConstants.LaunchUrl, true);
+                    return this.Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.LaunchUrl, true);
                 });
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.LaunchUrl, value);
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.LaunchUrl, value);
                 });
             }
         }
@@ -147,7 +147,7 @@ namespace Microsoft.NodejsTools.Project {
             get {
                 return HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
                     bool res;
-                    if (Boolean.TryParse(Node.ProjectMgr.GetProjectProperty(NodejsConstants.StartWebBrowser, true), out res)) {
+                    if (Boolean.TryParse(Node.ProjectMgr.GetProjectProperty(NodeProjectProperty.StartWebBrowser, true), out res)) {
                         return res;
                     }
                     return true;
@@ -155,7 +155,7 @@ namespace Microsoft.NodejsTools.Project {
             }
             set {
                 HierarchyNode.ProjectMgr.Site.GetUIThread().Invoke(() => {
-                    Node.ProjectMgr.SetProjectProperty(NodejsConstants.StartWebBrowser, value.ToString());
+                    Node.ProjectMgr.SetProjectProperty(NodeProjectProperty.StartWebBrowser, value.ToString());
                 });
             }
         }

--- a/Nodejs/Product/Nodejs/Repl/NodejsReplEvaluator.cs
+++ b/Nodejs/Product/Nodejs/Repl/NodejsReplEvaluator.cs
@@ -188,7 +188,7 @@ namespace Microsoft.NodejsTools.Repl {
             if (startupProject != null) {
                 nodeExePath = Nodejs.GetAbsoluteNodeExePath(
                     startupProject.ProjectHome,
-                    startupProject.GetProjectProperty(NodejsConstants.NodeExePath)
+                    startupProject.GetProjectProperty(NodeProjectProperty.NodeExePath)
                 );
             } else {
                 nodeExePath = Nodejs.NodeExePath;

--- a/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
+++ b/Nodejs/Product/Nodejs/Repl/NpmReplCommand.cs
@@ -146,7 +146,7 @@ namespace Microsoft.NodejsTools.Repl {
                     nodejsProject != null ?
                         Nodejs.GetAbsoluteNodeExePath(
                             nodejsProject.ProjectHome,
-                            nodejsProject.GetProjectProperty(NodejsConstants.NodeExePath))
+                            nodejsProject.GetProjectProperty(NodeProjectProperty.NodeExePath))
                         : null);
             } catch (NpmNotFoundException) {
                 Nodejs.ShowNodejsNotInstalled();

--- a/Nodejs/Product/TestAdapter/TestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscoverer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
             var nodeExePath =
                 Nodejs.GetAbsoluteNodeExePath(
                     projectHome,
-                    proj.GetPropertyValue(NodejsConstants.NodeExePath));
+                    proj.GetPropertyValue(NodeProjectProperty.NodeExePath));
 
             if (!File.Exists(nodeExePath)) {
                 logger.SendMessage(TestMessageLevel.Error, string.Format(CultureInfo.CurrentCulture, "Node.exe was not found.  Please install Node.js before running tests."));

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -240,7 +240,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
             projSettings.NodeExePath =
                 Nodejs.GetAbsoluteNodeExePath(
                     projectRootDir,
-                    proj.GetPropertyValue(NodejsConstants.NodeExePath));
+                    proj.GetPropertyValue(NodeProjectProperty.NodeExePath));
 
             return projSettings;
         }

--- a/Nodejs/Tests/Core.UI/DebuggerUITests.cs
+++ b/Nodejs/Tests/Core.UI/DebuggerUITests.cs
@@ -112,7 +112,7 @@ process.exit(" + exitCode + ");"),
             var project = Project("NoDebugging",
                 Compile("server"),
                 Property(CommonConstants.StartupFile, "server.js"),
-                Property(NodejsConstants.NodeExeArguments, "-v")
+                Property(NodeProjectProperty.NodeExeArguments, "-v")
             );
 
             using (var solution = project.Generate().ToVs()) {

--- a/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/NodejsBasicProjectTests.cs
@@ -111,7 +111,7 @@ while(true) {{
 
             var project = Project("DebuggerPort",
                 Compile("server", code),
-                Property(NodejsConstants.DebuggerPort, "1234"),
+                Property(NodeProjectProperty.DebuggerPort, "1234"),
                 Property(CommonConstants.StartupFile, "server.js")
             );
 
@@ -144,7 +144,7 @@ while(true) {{
 
             var project = Project("EnvironmentVariables",
                 Compile("server", code),
-                Property(NodejsConstants.Environment, "fob=1\nbar=2;3\r\nbaz=4"),
+                Property(NodeProjectProperty.Environment, "fob=1\nbar=2;3\r\nbaz=4"),
                 Property(CommonConstants.StartupFile, "server.js")
             );
 
@@ -176,7 +176,7 @@ require('fs').writeFileSync('{0}', process.env.fob + process.env.bar + process.e
 
             var project = Project("EnvironmentVariables",
                 Compile("server", code),
-                Property(NodejsConstants.Environment, "fob=1\nbar=2;3\r\nbaz=4"),
+                Property(NodeProjectProperty.Environment, "fob=1\nbar=2;3\r\nbaz=4"),
                 Property(CommonConstants.StartupFile, "server.js")
             );
 
@@ -202,8 +202,8 @@ require('fs').writeFileSync('{0}', process.env.fob + process.env.bar + process.e
 
             var project = Project("ProjectProperties",
                 Compile("server"),
-                Property(NodejsConstants.Environment, "fob=1\r\nbar=2;3\nbaz=4"),
-                Property(NodejsConstants.DebuggerPort, "1234"),
+                Property(NodeProjectProperty.Environment, "fob=1\r\nbar=2;3\nbaz=4"),
+                Property(NodeProjectProperty.DebuggerPort, "1234"),
                 Property(CommonConstants.StartupFile, "server.js")
             );
 


### PR DESCRIPTION
**Bug**
Constants for accessing Node.js project properties are currently defined in `NodejsConstants`. That's a pretty poor class name, and can easily lead to these properties being misused.

**Fix**
Move the project property constants into a new `NodeProjectProperty` class. All Mechanical refactoring with VS' rename function.