### PR TITLE
Fix Test Adapter Dll Reference

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -730,6 +730,16 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>.</VSIXSubPath>
     </Content>
+    <Content Include="$(OutputPath)\Microsoft.VisualStudio.Shell.Interop.8.0.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>.</VSIXSubPath>
+    </Content>
+    <Content Include="$(OutputPath)\envdte.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>.</VSIXSubPath>
+	</Content>
     <Content Include="Credits.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
**Bug**
In VS15, many assemblies have been moved out of the GAC. This can prevent our test adapter from loading properly. 

**fix**
We already copy a few dlls into our package and reference these dlls in the vsix. This change ensures we also copy over the shell.interop.8.0 and envdte dll