### PR TITLE
Extract Two Title Strings for Project Import Wizard

### DIFF
--- a/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Save Project.
+        /// </summary>
+        public static string SaveProjectPageTitle {
+            get {
+                return ResourceManager.GetString("SaveProjectPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to We won&apos;t move any files from where they are now..
         /// </summary>
         public static string SelectNodeCodeHelpText {
@@ -165,6 +174,15 @@ namespace Microsoft.NodejsTools {
         public static string SelectNodeCodeTitle {
             get {
                 return ResourceManager.GetString("SelectNodeCodeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source Files.
+        /// </summary>
+        public static string SourceFilesPageTitle {
+            get {
+                return ResourceManager.GetString("SourceFilesPageTitle", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/ImportWizardResources.resx
+++ b/Nodejs/Product/Nodejs/ImportWizardResources.resx
@@ -147,11 +147,17 @@
   <data name="SaveFileLocationTitle" xml:space="preserve">
     <value>Select where to save your project file</value>
   </data>
+  <data name="SaveProjectPageTitle" xml:space="preserve">
+    <value>Save Project</value>
+  </data>
   <data name="SelectNodeCodeHelpText" xml:space="preserve">
     <value>We won't move any files from where they are now.</value>
   </data>
   <data name="SelectNodeCodeTitle" xml:space="preserve">
     <value>Enter or browse to the folder containing your Node.js code</value>
+  </data>
+  <data name="SourceFilesPageTitle" xml:space="preserve">
+    <value>Source Files</value>
   </data>
   <data name="Welcome" xml:space="preserve">
     <value>Welcome to the Create New Project from Existing Node.js Code Wizard</value>

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/FileSourcePage.xaml
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/FileSourcePage.xaml
@@ -9,7 +9,7 @@
       xmlns:resx="clr-namespace:Microsoft.NodejsTools"
       mc:Ignorable="d" 
       d:DesignHeight="300" d:DesignWidth="500"
-      Title="Source Files"
+      Title="{x:Static resx:ImportWizardResources.SourceFilesPageTitle}"
       FocusManager.FocusedElement="{Binding ElementName=SourcePathTextBox}">
     <Page.Resources>
         <ResourceDictionary Source="ImportWizardDictionary.xaml" />

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/SaveProjectPage.xaml
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/SaveProjectPage.xaml
@@ -9,7 +9,7 @@
       xmlns:resx="clr-namespace:Microsoft.NodejsTools"
       mc:Ignorable="d" 
       d:DesignHeight="300" d:DesignWidth="500"
-      Title="Save Project"
+      Title="{x:Static resx:ImportWizardResources.SaveProjectPageTitle}"
       FocusManager.FocusedElement="{Binding ElementName=ProjectPathTextBox}">
 
     <Page.Resources>


### PR DESCRIPTION
**Bug**
I missed extracting a few strings from the import wizard ui in #1371 and 1369.

**Fix**
Extract these strings as well so that they can be localized.