### PR TITLE
Extract remaining UI strings from import wizard XAML files

### DIFF
--- a/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
@@ -79,6 +79,24 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Files with the .js extension are always included..
+        /// </summary>
+        public static string FileFilterHelpText {
+            get {
+                return ResourceManager.GetString("FileFilterHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the filter for files to include.
+        /// </summary>
+        public static string FileFilterTitle {
+            get {
+                return ResourceManager.GetString("FileFilterTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Finish.
         /// </summary>
         public static string FinishButtonLabel {
@@ -93,6 +111,24 @@ namespace Microsoft.NodejsTools {
         public static string NextButtonLabel {
             get {
                 return ResourceManager.GetString("NextButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We won&apos;t move any files from where they are now..
+        /// </summary>
+        public static string SelectNodeCodeHelpText {
+            get {
+                return ResourceManager.GetString("SelectNodeCodeHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter or browse to the folder containing your Node.js code.
+        /// </summary>
+        public static string SelectNodeCodeTitle {
+            get {
+                return ResourceManager.GetString("SelectNodeCodeTitle", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
@@ -79,6 +79,24 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If it is not in this list, you can right-click any file in your project and choose &quot;Set as startup file&quot;.
+        /// </summary>
+        public static string F5FileSelectHelpText {
+            get {
+                return ResourceManager.GetString("F5FileSelectHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Choose which file to run when F5 is pressed..
+        /// </summary>
+        public static string F5FileSelectTitle {
+            get {
+                return ResourceManager.GetString("F5FileSelectTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Files with the .js extension are always included..
         /// </summary>
         public static string FileFilterHelpText {
@@ -111,6 +129,24 @@ namespace Microsoft.NodejsTools {
         public static string NextButtonLabel {
             get {
                 return ResourceManager.GetString("NextButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We won&apos;t move any files, and you can use Save As to move the project file later..
+        /// </summary>
+        public static string SaveFileLocationHelpText {
+            get {
+                return ResourceManager.GetString("SaveFileLocationHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select where to save your project file.
+        /// </summary>
+        public static string SaveFileLocationTitle {
+            get {
+                return ResourceManager.GetString("SaveFileLocationTitle", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/ImportWizardResources.resx
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.resx
@@ -123,11 +123,23 @@
   <data name="CancelButtonLabel" xml:space="preserve">
     <value>_Cancel</value>
   </data>
+  <data name="FileFilterHelpText" xml:space="preserve">
+    <value>Files with the .js extension are always included.</value>
+  </data>
+  <data name="FileFilterTitle" xml:space="preserve">
+    <value>Enter the filter for files to include</value>
+  </data>
   <data name="FinishButtonLabel" xml:space="preserve">
     <value>_Finish</value>
   </data>
   <data name="NextButtonLabel" xml:space="preserve">
     <value>_Next</value>
+  </data>
+  <data name="SelectNodeCodeHelpText" xml:space="preserve">
+    <value>We won't move any files from where they are now.</value>
+  </data>
+  <data name="SelectNodeCodeTitle" xml:space="preserve">
+    <value>Enter or browse to the folder containing your Node.js code</value>
   </data>
   <data name="Welcome" xml:space="preserve">
     <value>Welcome to the Create New Project from Existing Node.js Code Wizard</value>

--- a/Nodejs/Product/Nodejs/ImportWizardResources.resx
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.resx
@@ -123,6 +123,12 @@
   <data name="CancelButtonLabel" xml:space="preserve">
     <value>_Cancel</value>
   </data>
+  <data name="F5FileSelectHelpText" xml:space="preserve">
+    <value>If it is not in this list, you can right-click any file in your project and choose "Set as startup file"</value>
+  </data>
+  <data name="F5FileSelectTitle" xml:space="preserve">
+    <value>Choose which file to run when F5 is pressed.</value>
+  </data>
   <data name="FileFilterHelpText" xml:space="preserve">
     <value>Files with the .js extension are always included.</value>
   </data>
@@ -134,6 +140,12 @@
   </data>
   <data name="NextButtonLabel" xml:space="preserve">
     <value>_Next</value>
+  </data>
+  <data name="SaveFileLocationHelpText" xml:space="preserve">
+    <value>We won't move any files, and you can use Save As to move the project file later.</value>
+  </data>
+  <data name="SaveFileLocationTitle" xml:space="preserve">
+    <value>Select where to save your project file</value>
   </data>
   <data name="SelectNodeCodeHelpText" xml:space="preserve">
     <value>We won't move any files from where they are now.</value>

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/FileSourcePage.xaml
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/FileSourcePage.xaml
@@ -6,6 +6,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
       xmlns:l="clr-namespace:Microsoft.NodejsTools.Project.ImportWizard"
+      xmlns:resx="clr-namespace:Microsoft.NodejsTools"
       mc:Ignorable="d" 
       d:DesignHeight="300" d:DesignWidth="500"
       Title="Source Files"
@@ -20,8 +21,8 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
 
-        <wpf:LabelledControl Title="Choose which file to run when F5 is pressed."
-                           HelpText="If it is not in this list, you can right-click any file in your project and choose &quot;Set as startup file&quot;"
+        <wpf:LabelledControl Title="{x:Static resx:ImportWizardResources.F5FileSelectTitle}"
+                           HelpText="{x:Static resx:ImportWizardResources.F5FileSelectHelpText}"
                            Grid.Row="0">
             <ListView Name="listView"
                       ItemsSource="{Binding TopLevelJavaScriptFiles}"

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/SaveProjectPage.xaml
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/SaveProjectPage.xaml
@@ -6,6 +6,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:l="clr-namespace:Microsoft.NodejsTools.Project.ImportWizard"
       xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
+      xmlns:resx="clr-namespace:Microsoft.NodejsTools"
       mc:Ignorable="d" 
       d:DesignHeight="300" d:DesignWidth="500"
       Title="Save Project"
@@ -20,9 +21,9 @@
             <RowDefinition Height="auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        
-        <wpf:LabelledControl Title="Select where to save your project file."
-                           HelpText="We won't move any files, and you can use Save As to move the project file later."
+
+        <wpf:LabelledControl Title="{x:Static resx:ImportWizardResources.SaveFileLocationTitle}"
+                           HelpText="{x:Static resx:ImportWizardResources.SaveFileLocationHelpText}"
                            Grid.Row="0">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/StartupPage.xaml
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/StartupPage.xaml
@@ -6,6 +6,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
       xmlns:l="clr-namespace:Microsoft.NodejsTools.Project.ImportWizard"
+      xmlns:resx="clr-namespace:Microsoft.NodejsTools"
       mc:Ignorable="d" 
       d:DesignHeight="300" d:DesignWidth="500"
       Title="Source Files"
@@ -20,9 +21,9 @@
             <RowDefinition Height="auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        
-        <wpf:LabelledControl Title="Enter or browse to the folder containing your Node.js code."
-                           HelpText="We won't move any files from where they are now."
+
+        <wpf:LabelledControl Title="{x:Static resx:ImportWizardResources.SelectNodeCodeTitle}"
+                           HelpText="{x:Static resx:ImportWizardResources.SelectNodeCodeHelpText}"
                            Grid.Row="0">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -37,8 +38,8 @@
             </Grid>
         </wpf:LabelledControl>
 
-        <wpf:LabelledControl Title="Enter the filter for files to include."
-                           HelpText="Files with the .js extension are always included."
+        <wpf:LabelledControl Title="{x:Static resx:ImportWizardResources.FileFilterTitle}"
+                           HelpText="{x:Static resx:ImportWizardResources.FileFilterHelpText}"
                            Grid.Row="1">
             <TextBox Text="{Binding Path=Filters,Mode=TwoWay}" />
         </wpf:LabelledControl>


### PR DESCRIPTION
##### Bug
Import Wizard has ui strings hardcoded in the XAML files.

##### Fix
Extract these remaining strings to a resx file so that they can be localized.
