### PR TITLE
Prepare Nodejs Project Properties Page for Localization

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -24,6 +24,7 @@
         /// </summary>
         private void InitializeComponent() {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NodejsGeneralPropertyPageControl));
             this._nodeExePathLabel = new System.Windows.Forms.Label();
             this._nodeArguments = new System.Windows.Forms.Label();
             this._startBrowser = new System.Windows.Forms.CheckBox();
@@ -52,160 +53,96 @@
             // 
             // _nodeExePathLabel
             // 
-            this._nodeExePathLabel.AutoSize = true;
-            this._nodeExePathLabel.Location = new System.Drawing.Point(14, 22);
+            resources.ApplyResources(this._nodeExePathLabel, "_nodeExePathLabel");
             this._nodeExePathLabel.Name = "_nodeExePathLabel";
-            this._nodeExePathLabel.Size = new System.Drawing.Size(80, 13);
-            this._nodeExePathLabel.TabIndex = 0;
-            this._nodeExePathLabel.Text = "Node.exe &path:";
             // 
             // _nodeArguments
             // 
-            this._nodeArguments.AutoSize = true;
-            this._nodeArguments.Location = new System.Drawing.Point(14, 48);
+            resources.ApplyResources(this._nodeArguments, "_nodeArguments");
             this._nodeArguments.Name = "_nodeArguments";
-            this._nodeArguments.Size = new System.Drawing.Size(93, 13);
-            this._nodeArguments.TabIndex = 3;
-            this._nodeArguments.Text = "N&ode.exe options:";
             // 
             // _startBrowser
             // 
-            this._startBrowser.AutoSize = true;
-            this._startBrowser.Location = new System.Drawing.Point(17, 284);
+            resources.ApplyResources(this._startBrowser, "_startBrowser");
             this._startBrowser.Name = "_startBrowser";
-            this._startBrowser.Size = new System.Drawing.Size(161, 17);
-            this._startBrowser.TabIndex = 20;
-            this._startBrowser.Text = "St&art web browser on launch";
             this._startBrowser.UseVisualStyleBackColor = true;
             this._startBrowser.CheckedChanged += new System.EventHandler(this.Changed);
             // 
             // _nodeExePath
             // 
-            this._nodeExePath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            resources.ApplyResources(this._nodeExePath, "_nodeExePath");
             this._nodeExePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this._nodeExePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystem;
-            this._nodeExePath.Location = new System.Drawing.Point(135, 19);
             this._nodeExePath.Name = "_nodeExePath";
-            this._nodeExePath.Size = new System.Drawing.Size(308, 20);
-            this._nodeExePath.TabIndex = 1;
             this._nodeExePath.TextChanged += new System.EventHandler(this.NodeExePathChanged);
             // 
             // _nodeExeArguments
             // 
-            this._nodeExeArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._nodeExeArguments.Location = new System.Drawing.Point(135, 45);
+            resources.ApplyResources(this._nodeExeArguments, "_nodeExeArguments");
             this._nodeExeArguments.Name = "_nodeExeArguments";
-            this._nodeExeArguments.Size = new System.Drawing.Size(340, 20);
-            this._nodeExeArguments.TabIndex = 4;
             this._nodeExeArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _nodejsPort
             // 
-            this._nodejsPort.Location = new System.Drawing.Point(135, 176);
+            resources.ApplyResources(this._nodejsPort, "_nodejsPort");
             this._nodejsPort.Name = "_nodejsPort";
-            this._nodejsPort.Size = new System.Drawing.Size(105, 20);
-            this._nodejsPort.TabIndex = 15;
             this._nodejsPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _nodePortLabel
             // 
-            this._nodePortLabel.AutoSize = true;
-            this._nodePortLabel.Location = new System.Drawing.Point(14, 179);
+            resources.ApplyResources(this._nodePortLabel, "_nodePortLabel");
             this._nodePortLabel.Name = "_nodePortLabel";
-            this._nodePortLabel.Size = new System.Drawing.Size(67, 13);
-            this._nodePortLabel.TabIndex = 14;
-            this._nodePortLabel.Text = "Node.&js port:";
             // 
             // _scriptArgsLabel
             // 
-            this._scriptArgsLabel.AutoSize = true;
-            this._scriptArgsLabel.Location = new System.Drawing.Point(14, 100);
+            resources.ApplyResources(this._scriptArgsLabel, "_scriptArgsLabel");
             this._scriptArgsLabel.Name = "_scriptArgsLabel";
-            this._scriptArgsLabel.Size = new System.Drawing.Size(89, 13);
-            this._scriptArgsLabel.TabIndex = 7;
-            this._scriptArgsLabel.Text = "Script ar&guments:";
             // 
             // _scriptArguments
             // 
-            this._scriptArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptArguments.Location = new System.Drawing.Point(135, 97);
+            resources.ApplyResources(this._scriptArguments, "_scriptArguments");
             this._scriptArguments.Name = "_scriptArguments";
-            this._scriptArguments.Size = new System.Drawing.Size(340, 20);
-            this._scriptArguments.TabIndex = 8;
             this._scriptArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _workingDirLabel
             // 
-            this._workingDirLabel.AutoSize = true;
-            this._workingDirLabel.Location = new System.Drawing.Point(14, 126);
+            resources.ApplyResources(this._workingDirLabel, "_workingDirLabel");
             this._workingDirLabel.Name = "_workingDirLabel";
-            this._workingDirLabel.Size = new System.Drawing.Size(93, 13);
-            this._workingDirLabel.TabIndex = 9;
-            this._workingDirLabel.Text = "Working director&y:";
             // 
             // _workingDir
             // 
-            this._workingDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._workingDir.Location = new System.Drawing.Point(135, 123);
+            resources.ApplyResources(this._workingDir, "_workingDir");
             this._workingDir.Name = "_workingDir";
-            this._workingDir.Size = new System.Drawing.Size(308, 20);
-            this._workingDir.TabIndex = 10;
             this._workingDir.TextChanged += new System.EventHandler(this.WorkingDirTextChanged);
             // 
             // _launchUrl
             // 
-            this._launchUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._launchUrl.Location = new System.Drawing.Point(135, 150);
+            resources.ApplyResources(this._launchUrl, "_launchUrl");
             this._launchUrl.Name = "_launchUrl";
-            this._launchUrl.Size = new System.Drawing.Size(340, 20);
-            this._launchUrl.TabIndex = 13;
             this._launchUrl.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _launchUrlLabel
             // 
-            this._launchUrlLabel.AutoSize = true;
-            this._launchUrlLabel.Location = new System.Drawing.Point(14, 153);
+            resources.ApplyResources(this._launchUrlLabel, "_launchUrlLabel");
             this._launchUrlLabel.Name = "_launchUrlLabel";
-            this._launchUrlLabel.Size = new System.Drawing.Size(71, 13);
-            this._launchUrlLabel.TabIndex = 12;
-            this._launchUrlLabel.Text = "Launch &URL:";
             // 
             // _envVars
             // 
-            this._envVars.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._envVars.Location = new System.Drawing.Point(135, 228);
-            this._envVars.Multiline = true;
+            resources.ApplyResources(this._envVars, "_envVars");
             this._envVars.Name = "_envVars";
-            this._envVars.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this._envVars.Size = new System.Drawing.Size(340, 50);
-            this._envVars.TabIndex = 19;
             this._envVars.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _browsePath
             // 
-            this._browsePath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browsePath.Location = new System.Drawing.Point(449, 17);
+            resources.ApplyResources(this._browsePath, "_browsePath");
             this._browsePath.Name = "_browsePath";
-            this._browsePath.Size = new System.Drawing.Size(26, 23);
-            this._browsePath.TabIndex = 2;
-            this._browsePath.Text = "...";
             this._browsePath.UseVisualStyleBackColor = true;
             this._browsePath.Click += new System.EventHandler(this.BrowsePathClick);
             // 
             // _browseDirectory
             // 
-            this._browseDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._browseDirectory.Location = new System.Drawing.Point(449, 121);
+            resources.ApplyResources(this._browseDirectory, "_browseDirectory");
             this._browseDirectory.Name = "_browseDirectory";
-            this._browseDirectory.Size = new System.Drawing.Size(26, 23);
-            this._browseDirectory.TabIndex = 11;
-            this._browseDirectory.Text = "...";
             this._browseDirectory.UseVisualStyleBackColor = true;
             this._browseDirectory.Click += new System.EventHandler(this.BrowseDirectoryClick);
             // 
@@ -215,52 +152,34 @@
             // 
             // _debuggerPortLabel
             // 
-            this._debuggerPortLabel.AutoSize = true;
-            this._debuggerPortLabel.Location = new System.Drawing.Point(14, 205);
+            resources.ApplyResources(this._debuggerPortLabel, "_debuggerPortLabel");
             this._debuggerPortLabel.Name = "_debuggerPortLabel";
-            this._debuggerPortLabel.Size = new System.Drawing.Size(78, 13);
-            this._debuggerPortLabel.TabIndex = 16;
-            this._debuggerPortLabel.Text = "&Debugger port:";
             // 
             // _debuggerPort
             // 
-            this._debuggerPort.Location = new System.Drawing.Point(135, 202);
+            resources.ApplyResources(this._debuggerPort, "_debuggerPort");
             this._debuggerPort.Name = "_debuggerPort";
-            this._debuggerPort.Size = new System.Drawing.Size(105, 20);
-            this._debuggerPort.TabIndex = 17;
             this._debuggerPort.TextChanged += new System.EventHandler(this.PortChanged);
             // 
             // _envVarsLabel
             // 
-            this._envVarsLabel.AutoSize = true;
-            this._envVarsLabel.Location = new System.Drawing.Point(14, 231);
+            resources.ApplyResources(this._envVarsLabel, "_envVarsLabel");
             this._envVarsLabel.Name = "_envVarsLabel";
-            this._envVarsLabel.Size = new System.Drawing.Size(115, 13);
-            this._envVarsLabel.TabIndex = 18;
-            this._envVarsLabel.Text = "Environment &Variables:";
             // 
             // _scriptLabel
             // 
-            this._scriptLabel.AutoSize = true;
-            this._scriptLabel.Location = new System.Drawing.Point(14, 74);
+            resources.ApplyResources(this._scriptLabel, "_scriptLabel");
             this._scriptLabel.Name = "_scriptLabel";
-            this._scriptLabel.Size = new System.Drawing.Size(94, 13);
-            this._scriptLabel.TabIndex = 5;
-            this._scriptLabel.Text = "&Script (startup file):";
             // 
             // _scriptFile
             // 
-            this._scriptFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptFile.Location = new System.Drawing.Point(135, 71);
+            resources.ApplyResources(this._scriptFile, "_scriptFile");
             this._scriptFile.Name = "_scriptFile";
-            this._scriptFile.Size = new System.Drawing.Size(340, 20);
-            this._scriptFile.TabIndex = 6;
             this._scriptFile.TextChanged += new System.EventHandler(this.Changed);
             // 
             // NodejsGeneralPropertyPageControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this._scriptLabel);
             this.Controls.Add(this._scriptFile);
@@ -283,9 +202,7 @@
             this.Controls.Add(this._scriptArguments);
             this.Controls.Add(this._nodeExeArguments);
             this.Controls.Add(this._nodeExePath);
-            this.MinimumSize = new System.Drawing.Size(303, 303);
             this.Name = "NodejsGeneralPropertyPageControl";
-            this.Size = new System.Drawing.Size(488, 318);
             ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.resx
@@ -117,10 +117,583 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="_nodeExePathLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="_nodeExePathLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 22</value>
+  </data>
+  <data name="_nodeExePathLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 13</value>
+  </data>
+  <data name="_nodeExePathLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="_nodeExePathLabel.Text" xml:space="preserve">
+    <value>Node.exe &amp;path:</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePathLabel.Name" xml:space="preserve">
+    <value>_nodeExePathLabel</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePathLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePathLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePathLabel.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="_nodeArguments.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_nodeArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 48</value>
+  </data>
+  <data name="_nodeArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 13</value>
+  </data>
+  <data name="_nodeArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="_nodeArguments.Text" xml:space="preserve">
+    <value>N&amp;ode.exe options:</value>
+  </data>
+  <data name="&gt;&gt;_nodeArguments.Name" xml:space="preserve">
+    <value>_nodeArguments</value>
+  </data>
+  <data name="&gt;&gt;_nodeArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodeArguments.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodeArguments.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="_startBrowser.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_startBrowser.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 284</value>
+  </data>
+  <data name="_startBrowser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>161, 17</value>
+  </data>
+  <data name="_startBrowser.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="_startBrowser.Text" xml:space="preserve">
+    <value>St&amp;art web browser on launch</value>
+  </data>
+  <data name="&gt;&gt;_startBrowser.Name" xml:space="preserve">
+    <value>_startBrowser</value>
+  </data>
+  <data name="&gt;&gt;_startBrowser.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_startBrowser.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_startBrowser.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="_nodeExePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_nodeExePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 19</value>
+  </data>
+  <data name="_nodeExePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>308, 20</value>
+  </data>
+  <data name="_nodeExePath.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePath.Name" xml:space="preserve">
+    <value>_nodeExePath</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePath.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodeExePath.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="_nodeExeArguments.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_nodeExeArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 45</value>
+  </data>
+  <data name="_nodeExeArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 20</value>
+  </data>
+  <data name="_nodeExeArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeArguments.Name" xml:space="preserve">
+    <value>_nodeExeArguments</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeArguments.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeArguments.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="_nodejsPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 176</value>
+  </data>
+  <data name="_nodejsPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 20</value>
+  </data>
+  <data name="_nodejsPort.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;_nodejsPort.Name" xml:space="preserve">
+    <value>_nodejsPort</value>
+  </data>
+  <data name="&gt;&gt;_nodejsPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodejsPort.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodejsPort.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="_nodePortLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_nodePortLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 179</value>
+  </data>
+  <data name="_nodePortLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="_nodePortLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="_nodePortLabel.Text" xml:space="preserve">
+    <value>Node.&amp;js port:</value>
+  </data>
+  <data name="&gt;&gt;_nodePortLabel.Name" xml:space="preserve">
+    <value>_nodePortLabel</value>
+  </data>
+  <data name="&gt;&gt;_nodePortLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodePortLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_nodePortLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="_scriptArgsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_scriptArgsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 100</value>
+  </data>
+  <data name="_scriptArgsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="_scriptArgsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="_scriptArgsLabel.Text" xml:space="preserve">
+    <value>Script ar&amp;guments:</value>
+  </data>
+  <data name="&gt;&gt;_scriptArgsLabel.Name" xml:space="preserve">
+    <value>_scriptArgsLabel</value>
+  </data>
+  <data name="&gt;&gt;_scriptArgsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_scriptArgsLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_scriptArgsLabel.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="_scriptArguments.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_scriptArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 97</value>
+  </data>
+  <data name="_scriptArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 20</value>
+  </data>
+  <data name="_scriptArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;_scriptArguments.Name" xml:space="preserve">
+    <value>_scriptArguments</value>
+  </data>
+  <data name="&gt;&gt;_scriptArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_scriptArguments.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_scriptArguments.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="_workingDirLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_workingDirLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 126</value>
+  </data>
+  <data name="_workingDirLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 13</value>
+  </data>
+  <data name="_workingDirLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="_workingDirLabel.Text" xml:space="preserve">
+    <value>Working director&amp;y:</value>
+  </data>
+  <data name="&gt;&gt;_workingDirLabel.Name" xml:space="preserve">
+    <value>_workingDirLabel</value>
+  </data>
+  <data name="&gt;&gt;_workingDirLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_workingDirLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_workingDirLabel.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="_workingDir.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_workingDir.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 123</value>
+  </data>
+  <data name="_workingDir.Size" type="System.Drawing.Size, System.Drawing">
+    <value>308, 20</value>
+  </data>
+  <data name="_workingDir.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;_workingDir.Name" xml:space="preserve">
+    <value>_workingDir</value>
+  </data>
+  <data name="&gt;&gt;_workingDir.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_workingDir.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_workingDir.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="_launchUrl.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_launchUrl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 150</value>
+  </data>
+  <data name="_launchUrl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 20</value>
+  </data>
+  <data name="_launchUrl.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;_launchUrl.Name" xml:space="preserve">
+    <value>_launchUrl</value>
+  </data>
+  <data name="&gt;&gt;_launchUrl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_launchUrl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_launchUrl.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="_launchUrlLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_launchUrlLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 153</value>
+  </data>
+  <data name="_launchUrlLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="_launchUrlLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="_launchUrlLabel.Text" xml:space="preserve">
+    <value>Launch &amp;URL:</value>
+  </data>
+  <data name="&gt;&gt;_launchUrlLabel.Name" xml:space="preserve">
+    <value>_launchUrlLabel</value>
+  </data>
+  <data name="&gt;&gt;_launchUrlLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_launchUrlLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_launchUrlLabel.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
   <metadata name="_tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="_envVars.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_envVars.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 228</value>
+  </data>
+  <data name="_envVars.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_envVars.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Both</value>
+  </data>
+  <data name="_envVars.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 50</value>
+  </data>
+  <data name="_envVars.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;_envVars.Name" xml:space="preserve">
+    <value>_envVars</value>
+  </data>
+  <data name="&gt;&gt;_envVars.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_envVars.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_envVars.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="_browsePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="_browsePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>449, 17</value>
+  </data>
+  <data name="_browsePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>26, 23</value>
+  </data>
+  <data name="_browsePath.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="_browsePath.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
+    <value>_browsePath</value>
+  </data>
+  <data name="&gt;&gt;_browsePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_browsePath.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_browsePath.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="_browseDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="_browseDirectory.Location" type="System.Drawing.Point, System.Drawing">
+    <value>449, 121</value>
+  </data>
+  <data name="_browseDirectory.Size" type="System.Drawing.Size, System.Drawing">
+    <value>26, 23</value>
+  </data>
+  <data name="_browseDirectory.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="_browseDirectory.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
+    <value>_browseDirectory</value>
+  </data>
+  <data name="&gt;&gt;_browseDirectory.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_browseDirectory.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_browseDirectory.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <metadata name="_nodeExeErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>110, 17</value>
   </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="_scriptLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_scriptLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 74</value>
+  </data>
+  <data name="_scriptLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 13</value>
+  </data>
+  <data name="_scriptLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="_scriptLabel.Text" xml:space="preserve">
+    <value>&amp;Script (startup file):</value>
+  </data>
+  <data name="&gt;&gt;_scriptLabel.Name" xml:space="preserve">
+    <value>_scriptLabel</value>
+  </data>
+  <data name="&gt;&gt;_scriptLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_scriptLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_scriptLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="_scriptFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_scriptFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 71</value>
+  </data>
+  <data name="_scriptFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 20</value>
+  </data>
+  <data name="_scriptFile.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;_scriptFile.Name" xml:space="preserve">
+    <value>_scriptFile</value>
+  </data>
+  <data name="&gt;&gt;_scriptFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_scriptFile.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_scriptFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="_envVarsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_envVarsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 231</value>
+  </data>
+  <data name="_envVarsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 13</value>
+  </data>
+  <data name="_envVarsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="_envVarsLabel.Text" xml:space="preserve">
+    <value>Environment &amp;Variables:</value>
+  </data>
+  <data name="&gt;&gt;_envVarsLabel.Name" xml:space="preserve">
+    <value>_envVarsLabel</value>
+  </data>
+  <data name="&gt;&gt;_envVarsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_envVarsLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_envVarsLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="_debuggerPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>135, 202</value>
+  </data>
+  <data name="_debuggerPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 20</value>
+  </data>
+  <data name="_debuggerPort.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPort.Name" xml:space="preserve">
+    <value>_debuggerPort</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPort.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPort.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="_debuggerPortLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_debuggerPortLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 205</value>
+  </data>
+  <data name="_debuggerPortLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 13</value>
+  </data>
+  <data name="_debuggerPortLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="_debuggerPortLabel.Text" xml:space="preserve">
+    <value>&amp;Debugger port:</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPortLabel.Name" xml:space="preserve">
+    <value>_debuggerPortLabel</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPortLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPortLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_debuggerPortLabel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>303, 303</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>488, 318</value>
+  </data>
+  <data name="&gt;&gt;_tooltip.Name" xml:space="preserve">
+    <value>_tooltip</value>
+  </data>
+  <data name="&gt;&gt;_tooltip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeErrorProvider.Name" xml:space="preserve">
+    <value>_nodeExeErrorProvider</value>
+  </data>
+  <data name="&gt;&gt;_nodeExeErrorProvider.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>NodejsGeneralPropertyPageControl</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>


### PR DESCRIPTION
**Bug**
The Nodejs Project properties page contains embedded strings that should be localized.

**Fix**
Extract strings to their own resx files using the approach described here: https://msdn.microsoft.com/en-us/library/y99d1cd3(v=vs.71).aspx

This will allow us to properly localize the form in the future.