### PR TITLE
Fix Path used For Resolving Target File Location for Tests in VS15 RC+

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -217,7 +217,7 @@ namespace Microsoft.NodejsTools {
             Environment.SetEnvironmentVariable(NodejsConstants.NodeToolsProcessIdEnvironmentVariable, Process.GetCurrentProcess().Id.ToString());
 
 #if DEV15
-            var devenvPath = Environment.GetEnvironmentVariable("VSAPPIDPATH");
+            var devenvPath = Environment.GetEnvironmentVariable("VSAPPIDDIR");
             if (!string.IsNullOrEmpty(devenvPath)) {
                 try {
                     var root = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(devenvPath), @"..\.."));


### PR DESCRIPTION
In VS15 RC, we should use the VSAPPIDDIR instead of VSAPPIDPATH to pick up the path to the visual studio install root.