### PR TITLE
Switch to Branch Blacklist for main AppVeyor Build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 -
   version: 1.0.{build}
   branches:
-    only:
-    - master
+    except:
+    - v1.1.x
     - v1.2.x
   skip_tags: true
   image: Visual Studio 2015
@@ -45,6 +45,25 @@
     - path: NTVS_Out
       name: NtvsOut
       type: zip
+-
+  version: 1.0.{build}
+  branches:
+    only:
+    - v1.2.x
+  skip_tags: true
+  image: Visual Studio 2015
+  environment:
+    matrix:
+    - nodejs_version: 4
+      vs_version: 14.0
+      architecture: x64
+    - nodejs_version: 5
+      vs_version: 14.0
+      architecture: x86
+  install: *default_install_script
+  build_script: *default_build_script
+  test_script: *default_test_script
+  artifacts: *default_artifacts
 -
   version: 1.0.{build}
   branches:


### PR DESCRIPTION
**Bug**
Issue #1388. Some of our branches (such as feature branches) are currently not built by appveyor because we use a branch whitelist. We have to opt new branches into appveyor.

**Fix**
Change the main build to use a branch blacklist instead. Also gives the `v1.2.x` branch it's own build definition and excludes it from the main build.

Closes #1388