### PR TITLE
Extract more strings to resource files

### DIFF
--- a/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
+++ b/Nodejs/Product/Nodejs/Commands/AzureExplorerAttachDebuggerCommand.cs
@@ -80,10 +80,7 @@ namespace Microsoft.NodejsTools.Commands {
             Action<Task<bool>> onAttach = null;
             onAttach = (attachTask) => {
                 if (!attachTask.Result) {
-                    string msg = string.Format(CultureInfo.CurrentCulture,
-                        "Could not attach to node.exe process on Azure Website at {0}.\r\n\r\n" +
-                        "Error retrieving websocket debug proxy information from web.config.",
-                        webSite.Uri);
+                    string msg = Project.SR.GetString(Project.SR.AzureRemoteDebugCouldNotAttachToWebsiteErrorMessage, webSite.Uri);
                     if (MessageBox.Show(msg, null, MessageBoxButtons.RetryCancel, MessageBoxIcon.Error) == DialogResult.Retry) {
                         AttachWorker(webSite).ContinueWith(onAttach);
                     }
@@ -188,7 +185,11 @@ namespace Microsoft.NodejsTools.Commands {
         }
 
         private async Task<bool> AttachWorker(AzureWebSiteInfo webSite) {
-            using (new WaitDialog("Azure remote debugging", "Attaching to Azure Website at " + webSite.Uri, NodejsPackage.Instance, showProgress: true)) {
+            using (new WaitDialog(
+                Project.SR.GetString(Project.SR.AzureRemoteDebugWaitCaption),
+                Project.SR.GetString(Project.SR.AzureRemoteDebugWaitMessage, webSite.Uri),
+                NodejsPackage.Instance,
+                showProgress: true)) {
                 // Get path (relative to site URL) for the debugger endpoint.
                 XDocument webConfig;
                 try {
@@ -223,7 +224,7 @@ namespace Microsoft.NodejsTools.Commands {
                     // ask the user to retry, so the only case where we actually get here is if user canceled on error. If this is the case,
                     // we don't want to pop any additional error messages, so always return true, but log the error in the Output window.
                     var output = OutputWindowRedirector.GetGeneral(NodejsPackage.Instance);
-                    output.WriteErrorLine("Failed to attach to Azure Website: " + ex.Message);
+                    output.WriteErrorLine(Project.SR.GetString(Project.SR.AzureRemoveDebugCouldNotAttachToWebsiteExceptionErrorMessage, ex.Message));
                     output.ShowAndActivate();
                 }
                 return true;

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/Remote/NodeRemoteEnumDebugProcesses.cs
@@ -126,7 +126,7 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                 } catch (PlatformNotSupportedException) {
                     LiveLogger.WriteLine("PlatformNotSupportedException connecting to remote debugger");
                     MessageBox.Show(
-                        "Remote debugging of node.js Microsoft Azure applications is only supported on Windows 8 and above.",
+                        Project.SR.GetString(Project.SR.RemoteDebugUnsupportedPlatformErrorMessage),
                         null, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return null;
                 }
@@ -137,20 +137,14 @@ namespace Microsoft.NodejsTools.Debugger.Remote {
                     }
                 }
 
-                string errText = string.Format(CultureInfo.CurrentCulture,
-                    "Could not attach to Node.js process at {0}{1}\r\n\r\n",
+                string errText = Project.SR.GetString(Project.SR.RemoteDebugCouldNotAttachErrorMessage,
                     port.Uri,
                     exception != null ? ":\r\n\r\n" + exception.Message : ".");
                 if (!(exception is DebuggerAlreadyAttachedException)) {
                     if (port.Uri.Scheme == "ws" || port.Uri.Scheme == "wss") {
-                        errText +=
-                            "Make sure that the Azure web site is deployed in the Debug configuration, and web sockets " +
-                            "are enabled for it in the Azure management portal.";
+                        errText += Project.SR.GetString(Project.SR.RemoteDebugEnableWebSocketsErrorMessage);
                     } else {
-                        errText += string.Format(CultureInfo.CurrentCulture,
-                            "Make sure that the process is running behind the remote debug proxy (RemoteDebug.js), " +
-                            "and the debugger port (default {0}) is open on the target host.",
-                            NodejsConstants.DefaultDebuggerPort);
+                        errText += Project.SR.GetString(Project.SR.RemoteDebugCheckProxyAndPortErrorMessage, NodejsConstants.DefaultDebuggerPort);
                     }
                 }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -192,9 +192,9 @@ namespace Microsoft.NodejsTools.Project {
 
         private void LaunchDebugger(IServiceProvider provider, VsDebugTargetInfo dbgInfo) {
             if (!Directory.Exists(dbgInfo.bstrCurDir)) {
-                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, "Working directory \"{0}\" does not exist.", dbgInfo.bstrCurDir), SR.ProductName);
+                MessageBox.Show(SR.GetString(SR.DebugWorkingDirectoryDoesNotExistErrorMessage, dbgInfo.bstrCurDir), SR.ProductName);
             } else if (!File.Exists(dbgInfo.bstrExe)) {
-                MessageBox.Show(string.Format(CultureInfo.CurrentCulture, "Interpreter \"{0}\" does not exist.", dbgInfo.bstrExe), SR.ProductName);
+                MessageBox.Show(SR.GetString(SR.DebugInterpreterDoesNotExistErrorMessage, dbgInfo.bstrExe), SR.ProductName);
             } else if (DoesProjectSupportDebugging()) {
                 VsShellUtilities.LaunchDebugger(provider, dbgInfo);
             }
@@ -204,8 +204,7 @@ namespace Microsoft.NodejsTools.Project {
             var typeScriptOutFile = _project.GetProjectProperty("TypeScriptOutFile");
             if (!string.IsNullOrEmpty(typeScriptOutFile)) {
                 return MessageBox.Show(
-                    "This TypeScript project has 'Combine Javascript output into file' option enabled. This option is not supported by NTVS debugger, " +
-                    "and may result in erratic behavior of breakpoints, stepping, and debug tool windows. Are you sure you want to start debugging?",
+                    SR.GetString(SR.DebugTypeScriptCombineNotSupportedWarningMessage),
                     SR.ProductName,
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning
@@ -328,7 +327,7 @@ namespace Microsoft.NodejsTools.Project {
         private string ResolveStartupFile() {
             string startupFile = _project.GetStartupFile();
             if (string.IsNullOrEmpty(startupFile)) {
-                throw new ApplicationException("Please select a startup file to launch by right-clicking the file in Solution Explorer and selecting 'Set as Node.js Startup File' or by modifying your configuration in project properties.");
+                throw new ApplicationException(SR.GetString(SR.DebugCouldNotResolveStartupFileErrorMessage));
             }
 
             if (TypeScriptHelpers.IsTypeScriptFile(startupFile)) {

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -37,6 +37,10 @@ namespace Microsoft.NodejsTools.Project {
         internal const string CategoryStatus = "CategoryStatus";
         internal const string CategoryVersion = "CategoryVersion";
         internal const string ContinueWithoutAzureToolsUpgrade = "ContinueWithoutAzureToolsUpgrade";
+        internal const string DebugCouldNotResolveStartupFileErrorMessage = "DebugCouldNotResolveStartupFileErrorMessage";
+        internal const string DebugWorkingDirectoryDoesNotExistErrorMessage = "DebugWorkingDirectoryDoesNotExistErrorMessage";
+        internal const string DebugInterpreterDoesNotExistErrorMessage = "DebugInterpreterDoesNotExistErrorMessage";
+        internal const string DebugTypeScriptCombineNotSupportedWarningMessage = "DebugTypeScriptCombineNotSupportedWarningMessage";
         internal const string DebuggerConnectionClosed = "DebuggerConnectionClosed";
         internal const string DebuggerModuleUpdateFailed = "DebuggerModuleUpdateFailed";
         internal const string DebuggerPort = "DebuggerPort";

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -52,6 +52,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string ImportingProjectErrorStatusText = "ImportingProjectErrorStatusText";
         internal const string ImportingProjectStatusText = "ImportingProjectStatusText";
         internal const string ImportingProjectUnexpectedErrorMessage = "ImportingProjectUnexpectedErrorMessage";
+        internal const string ImportWizzardCouldNotStartNotAutomationObjectErrorMessage = "ImportWizzardCouldNotStartNotAutomationObjectErrorMessage";
         internal const string IncludeNodeModulesCancelTitle = "IncludeNodeModulesCancelTitle";
         internal const string IncludeNodeModulesContent = "IncludeNodeModulesContent";
         internal const string IncludeNodeModulesIncludeDescription = "IncludeNodeModulesIncludeDescription";

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -23,20 +23,19 @@ namespace Microsoft.NodejsTools.Project {
     internal class SR : CommonSR {
         internal const string NodejsToolsForVisualStudio = "NodejsToolsForVisualStudio";
 
-        internal const string NodeModulesCouldNotParsePackageJsonErrorMessageText = "NodeModulesCouldNotParsePackageJsonErrorMessageText";
-        internal const string NpmNotInstalledMessageText = "NpmNotInstalledMessageText";
-        internal const string NpmNotInstalledMessageCaption = "NpmNotInstalledMessageCaption";
-        internal const string ImportingProjectAccessErrorStatusText = "ImportingProjectAccessErrorStatusText";
-        internal const string ImportingProjectUnexpectedErrorMessage = "ImportingProjectUnexpectedErrorMessage";
+        internal const string AzureRemoteDebugCouldNotAttachToWebsiteErrorMessage = "AzureRemoveDebugCouldNotAttachToWebsiteErrorMessage";
+        internal const string AzureRemoteDebugWaitCaption = "AzureRemoteDebugWaitCaption";
+        internal const string AzureRemoteDebugWaitMessage = "AzureRemoteDebugWaitMessage";
+        internal const string AzureRemoveDebugCouldNotAttachToWebsiteExceptionErrorMessage = "AzureRemoveDebugCouldNotAttachToWebsiteExceptionErrorMessage";
         internal const string AzureToolsInstallInstructions = "AzureToolsInstallInstructions";
         internal const string AzureToolsRequired = "AzureToolsRequired";
         internal const string AzureToolsUpgradeInstructions = "AzureToolsUpgradeInstructions";
         internal const string AzureToolsUpgradeRecommended = "AzureToolsUpgradeRecommended";
+        internal const string CacheDirectoryClearFailedCaption = "CacheDirectoryClearFailedCaption";
+        internal const string CacheDirectoryClearFailedTitle = "CacheDirectoryClearFailedTitle";
         internal const string CatalogLoadingDefault = "CatalogLoadingDefault";
         internal const string CategoryStatus = "CategoryStatus";
         internal const string CategoryVersion = "CategoryVersion";
-        internal const string CacheDirectoryClearFailedTitle = "CacheDirectoryClearFailedTitle";
-        internal const string CacheDirectoryClearFailedCaption = "CacheDirectoryClearFailedCaption";
         internal const string ContinueWithoutAzureToolsUpgrade = "ContinueWithoutAzureToolsUpgrade";
         internal const string DebuggerConnectionClosed = "DebuggerConnectionClosed";
         internal const string DebuggerModuleUpdateFailed = "DebuggerModuleUpdateFailed";
@@ -45,16 +44,18 @@ namespace Microsoft.NodejsTools.Project {
         internal const string DownloadAndInstall = "DownloadAndInstall";
         internal const string EnvironmentVariables = "EnvironmentVariables";
         internal const string ErrorNoDte = "ErrorNoDte";
-        internal const string ImportingProjectStatusText = "ImportingProjectStatusText";
+        internal const string ImportingProjectAccessErrorStatusText = "ImportingProjectAccessErrorStatusText";
         internal const string ImportingProjectErrorStatusText = "ImportingProjectErrorStatusText";
+        internal const string ImportingProjectStatusText = "ImportingProjectStatusText";
+        internal const string ImportingProjectUnexpectedErrorMessage = "ImportingProjectUnexpectedErrorMessage";
         internal const string IncludeNodeModulesCancelTitle = "IncludeNodeModulesCancelTitle";
         internal const string IncludeNodeModulesContent = "IncludeNodeModulesContent";
         internal const string IncludeNodeModulesIncludeDescription = "IncludeNodeModulesIncludeDescription";
         internal const string IncludeNodeModulesIncludeTitle = "IncludeNodeModulesIncludeTitle";
         internal const string IncludeNodeModulesInformation = "IncludeNodeModulesInformation";
-        internal const string InteractiveWindowProcessExitedMessage = "InteractiveWindowProcessExitedMessage";
         internal const string InteractiveWindowFailedToStartProcessErrorMessage = "InteractiveWindowFailedToStartProcessErrorMessage";
         internal const string InteractiveWindowNoProcessErrorMessage = "InteractiveWindowNoProcessErrorMessage";
+        internal const string InteractiveWindowProcessExitedMessage = "InteractiveWindowProcessExitedMessage";
         internal const string InteractiveWindowTitle = "InteractiveWindowTitle";
         internal const string InvalidPortNumber = "InvalidPortNumber";
         internal const string LaunchUrlToolTip = "LaunchUrlToolTip";
@@ -81,6 +82,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string NodeExePathDescription = "NodeExePathDescription";
         internal const string NodeExePathNotFound = "NodeExePathNotFound";
         internal const string NodeExePathToolTip = "NodeExePathToolTip";
+        internal const string NodeModulesCouldNotParsePackageJsonErrorMessageText = "NodeModulesCouldNotParsePackageJsonErrorMessageText";
         internal const string NodejsNotInstalled = "NodejsNotInstalled";
         internal const string NodejsNotInstalledShort = "NodejsNotInstalledShort";
         internal const string NodejsNotSupported = "NodejsNotSupported";
@@ -94,6 +96,8 @@ namespace Microsoft.NodejsTools.Project {
         internal const string NpmNodePackageInstallationDescription = "NpmNodePackageInstallationDescription";
         internal const string NpmNodePath = "NpmNodePath";
         internal const string NpmNodePathDescription = "NpmNodePathDescription";
+        internal const string NpmNotInstalledMessageCaption = "NpmNotInstalledMessageCaption";
+        internal const string NpmNotInstalledMessageText = "NpmNotInstalledMessageText";
         internal const string NpmOutputPaneTitle = "NpmOutputPaneTitle";
         internal const string NpmPackageAuthor = "NpmPackageAuthor";
         internal const string NpmPackageAuthorDescription = "NpmPackageAuthorDescription";
@@ -150,8 +154,12 @@ namespace Microsoft.NodejsTools.Project {
         internal const string PropertiesClassLocalPackage = "PropertiesClassLocalPackage";
         internal const string PropertiesClassLocalSubPackage = "PropertiesClassLocalSubPackage";
         internal const string PropertiesClassNpm = "PropertiesClassNpm";
+        internal const string RemoteDebugCheckProxyAndPortErrorMessage = "RemoteDebugCheckProxyAndPortErrorMessage";
+        internal const string RemoteDebugCouldNotAttachErrorMessage = "RemoteDebugCouldNotAttachErrorMessage";
+        internal const string RemoteDebugEnableWebSocketsErrorMessage = "RemoteDebugEnableWebSocketsErrorMessage";
         internal const string RemoteDebugProxyFileDoesNotExist = "RemoteDebugProxyFileDoesNotExist";
         internal const string RemoteDebugProxyFolderDoesNotExist = "RemoteDebugProxyFolderDoesNotExist";
+        internal const string RemoteDebugUnsupportedPlatformErrorMessage = "RemoteDebugUnsupportedPlatformErrorMessage";
         internal const string ReplInitializationMessage = "ReplInitializationMessage";
         internal const string ReplWindowNpmInitNoYesFlagWarning = "ReplWindowNpmInitNoYesFlagWarning";
         internal const string RequestedVersionRangeNone = "RequestedVersionRangeNone";
@@ -162,11 +170,11 @@ namespace Microsoft.NodejsTools.Project {
         internal const string StatusTypingsLoading = "StatusTypingsLoading";
         internal const string TestFramework = "TestFramework";
         internal const string TestFrameworkDescription = "TestFrameworkDescription";
+        internal const string TypeScriptMinVersionNotInstalled = "TypeScriptMinVersionNotInstalled";
         internal const string TypingsInfoBarSpan1 = "TypingsInfoBarSpan1";
         internal const string TypingsInfoBarSpan2 = "TypingsInfoBarSpan2";
         internal const string TypingsInfoBarSpan3 = "TypingsInfoBarSpan3";
         internal const string TypingsOpenOptionsText = "TypingsOpenOptionsText";
-        internal const string TypeScriptMinVersionNotInstalled = "TypeScriptMinVersionNotInstalled";
         internal const string TypingsToolCouldNotStart = "TypingsToolCouldNotStart";
         internal const string TypingsToolInstallFailed = "TypingsToolInstallFailed";
         internal const string TypingsToolNotInstalledError = "TypingsToolNotInstalledError";
@@ -175,6 +183,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string UpgradedEnvironmentVariables = "UpgradedEnvironmentVariables";
         internal const string WorkingDirInvalidOrMissing = "WorkingDirInvalidOrMissing";
         internal const string WorkingDirToolTip = "WorkingDirToolTip";
+
         private static readonly Lazy<ResourceManager> _manager = new Lazy<ResourceManager>(
             () => new System.Resources.ResourceManager("Microsoft.NodejsTools.Resources", typeof(SR).Assembly),
             LazyThreadSafetyMode.ExecutionAndPublication

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -620,4 +620,16 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="RemoteDebugUnsupportedPlatformErrorMessage" xml:space="preserve">
     <value>Remote debugging of node.js Microsoft Azure applications is only supported on Windows 8 and above.</value>
   </data>
+  <data name="DebugCouldNotResolveStartupFileErrorMessage" xml:space="preserve">
+    <value>Please select a startup file to launch by right-clicking the file in Solution Explorer and selecting 'Set as Node.js Startup File' or by modifying your configuration in project properties</value>
+  </data>
+  <data name="DebugInterpreterDoesNotExistErrorMessage" xml:space="preserve">
+    <value>Interpreter "{0}" does not exist.</value>
+  </data>
+  <data name="DebugTypeScriptCombineNotSupportedWarningMessage" xml:space="preserve">
+    <value>This TypeScript project has 'Combine Javascript output into file' option enabled. This option is not supported by NTVS debugger, and may result in erratic behavior of breakpoints, stepping, and debug tool windows. Are you sure you want to start debugging?</value>
+  </data>
+  <data name="DebugWorkingDirectoryDoesNotExistErrorMessage" xml:space="preserve">
+    <value>Working directory "{0}" does not exist.</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -592,4 +592,32 @@ The following error occurred trying to execute npm.cmd:
 
 {0}</value>
   </data>
+  <data name="AzureRemoteDebugWaitCaption" xml:space="preserve">
+    <value>Azure remote debugging</value>
+  </data>
+  <data name="AzureRemoteDebugWaitMessage" xml:space="preserve">
+    <value>Attaching to Azure Website at {0}</value>
+  </data>
+  <data name="AzureRemoveDebugCouldNotAttachToWebsiteErrorMessage" xml:space="preserve">
+    <value>Could not attach to node.exe process on Azure Website at {0}.
+
+Error retrieving websocket debug proxy information from web.config.</value>
+  </data>
+  <data name="AzureRemoveDebugCouldNotAttachToWebsiteExceptionErrorMessage" xml:space="preserve">
+    <value>Failed to attach to Azure Website: {0}</value>
+  </data>
+  <data name="RemoteDebugCheckProxyAndPortErrorMessage" xml:space="preserve">
+    <value>Make sure that the process is running behind the remote debug proxy (RemoteDebug.js), and the debugger port (default {0}) is open on the target host.</value>
+  </data>
+  <data name="RemoteDebugCouldNotAttachErrorMessage" xml:space="preserve">
+    <value>Could not attach to Node.js process at {0}{1}
+
+</value>
+  </data>
+  <data name="RemoteDebugEnableWebSocketsErrorMessage" xml:space="preserve">
+    <value>Make sure that the Azure web site is deployed in the Debug configuration, and web sockets are enabled for it in the Azure management portal.</value>
+  </data>
+  <data name="RemoteDebugUnsupportedPlatformErrorMessage" xml:space="preserve">
+    <value>Remote debugging of node.js Microsoft Azure applications is only supported on Windows 8 and above.</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -632,4 +632,7 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="DebugWorkingDirectoryDoesNotExistErrorMessage" xml:space="preserve">
     <value>Working directory "{0}" does not exist.</value>
   </data>
+  <data name="ImportWizzardCouldNotStartNotAutomationObjectErrorMessage" xml:space="preserve">
+    <value>Unable to start wizard: no automation object available.</value>
+  </data>
 </root>

--- a/Nodejs/Product/ProjectWizard/ImportWizard.cs
+++ b/Nodejs/Product/ProjectWizard/ImportWizard.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TemplateWizard;
+using Microsoft.NodejsTools.Project;
 
 namespace Microsoft.NodejsTools.ProjectWizard {
     public sealed class NewProjectFromExistingWizard : IWizard {
@@ -44,7 +45,7 @@ namespace Microsoft.NodejsTools.ProjectWizard {
 
             bool addingNewProject = false;
             if (dte == null) {
-                MessageBox.Show("Unable to start wizard: no automation object available.", "Node.js Tools for Visual Studio");
+                MessageBox.Show(SR.GetString(SR.ImportWizzardCouldNotStartNotAutomationObjectErrorMessage), SR.ProductName);
             } else {
                 // https://nodejstools.codeplex.com/workitem/462
                 // we need to make sure our package is loaded before invoking our command


### PR DESCRIPTION
**Bug**
Hardcoded UI strings in the code instead of in resource files. This prevents localization.

**Fix**
Extracting more of these strings to resource files. This change focuses on strings used in `MessageBox.Show`