### PR TITLE
Change OnPropertyChange strings to use `nameof`

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/LastRefreshedMessageProvider.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/LastRefreshedMessageProvider.cs
@@ -65,8 +65,5 @@ namespace Microsoft.NodejsTools.NpmUI {
         public int Days { get; private set; }
 
         public string Description { get; private set; }
-
-        public bool IsOld { get { return Days > 7; } }
-        public bool IsAncient { get { return Days > 14; } }
     }
 }

--- a/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmOutputViewModel.cs
@@ -99,9 +99,9 @@ namespace Microsoft.NodejsTools.NpmUI {
                     Pulse();
                 }
                 OnPropertyChanged();
-                OnPropertyChanged("ExecutionProgressVisibility");
-                OnPropertyChanged("ExecutionIdleVisibility");
-                OnPropertyChanged("IsCancellable");
+                OnPropertyChanged(nameof(ExecutionProgressVisibility));
+                OnPropertyChanged(nameof(ExecutionIdleVisibility));
+                OnPropertyChanged(nameof(IsCancellable));
             }
         }
 
@@ -148,7 +148,7 @@ namespace Microsoft.NodejsTools.NpmUI {
             }
 
             UpdateStatusMessage();
-            OnPropertyChanged("IsCancellable");
+            OnPropertyChanged(nameof(IsCancellable));
         }
 
         private void QueueCommand(QueuedNpmCommandInfo info) {
@@ -162,7 +162,7 @@ namespace Microsoft.NodejsTools.NpmUI {
             }
 
             UpdateStatusMessageSafe();
-            OnPropertyChanged("IsCancellable");
+            OnPropertyChanged(nameof(IsCancellable));
         }
 
         public void QueueCommand(string arguments) {
@@ -217,7 +217,7 @@ namespace Microsoft.NodejsTools.NpmUI {
 
         private void HandleCompletionSafe() {
             UpdateStatusMessage();
-            OnPropertyChanged("IsCancellable");
+            OnPropertyChanged(nameof(IsCancellable));
         }
 
         private void commander_CommandCompleted(object sender, NpmCommandCompletedEventArgs e) {

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -118,7 +118,7 @@ namespace Microsoft.NodejsTools.NpmUI {
             private set {
                 _isLoadingCatalog = value;
                 OnPropertyChanged();
-                OnPropertyChanged("CanRefreshCatalog");
+                OnPropertyChanged(nameof(CanRefreshCatalog));
             }
         }
 
@@ -155,7 +155,7 @@ namespace Microsoft.NodejsTools.NpmUI {
             set {
                 _loadingCatalogControlVisibility = value;
                 OnPropertyChanged();
-                OnPropertyChanged("FilterControlsVisibility");
+                OnPropertyChanged(nameof(FilterControlsVisibility));
             }
         }
         
@@ -258,7 +258,7 @@ namespace Microsoft.NodejsTools.NpmUI {
             set {
                 _isFiltering = value;
                 OnPropertyChanged();
-                OnPropertyChanged("PackageFilterState");
+                OnPropertyChanged(nameof(PackageFilterState));
             }
         }
 
@@ -276,7 +276,7 @@ namespace Microsoft.NodejsTools.NpmUI {
                 // PackageFilterState should be triggered before FilteredPackages
                 // to allow the UI to update the status before the package list,
                 // making for a smoother experience.
-                OnPropertyChanged("PackageFilterState");
+                OnPropertyChanged(nameof(PackageFilterState));
                 OnPropertyChanged();
             }
         }
@@ -290,7 +290,7 @@ namespace Microsoft.NodejsTools.NpmUI {
                 IsFiltering = !string.IsNullOrWhiteSpace(_filterText);
 
                 OnPropertyChanged();
-                OnPropertyChanged("PackageFilterState");
+                OnPropertyChanged(nameof(PackageFilterState));
             }
         }
 

--- a/Nodejs/Product/Profiling/Profiling/CompareReportsView.cs
+++ b/Nodejs/Product/Profiling/Profiling/CompareReportsView.cs
@@ -80,7 +80,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_baselineFile != value) {
                     _baselineFile = value;
-                    OnPropertyChanged("BaselineFile");
+                    OnPropertyChanged(nameof(BaselineFile));
                 }
             }
         }
@@ -95,7 +95,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_comparisonFile != value) {
                     _comparisonFile = value;
-                    OnPropertyChanged("ComparisonFile");
+                    OnPropertyChanged(nameof(ComparisonFile));
                 }
             }
         }
@@ -119,7 +119,7 @@ namespace Microsoft.NodejsTools.Profiling {
             private set {
                 if (_isValid != value) {
                     _isValid = value;
-                    OnPropertyChanged("IsValid");
+                    OnPropertyChanged(nameof(IsValid));
                 }
             }
         }

--- a/Nodejs/Product/Profiling/Profiling/ProfilingTargetView.cs
+++ b/Nodejs/Product/Profiling/Profiling/ProfilingTargetView.cs
@@ -127,7 +127,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_project != value) {
                     _project = value;
-                    OnPropertyChanged("Project");
+                    OnPropertyChanged(nameof(Project));
                 }
             }
         }
@@ -142,7 +142,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_isProjectSelected != value) {
                     _isProjectSelected = value;
-                    OnPropertyChanged("IsProjectSelected");
+                    OnPropertyChanged(nameof(IsProjectSelected));
                 }
             }
         }
@@ -164,7 +164,7 @@ namespace Microsoft.NodejsTools.Profiling {
                         _standalone.PropertyChanged += Standalone_PropertyChanged;
                     }
 
-                    OnPropertyChanged("Standalone");
+                    OnPropertyChanged(nameof(Standalone));
                 }
             }
         }
@@ -179,7 +179,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_isStandaloneSelected != value) {
                     _isStandaloneSelected = value;
-                    OnPropertyChanged("IsStandaloneSelected");
+                    OnPropertyChanged(nameof(IsStandaloneSelected));
                 }
             }
         }
@@ -204,7 +204,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// </summary>
         private void Standalone_PropertyChanged(object sender, PropertyChangedEventArgs e) {
             Debug.Assert(Standalone == sender);
-            OnPropertyChanged("Standalone");
+            OnPropertyChanged(nameof(Standalone));
         }
 
 
@@ -218,7 +218,7 @@ namespace Microsoft.NodejsTools.Profiling {
             private set {
                 if (_isValid != value) {
                     _isValid = value;
-                    OnPropertyChanged("IsValid");
+                    OnPropertyChanged(nameof(IsValid));
                 }
             }
         }

--- a/Nodejs/Product/Profiling/Profiling/StandaloneTargetView.cs
+++ b/Nodejs/Product/Profiling/Profiling/StandaloneTargetView.cs
@@ -85,7 +85,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_interpreterPath != value) {
                     _interpreterPath = value;
-                    OnPropertyChanged("InterpreterPath");
+                    OnPropertyChanged(nameof(InterpreterPath));
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_scriptPath != value) {
                     _scriptPath = value;
-                    OnPropertyChanged("ScriptPath");
+                    OnPropertyChanged(nameof(ScriptPath));
                     //if (string.IsNullOrEmpty(WorkingDirectory)) {
                     //    WorkingDirectory = Path.GetDirectoryName(_scriptPath);
                     //}
@@ -118,7 +118,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_workingDirectory != value) {
                     _workingDirectory = value;
-                    OnPropertyChanged("WorkingDirectory");
+                    OnPropertyChanged(nameof(WorkingDirectory));
                 }
             }
         }
@@ -133,7 +133,7 @@ namespace Microsoft.NodejsTools.Profiling {
             set {
                 if (_arguments != value) {
                     _arguments = value;
-                    OnPropertyChanged("Arguments");
+                    OnPropertyChanged(nameof(Arguments));
                 }
             }
         }
@@ -164,7 +164,7 @@ namespace Microsoft.NodejsTools.Profiling {
             private set {
                 if (_isValid != value) {
                     _isValid = value;
-                    OnPropertyChanged("IsValid");
+                    OnPropertyChanged(nameof(IsValid));
                 }
             }
         }


### PR DESCRIPTION
**Bug**
Most of our calls to `OnPropertyChange` currently use string values. This is problematic because strings are not strongly typed, so they can easily get out of sync with the actual property names.

**Fix**
Change these calls to use `nameof` instead. This ensures that an error is produced if the names ever get out of sync. Also this makes c# refactorings do the correct thing.

**testing**
Checked the flows where these properties are used to verify they still work as expected.