### PR TITLE
Extract More Project Property Keys to Own Class

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -47,14 +47,9 @@ namespace Microsoft.NodejsTools {
 
         internal const string BaseRegistryKey = "NodejsTools";
 
-        internal const string TypeScriptCfgProperty = "CfgPropertyPagesGuidsAddTypeScript";
-
         internal const ushort DefaultDebuggerPort = 5858;
 
         internal const string TypeScriptCompileItemType = "TypeScriptCompile";
-        internal const string EnableTypeScript = "EnableTypeScript";
-        internal const string TypeScriptSourceMap = "TypeScriptSourceMap";
-        internal const string TypeScriptModuleKind = "TypeScriptModuleKind";
         internal const string CommonJSModuleKind = "CommonJS";
         internal const string TypeScript = "TypeScript";
 
@@ -98,15 +93,20 @@ namespace Microsoft.NodejsTools {
         }
     }
 
-    internal class NodeProjectProperty {
+    internal static class NodeProjectProperty {
         internal const string DebuggerPort = "DebuggerPort";
+        internal const string EnableTypeScript = "EnableTypeScript";
         internal const string Environment = "Environment";
         internal const string EnvironmentVariables = "EnvironmentVariables";
         internal const string LaunchUrl = "LaunchUrl";
-        internal const string NodeExePath = "NodeExePath";
         internal const string NodeExeArguments = "NodeExeArguments";
+        internal const string NodeExePath = "NodeExePath";
         internal const string NodejsPort = "NodejsPort";
         internal const string ScriptArguments = "ScriptArguments";
         internal const string StartWebBrowser = "StartWebBrowser";
+        internal const string TypeScriptCfgProperty = "CfgPropertyPagesGuidsAddTypeScript";
+        internal const string TypeScriptModuleKind = "TypeScriptModuleKind";
+        internal const string TypeScriptOutDir = "TypeScriptOutDir";
+        internal const string TypeScriptSourceMap = "TypeScriptSourceMap";
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -242,7 +242,7 @@ namespace Microsoft.NodejsTools.Project {
 
         public bool IsTypeScriptProject {
             get {
-                return string.Equals(GetProjectProperty(NodejsConstants.EnableTypeScript), "true", StringComparison.OrdinalIgnoreCase);
+                return string.Equals(GetProjectProperty(NodeProjectProperty.EnableTypeScript), "true", StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -314,14 +314,14 @@ namespace Microsoft.NodejsTools.Project {
 
             if (IsProjectTypeScriptSourceFile(fileName) && !IsTypeScriptProject) {
                 // enable TypeScript on the project automatically...
-                SetProjectProperty(NodejsConstants.EnableTypeScript, "true");
-                SetProjectProperty(NodejsConstants.TypeScriptSourceMap, "true");
+                SetProjectProperty(NodeProjectProperty.EnableTypeScript, "true");
+                SetProjectProperty(NodeProjectProperty.TypeScriptSourceMap, "true");
 #if DEV14
                 // Reset cached value, so it will be recalculated later.
                 this.shouldAcquireTypingsAutomatically = false;
 #endif
-                if (String.IsNullOrWhiteSpace(GetProjectProperty(NodejsConstants.TypeScriptModuleKind))) {
-                    SetProjectProperty(NodejsConstants.TypeScriptModuleKind, NodejsConstants.CommonJSModuleKind);
+                if (String.IsNullOrWhiteSpace(GetProjectProperty(NodeProjectProperty.TypeScriptModuleKind))) {
+                    SetProjectProperty(NodeProjectProperty.TypeScriptModuleKind, NodejsConstants.CommonJSModuleKind);
                 }
             }
         }
@@ -425,10 +425,10 @@ namespace Microsoft.NodejsTools.Project {
         protected override Guid[] GetConfigurationDependentPropertyPages() {
             var res = base.GetConfigurationDependentPropertyPages();
 
-            var enableTs = GetProjectProperty(NodejsConstants.EnableTypeScript, resetCache: false);
+            var enableTs = GetProjectProperty(NodeProjectProperty.EnableTypeScript, resetCache: false);
             bool fEnableTs;
             if (enableTs != null && Boolean.TryParse(enableTs, out fEnableTs) && fEnableTs) {
-                var typeScriptPages = GetProjectProperty(NodejsConstants.TypeScriptCfgProperty);
+                var typeScriptPages = GetProjectProperty(NodeProjectProperty.TypeScriptCfgProperty);
                 if (typeScriptPages != null) {
                     foreach (var strGuid in typeScriptPages.Split(';')) {
                         Guid guid;

--- a/Nodejs/Product/Profiling/NodejsProfilingPackage.cs
+++ b/Nodejs/Product/Profiling/NodejsProfilingPackage.cs
@@ -279,14 +279,14 @@ namespace Microsoft.NodejsTools.Profiling {
                 return;
             }
             
-            var interpreterArgs = (string)projectToProfile.Properties.Item("NodeExeArguments").Value;
-            var scriptArgs = (string)projectToProfile.Properties.Item("ScriptArguments").Value;
-            var startBrowser = (bool)projectToProfile.Properties.Item("StartWebBrowser").Value;
-            string launchUrl = (string)projectToProfile.Properties.Item("LaunchUrl").Value;
+            var interpreterArgs = (string)projectToProfile.Properties.Item(NodeProjectProperty.NodeExeArguments).Value;
+            var scriptArgs = (string)projectToProfile.Properties.Item(NodeProjectProperty.ScriptArguments).Value;
+            var startBrowser = (bool)projectToProfile.Properties.Item(NodeProjectProperty.StartWebBrowser).Value;
+            string launchUrl = (string)projectToProfile.Properties.Item(NodeProjectProperty.LaunchUrl).Value;
 
-            int? port = (int?)projectToProfile.Properties.Item("NodejsPort").Value;
+            int? port = (int?)projectToProfile.Properties.Item(NodeProjectProperty.NodejsPort).Value;
 
-            string interpreterPath = (string)projectToProfile.Properties.Item("NodeExePath").Value;
+            string interpreterPath = (string)projectToProfile.Properties.Item(NodeProjectProperty.NodeExePath).Value;
 
             string startupFile = (string)projectToProfile.Properties.Item("StartupFile").Value;
             if (String.IsNullOrEmpty(startupFile)) {

--- a/Nodejs/Product/Profiling/Profiling.csproj
+++ b/Nodejs/Product/Profiling/Profiling.csproj
@@ -106,6 +106,9 @@
     <Compile Include="..\Nodejs\Guids.cs">
       <Link>Guids.cs</Link>
     </Compile>
+    <Compile Include="..\Nodejs\NodejsConstants.cs">
+      <Link>NodejsConstants.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DialogWindowVersioningWorkaround.cs" />
     <Compile Include="NativeMethods.cs" />

--- a/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
+++ b/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NodejsTools.TypeScript {
         }
 
         internal static string GetTypeScriptBackedJavaScriptFile(MSBuild.Project project, string pathToFile) {
-            var typeScriptOutDir = project.GetPropertyValue("TypeScriptOutDir");
+            var typeScriptOutDir = project.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir);
             return GetTypeScriptBackedJavaScriptFile(project.DirectoryPath, typeScriptOutDir, pathToFile);
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.NodejsTools.TypeScript {
             //Need to deal with the format being relative and explicit
             IVsBuildPropertyStorage props = (IVsBuildPropertyStorage)project;
             String outDir;
-            ErrorHandler.ThrowOnFailure(props.GetPropertyValue("TypeScriptOutDir", null, 0, out outDir));
+            ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, 0, out outDir));
 
             string projHome = GetProjectHome(project);
 

--- a/Nodejs/Tests/Core.UI/BasicProjectTests.cs
+++ b/Nodejs/Tests/Core.UI/BasicProjectTests.cs
@@ -552,25 +552,25 @@ namespace Microsoft.Nodejs.Tests.UI {
 
                 Assert.AreEqual(project.Properties.DTE, app.Dte);
 
-                Assert.AreEqual(project.Properties.Item("StartWebBrowser").Value.GetType(), typeof(bool));
-                Assert.IsTrue(project.Properties.Item("NodejsPort").Value == null || project.Properties.Item("NodejsPort").Value.GetType() == typeof(int));
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.StartWebBrowser).Value.GetType(), typeof(bool));
+                Assert.IsTrue(project.Properties.Item(NodeProjectProperty.NodejsPort).Value == null || project.Properties.Item(NodeProjectProperty.NodejsPort).Value.GetType() == typeof(int));
 
-                Assert.AreEqual(project.Properties.Item("LaunchUrl").Value, null);
-                Assert.AreEqual(project.Properties.Item("ScriptArguments").Value, null);
-                Assert.AreEqual(project.Properties.Item("NodeExeArguments").Value, null);
-                Assert.AreEqual(project.Properties.Item("NodeExePath").Value.GetType(), typeof(string));
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.LaunchUrl).Value, null);
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.ScriptArguments).Value, null);
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.NodeExeArguments).Value, null);
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.NodeExePath).Value.GetType(), typeof(string));
 
-                project.Properties.Item("StartWebBrowser").Value = true;
-                Assert.AreEqual(project.Properties.Item("StartWebBrowser").Value, true);
-                project.Properties.Item("StartWebBrowser").Value = false;
-                Assert.AreEqual(project.Properties.Item("StartWebBrowser").Value, false);
+                project.Properties.Item(NodeProjectProperty.StartWebBrowser).Value = true;
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.StartWebBrowser).Value, true);
+                project.Properties.Item(NodeProjectProperty.StartWebBrowser).Value = false;
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.StartWebBrowser).Value, false);
 
-                project.Properties.Item("NodejsPort").Value = 10000;
-                Assert.AreEqual(project.Properties.Item("NodejsPort").Value, 10000);
-                project.Properties.Item("NodejsPort").Value = 5000;
-                Assert.AreEqual(project.Properties.Item("NodejsPort").Value, 5000);
+                project.Properties.Item(NodeProjectProperty.NodejsPort).Value = 10000;
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.NodejsPort).Value, 10000);
+                project.Properties.Item(NodeProjectProperty.NodejsPort).Value = 5000;
+                Assert.AreEqual(project.Properties.Item(NodeProjectProperty.NodejsPort).Value, 5000);
 
-                foreach (var value in new[] { "LaunchUrl", "ScriptArguments", "NodeExeArguments", "NodeExePath" }) {
+                foreach (var value in new[] { NodeProjectProperty.LaunchUrl, NodeProjectProperty.ScriptArguments, NodeProjectProperty.NodeExeArguments, NodeProjectProperty.NodeExePath }) {
                     string tmpValue = Guid.NewGuid().ToString();
 
                     project.Properties.Item(value).Value = tmpValue;


### PR DESCRIPTION
Follow up on #1352. Move additional project property keys into own namespace to make their usage more clear. All mechanical refactoring.