### PR TITLE
Have TestExecutor run multiple tests with a single instance of node

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -72,9 +72,12 @@ var run_tests = function (testCases, callback) {
         try {
             var testCase = require(testCases[test].testFile);
             result.title = testCases[test].testName;
+            result.time = Date.now();
             testCase[testCases[test].testName]();
+            result.time = Date.now() - result.time;
             result.passed = true;
         } catch (err) {
+            result.time = Date.now() - result.time;
             result.passed = false;
             console.error(err.name);
             console.error(err.message);

--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -1,6 +1,22 @@
 var fs = require('fs');
 var path = require('path');
 var vm = require('vm');
+var result = {
+    'title': '',
+    'passed': false,
+    'stdOut': '',
+    'stdErr': '',
+    'time': 0
+};
+
+function append_stdout(string, encoding, fd) {
+    result.stdOut += string;
+}
+function append_stderr(string, encoding, fd) {
+    result.stdErr += string;
+}
+process.stdout.write = append_stdout;
+process.stderr.write = append_stderr;
 
 var find_tests = function (testFileList, discoverResultFile) {
     var debug;
@@ -50,8 +66,28 @@ var find_tests = function (testFileList, discoverResultFile) {
 };
 module.exports.find_tests = find_tests;
 
-var run_tests = function (testName, testFile) {
-    var testCase = require(testFile);
-    testCase[testName]();
+var run_tests = function (testCases, callback) {
+    var test_results = [];
+    for (var test in testCases) {
+        try {
+            var testCase = require(testCases[test].testFile);
+            result.title = testCases[test].testName;
+            testCase[testCases[test].testName]();
+            result.passed = true;
+        } catch (err) {
+            result.passed = false;
+            console.error(err.name);
+            console.error(err.message);
+        }
+        test_results.push(result)
+        result = {
+            'title': '',
+            'passed': false,
+            'stdOut': '',
+            'stdErr': '',
+            'time': 0
+        };
+    }
+    callback(test_results);
 };
 module.exports.run_tests = run_tests;

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -3,10 +3,11 @@ var EOL = require('os').EOL;
 var fs = require('fs');
 var path = require('path');
 var result = {
-    "title": "",
-    "passed": false,
-    "stdOut": "",
-    "stdErr": ""
+    'title': '',
+    'passed': false,
+    'stdOut': '',
+    'stdErr': '',
+    'time': ''
 };
 // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
 // 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
@@ -69,23 +70,28 @@ var find_tests = function (testFileList, discoverResultFile, projectFolder) {
 };
 module.exports.find_tests = find_tests;
 
-var run_tests = function (testName, testFile, workingFolder, projectFolder, callback) {
-    //var testResults = [];
-    var Mocha = detectMocha(projectFolder);
+var run_tests = function (testCases, callback) {
+    function escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    }
+
+    var testResults = [];
+    var Mocha = detectMocha(testCases[0].projectFolder);
     if (!Mocha) {
         return;
     }
 
-    var mocha = initializeMocha(Mocha, projectFolder);
+    var mocha = initializeMocha(Mocha, testCases[0].projectFolder);
 
-    //if (testName) {
-    //    if (typeof mocha.fgrep === 'function')
-    //        mocha.fgrep(testName); // since Mocha 3.0.0
-    //    else
-    //        mocha.grep(testName); // prior Mocha 3.0.0
-    //}
+    var testGrepString = '^(' + testCases.map(function (testCase) {
+        return testCase.testName
+    }).join('|') + ')$';
 
-    mocha.addFile(testFile);
+    if (testGrepString) {
+        mocha.grep(new RegExp(testGrepString));
+    }
+
+    mocha.addFile(testCases[0].testFile);
 
     // run tests
     var runner = mocha.run(function (code) { process.exit(code); });
@@ -94,29 +100,35 @@ var run_tests = function (testName, testFile, workingFolder, projectFolder, call
     });
     runner.on('test', function (test) {
         result.title = test.title;
+        result.time = Date.now();
         process.stdout.write = append_stdout;
         process.stderr.write = append_stderr;
     });
     runner.on('end', function () {
+        callback(testResults);
     });
     runner.on('pass', function (test) {
         result.passed = true;
-        callback(result);
+        result.time = Date.now() - result.time;
+        testResults.push(result);
         result = {
             'title': '',
             'passed': false,
             'stdOut': '',
-            'stdErr': ''
+            'stdErr': '',
+            'time': ''
         }
     });
     runner.on('fail', function (test, err) {
         result.passed = false;
-        callback(result);
+        result.time = Date.now() - result.time;
+        testResults.push(result);
         result = {
             'title': '',
             'passed': false,
             'stdOut': '',
-            'stdErr': ''
+            'stdErr': '',
+            'time': ''
         }
     });
 };

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -7,7 +7,7 @@ var result = {
     'passed': false,
     'stdOut': '',
     'stdErr': '',
-    'time': ''
+    'time': 0
 };
 // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
 // 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
@@ -94,12 +94,12 @@ var run_tests = function (testCases, callback) {
     mocha.addFile(testCases[0].testFile);
 
     // run tests
-    var runner = mocha.run(function (code) { process.exit(code); });
+    var runner = mocha.run(function (code) { });
 
     runner.on('start', function () {
     });
     runner.on('test', function (test) {
-        result.title = test.title;
+        result.title = test.fullTitle();
         result.time = Date.now();
         process.stdout.write = append_stdout;
         process.stderr.write = append_stderr;

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -8,27 +8,31 @@ var rl = readline.createInterface({
 });
 
 rl.on('line', (line) => {
-    var testInfo = JSON.parse(line);
+    var testCases = JSON.parse(line);
     // get rid of leftover quotations from C# (necessary?)
-    for(var s in testInfo) {
-        testInfo[s] = testInfo[s].replace(/["]+/g, '');
+    for (var test in testCases) {
+        for (var value in testCases[test]) {
+            testCases[test][value] = testCases[test][value].replace(/["]+/g, '');
+        }
     }
 
     try {
-        framework = require('./' + testInfo.framework + '/' + testInfo.framework + '.js');
+        framework = require('./' + testCases[0].framework + '/' + testCases[0].framework + '.js');
     } catch (exception) {
-        console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+        console.log("NTVS_ERROR:Failed to load TestFramework (" + testCases[0].framework + "), " + exception);
         process.exit(1);
     }
     
-    function sendResult(result) {
+    function returnResult(result) {
+        // unhook stdout and stderr
         process.stdout.write = old_stdout;
         process.stderr.write = old_stderr;
         console.log(JSON.stringify(result));
-        //process.exit(0);
+        // end process, tests are done running.
+        process.exit(0);
     }
     // run the test
-    framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder, sendResult);
+    framework.run_tests(testCases, returnResult);
     
     // close readline interface
     //rl.close();

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -27,7 +27,9 @@ rl.on('line', (line) => {
         // unhook stdout and stderr
         process.stdout.write = old_stdout;
         process.stderr.write = old_stderr;
-        console.log(JSON.stringify(result));
+        if (result) {
+            console.log(JSON.stringify(result));
+        }
         // end process, tests are done running.
         process.exit(0);
     }
@@ -35,5 +37,5 @@ rl.on('line', (line) => {
     framework.run_tests(testCases, returnResult);
     
     // close readline interface
-    //rl.close();
+    rl.close();
 });

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -327,9 +327,10 @@ namespace Microsoft.NodejsTools.TestAdapter {
             if (tests.Count() == results.Count()) {
                 TestResult result;
                 foreach(var res in results) {
+                    // If tests were run using "Run Selected Tests", the `tests` and `results` lists 
+                    // may not have the tests in the same order --so we query the test title from the `tests` list.
                     var test = tests.Where(n => n.DisplayName == res.title);
                     if(test.Count() == 1) {
-                        //frameworkHandle.RecordStart(test.First());
                         result = new TestResult(test.First());
                         result.Outcome = res.passed ? TestOutcome.Passed : TestOutcome.Failed;
                         result.Duration = new TimeSpan(0, 0, 0, 0, res.time);

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -29,7 +29,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
-using Newtonsoft.Json.Linq;
 using MSBuild = Microsoft.Build.Evaluation;
 using Newtonsoft.Json;
 
@@ -41,11 +40,13 @@ namespace Microsoft.NodejsTools.TestAdapter {
             passed = false;
             stdout = String.Empty;
             stderr = String.Empty;
+            time = 0;
         }
         public string title { get; set; }
         public bool passed { get; set; }
         public string stdout { get; set; }
         public string stderr { get; set; }
+        public int time { get; set; }
     }
 
     [ExtensionUri(TestExecutor.ExecutorUriString)]
@@ -70,7 +71,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
         }
 
         /// <summary>
-        /// This is the equivallent of "RunAll" functionality
+        /// This is the equivalent of "RunAll" functionality
         /// </summary>
         /// <param name="sources">Refers to the list of test sources passed to the test adapter from the client.  (Client could be VS or command line)</param>
         /// <param name="runContext">Defines the settings related to the current run</param>
@@ -94,17 +95,11 @@ namespace Microsoft.NodejsTools.TestAdapter {
             // okay.
             using (var app = VisualStudioApp.FromEnvironmentVariable(NodejsConstants.NodeToolsProcessIdEnvironmentVariable)) {
                 // .njsproj file path -> project settings
-
                 var projectToTests = new Dictionary<string, List<TestCase>>();
                 var sourceToSettings = new Dictionary<string, NodejsProjectSettings>();
                 NodejsProjectSettings settings = null;
 
                 // put tests into dictionary where key is their project working directory
-                // NOTE: It seems to me that if we were to run all tests over multiple projects in a solution, 
-                // we would have to separate the tests by their project in order to launch the node process
-                // correctly (to make sure we are using the correct working folder) and also to run
-                // groups of tests by test suite.
-
                 foreach (var test in receiver.Tests) {
                     if (!sourceToSettings.TryGetValue(test.Source, out settings)) {
                         sourceToSettings[test.Source] = settings = LoadProjectSettings(test.Source);
@@ -130,58 +125,118 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     // launch node process
                     LaunchNodeProcess(settings.WorkingDir, settings.NodeExePath, args);
                     // Run all test cases in a given project
-                    RunTestCases(entry.Value, runContext, frameworkHandle);
+                    RunTestCases(entry.Value, runContext, frameworkHandle, settings);
                     // dispose node process
                     _nodeProcess.Dispose();
                 }
             }
         }
 
+        /// <summary>
+        /// This is the equivalent of "Run Selected Tests" functionality.
+        /// </summary>
+        /// <param name="tests">The list of TestCases selected to run</param>
+        /// <param name="runContext">Defines the settings related to the current run</param>
+        /// <param name="frameworkHandle">Handle to framework.  Used for recording results</param>
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle) {
             ValidateArg.NotNull(tests, "tests");
             ValidateArg.NotNull(runContext, "runContext");
             ValidateArg.NotNull(frameworkHandle, "frameworkHandle");
             _cancelRequested.Reset();
-            bool hasExited = false;
-            bool isNull = _nodeProcess == null;
-            if (!isNull) {
-                hasExited = _nodeProcess.HasExited;
-            }
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, isNull.ToString());
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, hasExited.ToString());
-            if ( _nodeProcess == null || _nodeProcess.HasExited ) {
-                frameworkHandle.SendMessage(TestMessageLevel.Informational, "inside RunTests if statement");
-                TestCase firstTest = tests.First();
-                NodejsProjectSettings settings = LoadProjectSettings(firstTest.Source);
-                List<string> args = new List<string>();
-                args.AddRange(GetInterpreterArgs(firstTest, settings.WorkingDir, settings.ProjectRootDir));
-                LaunchNodeProcess(settings.WorkingDir, settings.NodeExePath, args);
-            }
 
-            RunTestCases(tests, runContext, frameworkHandle);
+            TestCase firstTest = tests.First();
+            NodejsProjectSettings settings = LoadProjectSettings(firstTest.Source);
+            List<string> args = new List<string>();
+            args.AddRange(GetInterpreterArgs(firstTest, settings.WorkingDir, settings.ProjectRootDir));
 
+            LaunchNodeProcess(settings.WorkingDir, settings.NodeExePath, args);
+            // Run all test cases selected
+            RunTestCases(tests, runContext, frameworkHandle, settings);
             _nodeProcess.Dispose();
         }
 
-        private void RunTestCases(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle) {
+        private void RunTestCases(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle, NodejsProjectSettings settings) {
             // May be null, but this is handled by RunTestCase if it matters.
             // No VS instance just means no debugging, but everything else is
             // okay.
             using (var app = VisualStudioApp.FromEnvironmentVariable(NodejsConstants.NodeToolsProcessIdEnvironmentVariable)) {
+                int port = 0;
                 // .njsproj file path -> project settings
                 var sourceToSettings = new Dictionary<string, NodejsProjectSettings>();
-
+                TestCaseObject testObject;
+                List<TestCaseObject> testObjects = new List<TestCaseObject>();
                 foreach (var test in tests) {
                     if (_cancelRequested.WaitOne(0)) {
                         break;
                     }
+                    frameworkHandle.RecordStart(test);
 
-                    try {
-                        RunTestCase(app, frameworkHandle, runContext, test, sourceToSettings);
-                    } catch (Exception ex) {
-                        frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
+                    if (settings == null) {
+                        frameworkHandle.SendMessage(
+                            TestMessageLevel.Error,
+                            "Unable to determine interpreter to use for " + test.Source);
+                        frameworkHandle.RecordEnd(test, TestOutcome.Failed);
                     }
+
+                    NodejsTestInfo testInfo = new NodejsTestInfo(test.FullyQualifiedName);
+                    List<string> args = new List<string>();
+                    if (runContext.IsBeingDebugged && app != null) {
+                        app.GetDTE().Debugger.DetachAll();
+                        args.AddRange(GetDebugArgs(settings, out port));
+                    }
+
+                    var workingDir = Path.GetDirectoryName(CommonUtils.GetAbsoluteFilePath(settings.WorkingDir, testInfo.ModulePath));
+                    args.AddRange(GetInterpreterArgs(test, workingDir, settings.ProjectRootDir));
+
+                    //Debug.Fail("attach debugger");
+                    if (!File.Exists(settings.NodeExePath)) {
+                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Interpreter path does not exist: " + settings.NodeExePath);
+                        return;
+                    }
+                    testObject = new TestCaseObject(args[1], args[2], args[3], args[4], args[5]);
+                    testObjects.Add(testObject);
                 }
+
+                if (!_nodeProcess.HasExited) {
+                    // send testcases to run_tests.js
+                    _nodeProcess.StandardInput.WriteLine(JsonConvert.SerializeObject(testObjects));
+                    _nodeProcess.StandardInput.Close();
+                    _nodeProcess.WaitForExit();
+                }
+
+                if (runContext.IsBeingDebugged && app != null) {
+                    try {
+                        //the '#ping=0' is a special flag to tell VS node debugger not to connect to the port,
+                        //because a connection carries the consequence of setting off --debug-brk, and breakpoints will be missed.
+                        string qualifierUri = string.Format("tcp://localhost:{0}#ping=0", port);
+                        //while (!app.AttachToProcess(_nodeProcess, NodejsRemoteDebugPortSupplierUnsecuredId, qualifierUri)) {
+                        //    if (_nodeProcess.Wait(TimeSpan.FromMilliseconds(500))) {
+                        //        break;
+                        //    }
+                        //}
+#if DEBUG
+                    } catch (COMException ex) {
+                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
+                        frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
+                        KillNodeProcess();
+                    }
+#else
+                    } catch (COMException) {
+                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
+                        KillNodeProcess();
+                    }
+#endif
+                }
+            }
+            var results = GetTestResultFromProcess(_nodeProcess.StandardOutput);
+
+            bool runCancelled = _cancelRequested.WaitOne(0);
+
+            if (results != null) {
+                RecordEnd(frameworkHandle, tests, results);
+            }
+            else {
+                frameworkHandle.SendMessage(TestMessageLevel.Error, "Failed to obtain results");
             }
         }
 
@@ -214,113 +269,24 @@ namespace Microsoft.NodejsTools.TestAdapter {
             };
         }
 
-        private void RunTestCase(VisualStudioApp app, IFrameworkHandle frameworkHandle, IRunContext runContext, TestCase test, Dictionary<string, NodejsProjectSettings> sourceToSettings) {
-            var testResult = new TestResult(test);
-            frameworkHandle.RecordStart(test);
-            testResult.StartTime = DateTimeOffset.Now;
-            NodejsProjectSettings settings;
-            if (!sourceToSettings.TryGetValue(test.Source, out settings)) {
-                sourceToSettings[test.Source] = settings = LoadProjectSettings(test.Source);
-            }
-            if (settings == null) {
-                frameworkHandle.SendMessage(
-                    TestMessageLevel.Error,
-                    "Unable to determine interpreter to use for " + test.Source);
-                RecordEnd(
-                    frameworkHandle,
-                    test,
-                    testResult,
-                    null,
-                    "Unable to determine interpreter to use for " + test.Source,
-                    TestOutcome.Failed);
-                return;
-            }
-
-            NodejsTestInfo testInfo = new NodejsTestInfo(test.FullyQualifiedName);
-            List<string> args = new List<string>();
-            int port = 0;
-            if (runContext.IsBeingDebugged && app != null) {
-                app.GetDTE().Debugger.DetachAll();
-                args.AddRange(GetDebugArgs(settings, out port));
-            }
-
-            var workingDir = Path.GetDirectoryName(CommonUtils.GetAbsoluteFilePath(settings.WorkingDir, testInfo.ModulePath));
-            args.AddRange(GetInterpreterArgs(test, workingDir, settings.ProjectRootDir));
-
-            //Debug.Fail("attach debugger");
-            if (!File.Exists(settings.NodeExePath)) {
-                frameworkHandle.SendMessage(TestMessageLevel.Error, "Interpreter path does not exist: " + settings.NodeExePath);
-                return;
-            }
-
-            lock (_syncObject) {
-#if DEBUG
-                frameworkHandle.SendMessage(TestMessageLevel.Informational, "cd " + workingDir);
-                //frameworkHandle.SendMessage(TestMessageLevel.Informational, _nodeProcess.Arguments);
-#endif
-                // send test to run_tests.js
-                TestCaseObject testObject = new TestCaseObject(args[1], args[2], args[3], args[4], args[5]);
-                if (!_nodeProcess.HasExited) {
-                    _nodeProcess.StandardInput.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(testObject));
-                    _nodeProcess.StandardInput.Close();
-                    _nodeProcess.WaitForExit(5000);
-                }       
-                if (runContext.IsBeingDebugged && app != null) {
-                    try {
-                        //the '#ping=0' is a special flag to tell VS node debugger not to connect to the port,
-                        //because a connection carries the consequence of setting off --debug-brk, and breakpoints will be missed.
-                        string qualifierUri = string.Format("tcp://localhost:{0}#ping=0", port);
-                        //while (!app.AttachToProcess(_nodeProcess, NodejsRemoteDebugPortSupplierUnsecuredId, qualifierUri)) {
-                        //    if (_nodeProcess.Wait(TimeSpan.FromMilliseconds(500))) {
-                        //        break;
-                        //    }
-                        //}
-#if DEBUG
-                    } catch (COMException ex) {
-                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
-                        frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
-                        KillNodeProcess();
-                    }
-#else
-                    } catch (COMException) {
-                        frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
-                        KillNodeProcess();
-                    }
-#endif
-                }
-            }
-            var result = GetTestResultFromProcess(_nodeProcess.StandardOutput);
-
-            bool runCancelled = _cancelRequested.WaitOne(0);
-
-            if (result != null) {
-                RecordEnd(frameworkHandle, test, testResult,
-                    result.stdout,
-                    result.stderr,
-                    (!runCancelled && result.passed) ? TestOutcome.Passed : TestOutcome.Failed);
-            } else {
-                frameworkHandle.SendMessage(TestMessageLevel.Error, "Failed to obtain result for " + test.DisplayName + " from TestRunner");
-            }
-        }
-
-        private ResultObject ParseTestResult(string line) {
-            ResultObject jsonResult = null;
+        private List<ResultObject> ParseTestResult(string line) {
+            List<ResultObject> jsonResults = null;
             try {
-                jsonResult = JsonConvert.DeserializeObject<ResultObject>(line);
+                jsonResults = JsonConvert.DeserializeObject<List<ResultObject>>(line);
             } catch (Exception) { }
-            return jsonResult;
+            return jsonResults;
         }
 
-        private ResultObject GetTestResultFromProcess(StreamReader sr) {
-            ResultObject result = null;
+        private List<ResultObject> GetTestResultFromProcess(StreamReader sr) {
+            List<ResultObject> results = null;
             while (sr.Peek() >= 0) {
-                result = ParseTestResult(sr.ReadLine());
-                if (result == null) {
+                results = ParseTestResult(sr.ReadLine());
+                if (results == null) {
                     continue;
                 }
                 break;
             }
-            return result;
+            return results;
         }
 
         private void LaunchNodeProcess(string workingDir, string nodeExePath, List<string> args) {
@@ -357,16 +323,24 @@ namespace Microsoft.NodejsTools.TestAdapter {
             return projSettings;
         }
 
-        private static void RecordEnd(IFrameworkHandle frameworkHandle, TestCase test, TestResult result, string stdout, string stderr, TestOutcome outcome) {
-            result.EndTime = DateTimeOffset.Now;
-            result.Duration = result.EndTime - result.StartTime;
-            result.Outcome = outcome;
-            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, stdout));
-            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, stderr));
-            result.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, stderr));
-
-            frameworkHandle.RecordResult(result);
-            frameworkHandle.RecordEnd(test, outcome);
+        private static void RecordEnd(IFrameworkHandle frameworkHandle, IEnumerable<TestCase> tests, List<ResultObject> results) {
+            if (tests.Count() == results.Count()) {
+                TestResult result;
+                foreach(var res in results) {
+                    var test = tests.Where(n => n.DisplayName == res.title);
+                    if(test.Count() == 1) {
+                        //frameworkHandle.RecordStart(test.First());
+                        result = new TestResult(test.First());
+                        result.Outcome = res.passed ? TestOutcome.Passed : TestOutcome.Failed;
+                        result.Duration = new TimeSpan(0, 0, 0, 0, res.time);
+                        result.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, res.stdout));
+                        result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, res.stderr));
+                        result.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, res.stderr));
+                        frameworkHandle.RecordResult(result);
+                        frameworkHandle.RecordEnd(test.First(), result.Outcome);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Hello!

In this batch of changes, I've enabled `TestExecutor` to run multiple tests with a single instance of node. I've also changed `run_tests.js` to accept a list of tests and return a list of results, and I've modified the test frameworks to record results and test durations.

Some caveats and questions:

- For `tape.js`, I haven't found a good way to determine test pass/failure. As of right now, `tape` tests are not 100% accurate. Using the template provided by NTVS, both tests are passing (expected is one pass and one fail). I looked at the API but couldn't find anything exposed to allow me to determine if a test has passed or not. Maybe I'm looking in the wrong place... Any suggestions?
- I've altered `RecordEnd` to accept a list of results. Since I call `RecordStart` for every test in the test list right away, in the VS Test Explorer all tests being run will be shown as running until they all finish (at the same time), instead of being shown as running when they are ACTUALLY being run by the test frameworks. This is not ideal, but I can't think of a way to do this properly if I'm passing around a list of tests... Let me know if there are any issues with this. I can elaborate if need be.
- Tests taking 0ms don't display as '<1ms' in VS Test Explorer. Do you know why? To record test duration I simply time the tests within the test frameworks themselves and then pass the value of `result.time` to `TestResult.Duration`. 

Please let me know if there are any areas where I should take a second look or improve. At this point the changes are functional but need some more testing. Mocha tests now run in the proper order (your `grep` suggestion worked like a charm-- thanks!)

Thanks again