### PR TITLE
Extract UI string from profiling ui

### DIFF
--- a/Nodejs/Product/Profiling/Profiling.csproj
+++ b/Nodejs/Product/Profiling/Profiling.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>

--- a/Nodejs/Product/Profiling/Profiling/CompareReportsWindow.xaml
+++ b/Nodejs/Product/Profiling/Profiling/CompareReportsWindow.xaml
@@ -4,7 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:Microsoft.NodejsTools.Profiling"
     xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf;assembly=Microsoft.NodejsTools"
-    Title="Select analysis files for comparison"
+    xmlns:resx="clr-namespace:Microsoft.NodejsTools.Profiling"
+    Title="{x:Static resx:Resources.CompareWindowTitle}"
     MinWidth="300" MinHeight="220"
     Width="500" Height="auto" SizeToContent="Height"
     WindowStartupLocation="CenterOwner"
@@ -37,7 +38,7 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <Label Grid.Row="0" Content="_Baseline File:" />
+        <Label Grid.Row="0" Content="{x:Static resx:Resources.BaselineFileLabel}" />
         <Grid Grid.Row="1" Margin="0 0 0 6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -50,7 +51,7 @@
             <Button Grid.Column="1" Click="BaselineBrowseClick" Style="{StaticResource BrowseButtonStyle}" />
         </Grid>
 
-        <Label Grid.Row="2" Content="Co_mparison File:" />
+        <Label Grid.Row="2" Content="{x:Static resx:Resources.ComparisionFileLabel}" />
         <Grid Grid.Row="3" Margin="0 0 0 6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -68,13 +69,11 @@
                     Margin="0 12 0 0">
             <Button IsDefault="True" Click="OkClick" IsEnabled="{Binding IsValid}"
                     MinWidth="86" MinHeight="24"
-                    AutomationProperties.AutomationId="Ok">
-                _OK
-            </Button>
+                    AutomationProperties.AutomationId="Ok"
+                    Content="{x:Static resx:Resources.OkButtonContent}" />
             <Button IsCancel="True" Click="CancelClick" MinWidth="86" MinHeight="24"
-                    AutomationProperties.AutomationId="Cancel">
-                _Cancel
-            </Button>
+                    AutomationProperties.AutomationId="Cancel"
+                    Content="{x:Static resx:Resources.CancelButtonContent}" />
         </StackPanel>
     </Grid>
 </ui:DialogWindowVersioningWorkaround>

--- a/Nodejs/Product/Profiling/Profiling/LaunchProfiling.xaml
+++ b/Nodejs/Product/Profiling/Profiling/LaunchProfiling.xaml
@@ -4,7 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:Microsoft.NodejsTools.Profiling"
     xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf;assembly=Microsoft.NodejsTools"
-    Title="Profiling Settings" 
+    xmlns:resx="clr-namespace:Microsoft.NodejsTools.Profiling"
+    Title="{x:Static resx:Resources.ProfilingSettingsTitle}" 
     MinHeight="440" Width="700" 
     MinWidth="400"
     SizeToContent="Height"
@@ -32,10 +33,13 @@
                 <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
 
-            <Label Grid.Row="0" Content="What would you like to profile?" Margin="6 12 6 0" FontWeight="Bold" />
+            <Label Grid.Row="0"
+                   Content="{x:Static resx:Resources.ProfilingSettingsHeader}"
+                   Margin="6 12 6 0"
+                   FontWeight="Bold" />
 
             <RadioButton Grid.Row="1" Margin="12 12 12 4"
-                                 Content="_Open project"
+                                 Content="{x:Static resx:Resources.OpenProjectButton}"
                                  AutomationProperties.AutomationId="ProfileProject"
                                  GroupName="ProjectOrStandalone"
                                  IsEnabled="{Binding IsAnyAvailableProjects}"
@@ -49,7 +53,7 @@
                               AutomationProperties.AutomationId="Project" />
 
             <RadioButton Grid.Row="3" Margin="12 12 12 4"
-                                 Content="S_tandalone script" 
+                                 Content="{x:Static resx:Resources.StandaloneScriptLabel}" 
                                  AutomationProperties.AutomationId="ProfileScript"
                                  GroupName="ProjectOrStandalone"
                                  IsChecked="{Binding IsStandaloneSelected}" />
@@ -68,7 +72,7 @@
                         <RowDefinition Height="auto" />
                     </Grid.RowDefinitions>
 
-                    <Label Grid.Row="1" Grid.Column="0" Content="_Node Path:"
+                    <Label Grid.Row="1" Grid.Column="0" Content="{x:Static resx:Resources.NodePathLabel}"
                                    Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="1" Grid.Column="1" Margin="4">
                         <Grid.ColumnDefinitions>
@@ -83,7 +87,7 @@
                                         Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="2" Grid.Column="0" Content="Sc_ript:"
+                    <Label Grid.Row="2" Grid.Column="0" Content="{x:Static resx:Resources.ScriptLabel}"
                                    Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="2" Grid.Column="1" Margin="4">
                         <Grid.ColumnDefinitions>
@@ -98,7 +102,7 @@
                                         Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="3" Grid.Column="0" Content="_Working Directory:"
+                    <Label Grid.Row="3" Grid.Column="0" Content="{x:Static resx:Resources.WorkingDirectoryLabel}"
                                    Padding="0" VerticalAlignment="Center" />
                     <Grid Grid.Row="3" Grid.Column="1" Margin="4">
                         <Grid.ColumnDefinitions>
@@ -113,7 +117,7 @@
                                         Width="{Binding RelativeSource={RelativeSource Self},Path=ActualHeight}" />
                     </Grid>
 
-                    <Label Grid.Row="4" Grid.Column="0" Content="Command Line _Arguments:"
+                    <Label Grid.Row="4" Grid.Column="0" Content="{x:Static resx:Resources.CommandLineArgumentsLabel}"
                                    Padding="0" VerticalAlignment="Center" />
                     <TextBox Grid.Row="4" Grid.Column="1" Margin="4"
                                      Text="{Binding Standalone.Arguments,UpdateSourceTrigger=PropertyChanged}"
@@ -127,9 +131,8 @@
                     AutomationProperties.AutomationId="Ok"
                     Content="{Binding StartText}"/>
             <Button IsCancel="True" Click="CancelClick" MinWidth="86" MinHeight="24"
-                    AutomationProperties.AutomationId="Cancel">
-                _Cancel
-            </Button>
+                    AutomationProperties.AutomationId="Cancel"
+                    Content="{x:Static resx:Resources.CancelButtonContent}" />
         </StackPanel>
     </Grid>
 </ui:DialogWindowVersioningWorkaround>

--- a/Nodejs/Product/Profiling/Resources.Designer.cs
+++ b/Nodejs/Product/Profiling/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NodejsTools.Profiling {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Microsoft.NodejsTools.Profiling {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NodejsTools.Profiling.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace Microsoft.NodejsTools.Profiling {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Baseline File:.
         /// </summary>
-        internal static string BaselineFileLabel {
+        public static string BaselineFileLabel {
             get {
                 return ResourceManager.GetString("BaselineFileLabel", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Cancel.
         /// </summary>
-        internal static string CancelButtonContent {
+        public static string CancelButtonContent {
             get {
                 return ResourceManager.GetString("CancelButtonContent", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Command Line _Arguments:.
         /// </summary>
-        internal static string CommandLineArgumentsLabel {
+        public static string CommandLineArgumentsLabel {
             get {
                 return ResourceManager.GetString("CommandLineArgumentsLabel", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Select analysis files for comparison.
         /// </summary>
-        internal static string CompareWindowTitle {
+        public static string CompareWindowTitle {
             get {
                 return ResourceManager.GetString("CompareWindowTitle", resourceCulture);
             }
@@ -99,16 +99,16 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Co_mparison File:.
         /// </summary>
-        internal static string ComparisonFileLabel {
+        public static string ComparisionFileLabel {
             get {
-                return ResourceManager.GetString("ComparisonFileLabel", resourceCulture);
+                return ResourceManager.GetString("ComparisionFileLabel", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Failed to build project, do you want to launch profiling anyway?.
         /// </summary>
-        internal static string FailedToBuild {
+        public static string FailedToBuild {
             get {
                 return ResourceManager.GetString("FailedToBuild", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Failed to open file {0}.
         /// </summary>
-        internal static string FailedToOpenFileErrorMessageText {
+        public static string FailedToOpenFileErrorMessageText {
             get {
                 return ResourceManager.GetString("FailedToOpenFileErrorMessageText", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Failed to read performance session {0}.
         /// </summary>
-        internal static string FailedToReadPerformanceSessionMessageText {
+        public static string FailedToReadPerformanceSessionMessageText {
             get {
                 return ResourceManager.GetString("FailedToReadPerformanceSessionMessageText", resourceCulture);
             }
@@ -138,7 +138,7 @@ namespace Microsoft.NodejsTools.Profiling {
         ///
         ///No profiling data is available..
         /// </summary>
-        internal static string FailedToSaveV8LogMessageText {
+        public static string FailedToSaveV8LogMessageText {
             get {
                 return ResourceManager.GetString("FailedToSaveV8LogMessageText", resourceCulture);
             }
@@ -147,7 +147,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Project has no configured startup file, cannot start profiling..
         /// </summary>
-        internal static string NoConfiguredStatupFileErrorMessageText {
+        public static string NoConfiguredStatupFileErrorMessageText {
             get {
                 return ResourceManager.GetString("NoConfiguredStatupFileErrorMessageText", resourceCulture);
             }
@@ -156,7 +156,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Node.js Tools for Visual Studio.
         /// </summary>
-        internal static string NodejsToolsForVS {
+        public static string NodejsToolsForVS {
             get {
                 return ResourceManager.GetString("NodejsToolsForVS", resourceCulture);
             }
@@ -165,7 +165,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Node Path:.
         /// </summary>
-        internal static string NodePathLabel {
+        public static string NodePathLabel {
             get {
                 return ResourceManager.GetString("NodePathLabel", resourceCulture);
             }
@@ -174,7 +174,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to No Profiling Target.
         /// </summary>
-        internal static string NoProfilingConfiguredMessageCaption {
+        public static string NoProfilingConfiguredMessageCaption {
             get {
                 return ResourceManager.GetString("NoProfilingConfiguredMessageCaption", resourceCulture);
             }
@@ -183,7 +183,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Profiling session is not configured - would you like to configure now and then launch?.
         /// </summary>
-        internal static string NoProfilingConfiguredMessageText {
+        public static string NoProfilingConfiguredMessageText {
             get {
                 return ResourceManager.GetString("NoProfilingConfiguredMessageText", resourceCulture);
             }
@@ -192,7 +192,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _OK.
         /// </summary>
-        internal static string OkButtonContent {
+        public static string OkButtonContent {
             get {
                 return ResourceManager.GetString("OkButtonContent", resourceCulture);
             }
@@ -201,7 +201,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Open project.
         /// </summary>
-        internal static string OpenProjectButton {
+        public static string OpenProjectButton {
             get {
                 return ResourceManager.GetString("OpenProjectButton", resourceCulture);
             }
@@ -210,7 +210,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Performance report no longer exists: {0}.
         /// </summary>
-        internal static string PerformanceReportNoLongerExistsMessageText {
+        public static string PerformanceReportNoLongerExistsMessageText {
             get {
                 return ResourceManager.GetString("PerformanceReportNoLongerExistsMessageText", resourceCulture);
             }
@@ -219,7 +219,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _OK.
         /// </summary>
-        internal static string ProfilingOk {
+        public static string ProfilingOk {
             get {
                 return ResourceManager.GetString("ProfilingOk", resourceCulture);
             }
@@ -228,7 +228,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to What would you like to profile?.
         /// </summary>
-        internal static string ProfilingSettingsHeader {
+        public static string ProfilingSettingsHeader {
             get {
                 return ResourceManager.GetString("ProfilingSettingsHeader", resourceCulture);
             }
@@ -237,7 +237,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Profiling Settings.
         /// </summary>
-        internal static string ProfilingSettingsTitle {
+        public static string ProfilingSettingsTitle {
             get {
                 return ResourceManager.GetString("ProfilingSettingsTitle", resourceCulture);
             }
@@ -246,7 +246,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Start.
         /// </summary>
-        internal static string ProfilingStart {
+        public static string ProfilingStart {
             get {
                 return ResourceManager.GetString("ProfilingStart", resourceCulture);
             }
@@ -255,7 +255,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Project could not be found in current solution..
         /// </summary>
-        internal static string ProjectNotFoundErrorMessageText {
+        public static string ProjectNotFoundErrorMessageText {
             get {
                 return ResourceManager.GetString("ProjectNotFoundErrorMessageText", resourceCulture);
             }
@@ -264,7 +264,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to Sc_ript:.
         /// </summary>
-        internal static string ScriptLabel {
+        public static string ScriptLabel {
             get {
                 return ResourceManager.GetString("ScriptLabel", resourceCulture);
             }
@@ -273,7 +273,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to S_tandalone script.
         /// </summary>
-        internal static string StandaloneScriptLabel {
+        public static string StandaloneScriptLabel {
             get {
                 return ResourceManager.GetString("StandaloneScriptLabel", resourceCulture);
             }
@@ -285,7 +285,7 @@ namespace Microsoft.NodejsTools.Profiling {
         ///There is probably a second copy of node.exe running
         ///and the results may be unavailable or incorrect..
         /// </summary>
-        internal static string UnableToDeleteV8Log {
+        public static string UnableToDeleteV8Log {
             get {
                 return ResourceManager.GetString("UnableToDeleteV8Log", resourceCulture);
             }
@@ -294,7 +294,7 @@ namespace Microsoft.NodejsTools.Profiling {
         /// <summary>
         ///   Looks up a localized string similar to _Working Directory:.
         /// </summary>
-        internal static string WorkingDirectoryLabel {
+        public static string WorkingDirectoryLabel {
             get {
                 return ResourceManager.GetString("WorkingDirectoryLabel", resourceCulture);
             }

--- a/Nodejs/Product/Profiling/Resources.Designer.cs
+++ b/Nodejs/Product/Profiling/Resources.Designer.cs
@@ -61,6 +61,51 @@ namespace Microsoft.NodejsTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Baseline File:.
+        /// </summary>
+        internal static string BaselineFileLabel {
+            get {
+                return ResourceManager.GetString("BaselineFileLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Cancel.
+        /// </summary>
+        internal static string CancelButtonContent {
+            get {
+                return ResourceManager.GetString("CancelButtonContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command Line _Arguments:.
+        /// </summary>
+        internal static string CommandLineArgumentsLabel {
+            get {
+                return ResourceManager.GetString("CommandLineArgumentsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select analysis files for comparison.
+        /// </summary>
+        internal static string CompareWindowTitle {
+            get {
+                return ResourceManager.GetString("CompareWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Co_mparison File:.
+        /// </summary>
+        internal static string ComparisonFileLabel {
+            get {
+                return ResourceManager.GetString("ComparisonFileLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to build project, do you want to launch profiling anyway?.
         /// </summary>
         internal static string FailedToBuild {
@@ -118,6 +163,15 @@ namespace Microsoft.NodejsTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Node Path:.
+        /// </summary>
+        internal static string NodePathLabel {
+            get {
+                return ResourceManager.GetString("NodePathLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No Profiling Target.
         /// </summary>
         internal static string NoProfilingConfiguredMessageCaption {
@@ -132,6 +186,24 @@ namespace Microsoft.NodejsTools.Profiling {
         internal static string NoProfilingConfiguredMessageText {
             get {
                 return ResourceManager.GetString("NoProfilingConfiguredMessageText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _OK.
+        /// </summary>
+        internal static string OkButtonContent {
+            get {
+                return ResourceManager.GetString("OkButtonContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Open project.
+        /// </summary>
+        internal static string OpenProjectButton {
+            get {
+                return ResourceManager.GetString("OpenProjectButton", resourceCulture);
             }
         }
         
@@ -154,6 +226,24 @@ namespace Microsoft.NodejsTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to What would you like to profile?.
+        /// </summary>
+        internal static string ProfilingSettingsHeader {
+            get {
+                return ResourceManager.GetString("ProfilingSettingsHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profiling Settings.
+        /// </summary>
+        internal static string ProfilingSettingsTitle {
+            get {
+                return ResourceManager.GetString("ProfilingSettingsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Start.
         /// </summary>
         internal static string ProfilingStart {
@@ -172,6 +262,24 @@ namespace Microsoft.NodejsTools.Profiling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sc_ript:.
+        /// </summary>
+        internal static string ScriptLabel {
+            get {
+                return ResourceManager.GetString("ScriptLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to S_tandalone script.
+        /// </summary>
+        internal static string StandaloneScriptLabel {
+            get {
+                return ResourceManager.GetString("StandaloneScriptLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to delete &apos;{0}&apos;.
         ///
         ///There is probably a second copy of node.exe running
@@ -180,6 +288,15 @@ namespace Microsoft.NodejsTools.Profiling {
         internal static string UnableToDeleteV8Log {
             get {
                 return ResourceManager.GetString("UnableToDeleteV8Log", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Working Directory:.
+        /// </summary>
+        internal static string WorkingDirectoryLabel {
+            get {
+                return ResourceManager.GetString("WorkingDirectoryLabel", resourceCulture);
             }
         }
     }

--- a/Nodejs/Product/Profiling/Resources.resx
+++ b/Nodejs/Product/Profiling/Resources.resx
@@ -174,7 +174,7 @@ and the results may be unavailable or incorrect.</value>
   <data name="CompareWindowTitle" xml:space="preserve">
     <value>Select analysis files for comparison</value>
   </data>
-  <data name="ComparisonFileLabel" xml:space="preserve">
+  <data name="ComparisionFileLabel" xml:space="preserve">
     <value>Co_mparison File:</value>
   </data>
   <data name="NodePathLabel" xml:space="preserve">

--- a/Nodejs/Product/Profiling/Resources.resx
+++ b/Nodejs/Product/Profiling/Resources.resx
@@ -162,4 +162,43 @@ No profiling data is available.</value>
 There is probably a second copy of node.exe running
 and the results may be unavailable or incorrect.</value>
   </data>
+  <data name="BaselineFileLabel" xml:space="preserve">
+    <value>_Baseline File:</value>
+  </data>
+  <data name="CancelButtonContent" xml:space="preserve">
+    <value>_Cancel</value>
+  </data>
+  <data name="CommandLineArgumentsLabel" xml:space="preserve">
+    <value>Command Line _Arguments:</value>
+  </data>
+  <data name="CompareWindowTitle" xml:space="preserve">
+    <value>Select analysis files for comparison</value>
+  </data>
+  <data name="ComparisonFileLabel" xml:space="preserve">
+    <value>Co_mparison File:</value>
+  </data>
+  <data name="NodePathLabel" xml:space="preserve">
+    <value>_Node Path:</value>
+  </data>
+  <data name="OkButtonContent" xml:space="preserve">
+    <value>_OK</value>
+  </data>
+  <data name="OpenProjectButton" xml:space="preserve">
+    <value>_Open project</value>
+  </data>
+  <data name="ProfilingSettingsHeader" xml:space="preserve">
+    <value>What would you like to profile?</value>
+  </data>
+  <data name="ProfilingSettingsTitle" xml:space="preserve">
+    <value>Profiling Settings</value>
+  </data>
+  <data name="ScriptLabel" xml:space="preserve">
+    <value>Sc_ript:</value>
+  </data>
+  <data name="StandaloneScriptLabel" xml:space="preserve">
+    <value>S_tandalone script</value>
+  </data>
+  <data name="WorkingDirectoryLabel" xml:space="preserve">
+    <value>_Working Directory:</value>
+  </data>
 </root>


### PR DESCRIPTION
Issue #1378 

##### Bug
`LaunchProfiling.xaml` contains hardcoded UI strings. This prevents the UI from being properly localized.

##### Fix
Extract all of these strings to resource files so that they can be properly localized.

Closes #1378 