### PR TITLE
Remove Show Node/Browser Labels Option From UI

### DIFF
--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.Designer.cs
@@ -31,7 +31,6 @@
             this._editAndContinue = new System.Windows.Forms.CheckBox();
             this._waitOnNormalExit = new System.Windows.Forms.CheckBox();
             this._waitOnAbnormalExit = new System.Windows.Forms.CheckBox();
-            this._showBrowserAndNodeLabels = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel3.SuspendLayout();
             this._topOptionsPanel.SuspendLayout();
             this.SuspendLayout();
@@ -46,8 +45,8 @@
             this.tableLayoutPanel3.Controls.Add(this._surveyNewsCheckLabel, 0, 7);
             this.tableLayoutPanel3.Controls.Add(this._surveyNewsCheckCombo, 1, 7);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 149);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 97);
+            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 9;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -58,18 +57,18 @@
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(508, 208);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(381, 193);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // _surveyNewsCheckLabel
             // 
             this._surveyNewsCheckLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this._surveyNewsCheckLabel.AutoSize = true;
-            this._surveyNewsCheckLabel.Location = new System.Drawing.Point(8, 7);
-            this._surveyNewsCheckLabel.Margin = new System.Windows.Forms.Padding(8, 0, 8, 0);
+            this._surveyNewsCheckLabel.Location = new System.Drawing.Point(6, 7);
+            this._surveyNewsCheckLabel.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this._surveyNewsCheckLabel.Name = "_surveyNewsCheckLabel";
-            this._surveyNewsCheckLabel.Size = new System.Drawing.Size(150, 17);
+            this._surveyNewsCheckLabel.Size = new System.Drawing.Size(117, 13);
             this._surveyNewsCheckLabel.TabIndex = 7;
             this._surveyNewsCheckLabel.Text = "&Check for survey/news";
             this._surveyNewsCheckLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -85,33 +84,30 @@
             "Once a day",
             "Once a week",
             "Once a month"});
-            this._surveyNewsCheckCombo.Location = new System.Drawing.Point(174, 4);
-            this._surveyNewsCheckCombo.Margin = new System.Windows.Forms.Padding(8, 4, 8, 4);
+            this._surveyNewsCheckCombo.Location = new System.Drawing.Point(135, 3);
+            this._surveyNewsCheckCombo.Margin = new System.Windows.Forms.Padding(6, 3, 6, 3);
             this._surveyNewsCheckCombo.Name = "_surveyNewsCheckCombo";
-            this._surveyNewsCheckCombo.Size = new System.Drawing.Size(326, 24);
+            this._surveyNewsCheckCombo.Size = new System.Drawing.Size(240, 21);
             this._surveyNewsCheckCombo.TabIndex = 8;
             // 
             // _topOptionsPanel
             // 
-            this._topOptionsPanel.Controls.Add(this._showBrowserAndNodeLabels);
             this._topOptionsPanel.Controls.Add(this._checkForLongPaths);
             this._topOptionsPanel.Controls.Add(this._editAndContinue);
             this._topOptionsPanel.Controls.Add(this._waitOnNormalExit);
             this._topOptionsPanel.Controls.Add(this._waitOnAbnormalExit);
             this._topOptionsPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this._topOptionsPanel.Location = new System.Drawing.Point(0, 0);
-            this._topOptionsPanel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this._topOptionsPanel.Name = "_topOptionsPanel";
-            this._topOptionsPanel.Size = new System.Drawing.Size(508, 149);
+            this._topOptionsPanel.Size = new System.Drawing.Size(381, 97);
             this._topOptionsPanel.TabIndex = 1;
             // 
             // _checkForLongPaths
             // 
             this._checkForLongPaths.AutoSize = true;
-            this._checkForLongPaths.Location = new System.Drawing.Point(5, 90);
-            this._checkForLongPaths.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this._checkForLongPaths.Location = new System.Drawing.Point(4, 73);
             this._checkForLongPaths.Name = "_checkForLongPaths";
-            this._checkForLongPaths.Size = new System.Drawing.Size(379, 21);
+            this._checkForLongPaths.Size = new System.Drawing.Size(291, 17);
             this._checkForLongPaths.TabIndex = 4;
             this._checkForLongPaths.Text = "Check for paths that exceed the &MAX_PATH length limit";
             this._checkForLongPaths.UseVisualStyleBackColor = true;
@@ -119,10 +115,9 @@
             // _editAndContinue
             // 
             this._editAndContinue.AutoSize = true;
-            this._editAndContinue.Location = new System.Drawing.Point(5, 62);
-            this._editAndContinue.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this._editAndContinue.Location = new System.Drawing.Point(4, 50);
             this._editAndContinue.Name = "_editAndContinue";
-            this._editAndContinue.Size = new System.Drawing.Size(190, 21);
+            this._editAndContinue.Size = new System.Drawing.Size(146, 17);
             this._editAndContinue.TabIndex = 3;
             this._editAndContinue.Text = "Enable &Edit and Continue";
             this._editAndContinue.UseVisualStyleBackColor = true;
@@ -130,10 +125,9 @@
             // _waitOnNormalExit
             // 
             this._waitOnNormalExit.AutoSize = true;
-            this._waitOnNormalExit.Location = new System.Drawing.Point(5, 33);
-            this._waitOnNormalExit.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this._waitOnNormalExit.Location = new System.Drawing.Point(4, 27);
             this._waitOnNormalExit.Name = "_waitOnNormalExit";
-            this._waitOnNormalExit.Size = new System.Drawing.Size(294, 21);
+            this._waitOnNormalExit.Size = new System.Drawing.Size(223, 17);
             this._waitOnNormalExit.TabIndex = 2;
             this._waitOnNormalExit.Text = "Wai&t for input when process exits normally";
             this._waitOnNormalExit.UseVisualStyleBackColor = true;
@@ -141,34 +135,22 @@
             // _waitOnAbnormalExit
             // 
             this._waitOnAbnormalExit.AutoSize = true;
-            this._waitOnAbnormalExit.Location = new System.Drawing.Point(5, 5);
-            this._waitOnAbnormalExit.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this._waitOnAbnormalExit.Location = new System.Drawing.Point(4, 4);
             this._waitOnAbnormalExit.Name = "_waitOnAbnormalExit";
-            this._waitOnAbnormalExit.Size = new System.Drawing.Size(310, 21);
+            this._waitOnAbnormalExit.Size = new System.Drawing.Size(235, 17);
             this._waitOnAbnormalExit.TabIndex = 1;
             this._waitOnAbnormalExit.Text = "&Wait for input when process exits abnormally";
             this._waitOnAbnormalExit.UseVisualStyleBackColor = true;
             // 
-            // _showBrowserAndNodeLabels
-            // 
-            this._showBrowserAndNodeLabels.AutoSize = true;
-            this._showBrowserAndNodeLabels.Location = new System.Drawing.Point(5, 119);
-            this._showBrowserAndNodeLabels.Margin = new System.Windows.Forms.Padding(4);
-            this._showBrowserAndNodeLabels.Name = "_showBrowserAndNodeLabels";
-            this._showBrowserAndNodeLabels.Size = new System.Drawing.Size(471, 21);
-            this._showBrowserAndNodeLabels.TabIndex = 6;
-            this._showBrowserAndNodeLabels.Text = "Show &labels denoting browser and Node.js code in Solution Explorer";
-            this._showBrowserAndNodeLabels.UseVisualStyleBackColor = true;
-            // 
             // NodejsGeneralOptionsControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel3);
             this.Controls.Add(this._topOptionsPanel);
-            this.Margin = new System.Windows.Forms.Padding(8, 10, 8, 10);
+            this.Margin = new System.Windows.Forms.Padding(6, 8, 6, 8);
             this.Name = "NodejsGeneralOptionsControl";
-            this.Size = new System.Drawing.Size(508, 357);
+            this.Size = new System.Drawing.Size(381, 290);
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
             this._topOptionsPanel.ResumeLayout(false);
@@ -188,6 +170,5 @@
         private System.Windows.Forms.CheckBox _waitOnAbnormalExit;
         private System.Windows.Forms.CheckBox _editAndContinue;
         private System.Windows.Forms.CheckBox _checkForLongPaths;
-        private System.Windows.Forms.CheckBox _showBrowserAndNodeLabels;
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.cs
@@ -66,10 +66,6 @@ namespace Microsoft.NodejsTools.Options {
             _waitOnNormalExit.Checked = page.WaitOnNormalExit;
             _editAndContinue.Checked = page.EditAndContinue;
             _checkForLongPaths.Checked = page.CheckForLongPaths;
-            _showBrowserAndNodeLabels.Checked = page.ShowBrowserAndNodeLabels;
-
-            // Disable the show "browser" and "node" labels option when the user is in ES6 IntelliSense Preview mode
-            _showBrowserAndNodeLabels.Enabled = false;
         }
 
         internal void SyncPageWithControlSettings(NodejsGeneralOptionsPage page) {
@@ -78,7 +74,6 @@ namespace Microsoft.NodejsTools.Options {
             page.WaitOnNormalExit = _waitOnNormalExit.Checked;
             page.EditAndContinue = _editAndContinue.Checked;
             page.CheckForLongPaths = _checkForLongPaths.Checked;
-            page.ShowBrowserAndNodeLabels = _showBrowserAndNodeLabels.Checked;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
@@ -31,8 +31,6 @@ namespace Microsoft.NodejsTools.Options {
         private const string WaitOnNormalExitSetting = "WaitOnNormalExit";
         private const string EditAndContinueSetting = "EditAndContinue";
         private const string CheckForLongPathsSetting = "CheckForLongPaths";
-        private const string ShowBrowserAndNodeLabelsSetting = "ShowBrowserAndNodeLabels";
-        private bool _showBrowserAndNodeLabels;
         private SurveyNewsPolicy _surveyNewsCheck;
         private string _surveyNewsFeedUrl;
         private string _surveyNewsIndexUrl;
@@ -55,12 +53,6 @@ namespace Microsoft.NodejsTools.Options {
         }
 
         /// <summary>
-        /// Indicates whether or not the Output window should be shown when
-        /// npm commands are being executed.
-        /// </summary>
-        public bool ShowOutputWindowWhenExecutingNpm { get; set; }
-
-        /// <summary>
         /// True if Node processes should pause for input before exiting
         /// if they exit abnormally.
         /// </summary>
@@ -81,25 +73,6 @@ namespace Microsoft.NodejsTools.Options {
         /// Indicates whether checks for long paths (exceeding MAX_PATH) are performed after installing packages.
         /// </summary>
         public bool CheckForLongPaths { get; set; }
-
-        /// <summary>
-        /// Indicates whether labels should be appended to folders in Solution Explorer denoting browser and Node.js code.
-        /// </summary>
-        public bool ShowBrowserAndNodeLabels {
-            get { return _showBrowserAndNodeLabels; }
-            set {
-                var oldSetting = _showBrowserAndNodeLabels;
-                _showBrowserAndNodeLabels = value;
-                if (oldSetting != _showBrowserAndNodeLabels) {
-                    var changed = ShowBrowserAndNodeLabelsChanged;
-                    if (changed != null) {
-                        changed(this, EventArgs.Empty);
-                    }
-                }
-            }
-        }
-
-        public event EventHandler<EventArgs> ShowBrowserAndNodeLabelsChanged;
 
         /// <summary>
         /// The frequency at which to check for updated news. Default is once
@@ -148,7 +121,6 @@ namespace Microsoft.NodejsTools.Options {
             WaitOnNormalExit = false;
             EditAndContinue = true;
             CheckForLongPaths = true;
-            _showBrowserAndNodeLabels = true;
         }
 
         public override void LoadSettingsFromStorage() {
@@ -161,7 +133,6 @@ namespace Microsoft.NodejsTools.Options {
             WaitOnNormalExit = LoadBool(WaitOnNormalExitSetting) ?? false;
             EditAndContinue = LoadBool(EditAndContinueSetting) ?? true;
             CheckForLongPaths = LoadBool(CheckForLongPathsSetting) ?? true;
-            _showBrowserAndNodeLabels = LoadBool(ShowBrowserAndNodeLabelsSetting) ?? true;
 
             // Synchronize UI with backing properties.
             if (_window != null) {
@@ -182,7 +153,6 @@ namespace Microsoft.NodejsTools.Options {
             SaveBool(WaitOnAbnormalExitSetting, WaitOnAbnormalExit);
             SaveBool(EditAndContinueSetting, EditAndContinue);
             SaveBool(CheckForLongPathsSetting, CheckForLongPaths);
-            SaveBool(ShowBrowserAndNodeLabelsSetting, ShowBrowserAndNodeLabels);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -470,11 +470,6 @@ namespace Microsoft.NodejsTools.Project {
                    ext.Equals(NodejsConstants.TypeScriptExtension, StringComparison.OrdinalIgnoreCase);
         }
 
-        public override int InitializeForOuter(string filename, string location, string name, uint flags, ref Guid iid, out IntPtr projectPointer, out int canceled) {
-            NodejsPackage.Instance.GeneralOptionsPage.ShowBrowserAndNodeLabelsChanged += ShowBrowserAndNodeLabelsChanged;
-
-            return base.InitializeForOuter(filename, location, name, flags, ref iid, out projectPointer, out canceled);
-        }
 
         protected override void Reload() {
             using (new DebugTimer("Project Load")) {
@@ -498,13 +493,6 @@ namespace Microsoft.NodejsTools.Project {
 
         private void UpdateProjectNodeFromProjectProperties() {
             _intermediateOutputPath = Path.Combine(ProjectHome, GetProjectProperty("BaseIntermediateOutputPath"));
-        }
-
-        private void ShowBrowserAndNodeLabelsChanged(object sender, EventArgs e) {
-            var nodejsFolderNodes = this.AllDescendants.Where(item => (item as NodejsFolderNode) != null).Select(item => (NodejsFolderNode)item);
-            foreach (var node in nodejsFolderNodes) {
-                ProjectMgr.ReDrawNode(node, UIHierarchyElement.Caption);
-            }
         }
 
         protected override void RaiseProjectPropertyChanged(string propertyName, string oldValue, string newValue) {
@@ -861,8 +849,6 @@ namespace Microsoft.NodejsTools.Project {
                     }
                     _idleNodeModulesTimer = null;
                 }
-
-                NodejsPackage.Instance.GeneralOptionsPage.ShowBrowserAndNodeLabelsChanged -= ShowBrowserAndNodeLabelsChanged;
 
                 OnDispose?.Invoke(this, EventArgs.Empty);
 


### PR DESCRIPTION
**Bug**
Issue #1362 - The Show Node/browser labels option is now unreachable since we only support ES6/TypeScript powered IntelliSense.

**Fix**
Remove this option from the ui and from the code.

![image](https://cloud.githubusercontent.com/assets/12821956/19535099/52a82976-95fb-11e6-8688-82231361fc33.png)


**Testing**
Checked new UI. Confirmed that nodes in solution explorer continue to render properly.

Closes #1362