### PR TITLE
Update SwixBuild For VS15

### DIFF
--- a/Nodejs/Setup/swix/packages.config
+++ b/Nodejs/Setup/swix/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0"/>
-  <package id="MicroBuild.Plugins.SwixBuild" version="1.0.18"/>
+  <package id="MicroBuild.Plugins.SwixBuild" version="1.0.71"/>
 </packages>


### PR DESCRIPTION
VS has requested to we update our SwixBuild dependency in order to properly support some new packaging features. This change just bumps the version of the package.