### PR TITLE
Extract a Few More Strings in DependencyNode

### DIFF
--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -230,7 +230,7 @@ namespace Microsoft.NodejsTools.Project {
                         } catch (Exception ex) {
                             if (ex is InvalidOperationException || ex is Win32Exception) {
                                 MessageBox.Show(
-                                    string.Format(CultureInfo.CurrentCulture, "Path to module does not exist:\n {0}", path),
+                                    SR.GetString(SR.DependencyNodeModuleDoesNotExist, path),
                                     SR.ProductName,
                                     MessageBoxButtons.OK,
                                     MessageBoxIcon.Error);
@@ -250,13 +250,14 @@ namespace Microsoft.NodejsTools.Project {
         private static string GetInitialPackageDisplayString(IPackage package) {
             var buff = new StringBuilder(package.Name);
             if (package.IsMissing) {
-                buff.Append(" (missing)");
+                buff.Append(string.Format(CultureInfo.CurrentCulture, " ({0})", SR.GetString(SR.DependencyNodeLabelMissing)));
             } else {
                 buff.Append('@');
                 buff.Append(package.Version);
 
                 if (!package.IsListedInParentPackageJson) {
-                    buff.AppendFormat(" (not listed in {0})", NodejsConstants.PackageJsonFile);
+                    buff.AppendFormat(string.Format(CultureInfo.CurrentCulture, " ({0})",
+                        SR.GetString(SR.DependencyNodeLabelNotListed, NodejsConstants.PackageJsonFile)));
                 } else {
                     var dependencyTypes = GetDependencyTypeNames(package);
                     if (package.IsDevDependency || package.IsOptionalDependency) {
@@ -268,7 +269,8 @@ namespace Microsoft.NodejsTools.Project {
             }
 
             if (package.IsBundledDependency) {
-                buff.Append("[bundled]");
+                buff.Append(string.Format(CultureInfo.CurrentCulture, "[{0}]",
+                    SR.GetString(SR.DependencyNodeLabelBundled)));
             }
             return buff.ToString();
         }

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -44,6 +44,10 @@ namespace Microsoft.NodejsTools.Project {
         internal const string DebuggerConnectionClosed = "DebuggerConnectionClosed";
         internal const string DebuggerModuleUpdateFailed = "DebuggerModuleUpdateFailed";
         internal const string DebuggerPort = "DebuggerPort";
+        internal const string DependencyNodeLabelBundled = "DependencyNodeLabelBundled";
+        internal const string DependencyNodeLabelMissing = "DependencyNodeLabelMissing";
+        internal const string DependencyNodeLabelNotListed = "DependencyNodeLabelNotListed";
+        internal const string DependencyNodeModuleDoesNotExist = "DependencyNodeModuleDoesNotExist";
         internal const string DontShowAgain = "DontShowAgain";
         internal const string DownloadAndInstall = "DownloadAndInstall";
         internal const string EnvironmentVariables = "EnvironmentVariables";

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -635,4 +635,17 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="ImportWizzardCouldNotStartNotAutomationObjectErrorMessage" xml:space="preserve">
     <value>Unable to start wizard: no automation object available.</value>
   </data>
+  <data name="DependencyNodeLabelBundled" xml:space="preserve">
+    <value>bundled</value>
+  </data>
+  <data name="DependencyNodeLabelMissing" xml:space="preserve">
+    <value>missing</value>
+  </data>
+  <data name="DependencyNodeLabelNotListed" xml:space="preserve">
+    <value>not listed in {0}</value>
+  </data>
+  <data name="DependencyNodeModuleDoesNotExist" xml:space="preserve">
+    <value>Path to module does not exist:
+{0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Just extracting a few more UI strings in DependencyNode.cs from code to a resouce file so that they can be localized.

I'm not extracting the `dev`, `optional`, and `standard` strings because these are terms used in the `package.json` and should probably not be localized.