### PR TITLE
Fix For WebTools.WebLinter Exception When Opening a Css/Js File inside a Folder

### DIFF
--- a/Common/Product/SharedProject/Automation/OAProjectItem.cs
+++ b/Common/Product/SharedProject/Automation/OAProjectItem.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudioTools.Project.Automation {
                     return ((OAProject)parentNode.GetAutomationObject()).ProjectItems;
                 } else {
                     // Not supported. Override this method in derived classes to return appropriate collection object
-                    throw new InvalidOperationException();
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
#1185

**Bug**
When we open a css/js file inside of a folder in an ntvs project, the webtools linter throws an exception.

I believe the root cause is that the linter calls into `OAProjectItem.Collection` (the implementation of `EnvDTE.ProjectItem.Collection`). When the file is inside of a folder, we throw an `InvalidOperationException`. WebTools should handle this (and they took a fix into VS15) but we can also workaround this behavior on our side.

**Fix**
Instead of throwing an exception, return null. Other overrides of `Collection` also return null, so I believe this the correct behavior.

**Testing**
Tested originally failing scenario. No exception seen. Also tried opening a bunch of other files and did not see any odd behavior or exceptions.

Closes #1185