### PR TITLE
prepare run_tests to run multiple tests

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/Tape/tape.js
@@ -2,6 +2,20 @@
 var EOL = require('os').EOL;
 var fs = require('fs');
 var path = require('path');
+var result = {
+    "title": "",
+    "passed": false,
+    "stdOut": "",
+    "stdErr": ""
+};
+
+process.stdout.write = function (string, encoding, fd) {
+    result.stdOut += string;
+}
+
+process.stderr.write = function (string, encoding, fd) {
+    result.stdErr += string;
+}
 
 function find_tests(testFileList, discoverResultFile, projectFolder) {
     var test = findTape(projectFolder);
@@ -37,8 +51,9 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
 };
 module.exports.find_tests = find_tests;
 
-function run_tests(testName, testFile, workingFolder, projectFolder) {
+function run_tests(testName, testFile, workingFolder, projectFolder, callback) {
     var testCases = loadTestCases(testFile);
+    result.title = testName;
     if (testCases === null) {
         return;
     }
@@ -51,10 +66,13 @@ function run_tests(testName, testFile, workingFolder, projectFolder) {
     try {
         var harness = test.getHarness();
         harness.only(testName);
+        result.passed = true;
     } catch (e) {
         logError("Error running test:", testName, "in", testFile, e);
-        return;
+        result.passed = false;
     }
+
+    callback(result);
 }
 module.exports.run_tests = run_tests;
 

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -12,14 +12,14 @@ var result = {
 // 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
 // and 'xunit' does not print the stack trace from the test.
 var defaultMochaOptions = { ui: 'tdd', reporter: 'tap', timeout: 2000 };
-
-process.stdout.write = function (string, encoding, fd) {
+function append_stdout(string, encoding, fd) {
     result.stdOut += string;
 }
-
-process.stderr.write = function (string, encoding, fd) {
+function append_stderr(string, encoding, fd) {
     result.stdErr += string;
 }
+process.stdout.write = append_stdout;
+process.stderr.write = append_stderr;
 
 var find_tests = function (testFileList, discoverResultFile, projectFolder) {
     var Mocha = detectMocha(projectFolder);
@@ -78,33 +78,46 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder, call
 
     var mocha = initializeMocha(Mocha, projectFolder);
 
-    if (testName) {
-        if (typeof mocha.fgrep === 'function')
-            mocha.fgrep(testName); // since Mocha 3.0.0
-        else
-            mocha.grep(testName); // prior Mocha 3.0.0
-    }
+    //if (testName) {
+    //    if (typeof mocha.fgrep === 'function')
+    //        mocha.fgrep(testName); // since Mocha 3.0.0
+    //    else
+    //        mocha.grep(testName); // prior Mocha 3.0.0
+    //}
 
     mocha.addFile(testFile);
 
     // run tests
-    var runner = mocha.run(function (code) { });
+    var runner = mocha.run(function (code) { process.exit(code); });
 
     runner.on('start', function () {
     });
     runner.on('test', function (test) {
         result.title = test.title;
+        process.stdout.write = append_stdout;
+        process.stderr.write = append_stderr;
     });
     runner.on('end', function () {
-        callback(result);
     });
     runner.on('pass', function (test) {
         result.passed = true;
-        //testResults.push(result);
+        callback(result);
+        result = {
+            'title': '',
+            'passed': false,
+            'stdOut': '',
+            'stdErr': ''
+        }
     });
     runner.on('fail', function (test, err) {
         result.passed = false;
-        //testResults.push(result);
+        callback(result);
+        result = {
+            'title': '',
+            'passed': false,
+            'stdOut': '',
+            'stdErr': ''
+        }
     });
 };
 

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -25,11 +25,11 @@ rl.on('line', (line) => {
         process.stdout.write = old_stdout;
         process.stderr.write = old_stderr;
         console.log(JSON.stringify(result));
-        process.exit(0);
+        //process.exit(0);
     }
     // run the test
     framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder, sendResult);
     
     // close readline interface
-    rl.close();
+    //rl.close();
 });


### PR DESCRIPTION
Hello!

In this PR I've made some minor adjustments to allow for run_tests to be able to actually run a list of tests, instead of just one-at-a-time. 

There are some issues that have arisen/will arise moving forward and I'd like to open a dialogue to see your opinion on how I should go about this. 

Firstly, about `mocha.grep`... 
I see now the reason why mocha tests are being run with multiple calls to `before()` and `after()` hooks -- each call to `run_tests` also called `mocha.grep`, turning a singular test suite containing 10 tests into 10 test suites containing 1 test. As my ultimate goal is to make `mocha` tests run properly, I would have to either remove the `grep` call completely (this would mean ALL mocha tests in a file will always run, breaking "Run Selected Tests" functionality) or construct a long `grep` string containing all selected tests and pass that to the `grep` call. 

Second problem -- recording start and end times:
The approach by NTVS currently is to call `RecordStart` on the given test case, send `mocha` the `testName` and `testFile` and have `mocha` grep the one `testName` out of the provided `testFile`. Then once that `process` exits, it's safe to call `RecordEnd` and record the end time for the test, then repeat. 
However, I want to run a list of tests-- in order to do so, I have to provide `mocha` with the list up front so it can adjust its test suite accordingly. If I'm providing `mocha` with a list of tests to run up front, we can no longer record accurate Start and End times for those tests. I could try to record the times in `mocha.js`, but this adds another requirement for the `run_tests` interface, and might make changes more difficult down the road.

Any guidance is welcome and appreciated. Please let me know if you need me to elaborate on anything written here, hopefully I haven't rambled too much...

Thanks again