### PR TITLE
Don't Show Create File Menu Item for Non NTVS Projects

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsTools.vsct
+++ b/Nodejs/Product/Nodejs/NodejsTools.vsct
@@ -97,6 +97,8 @@
         
       <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewFileCommand" priority="0x0550" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <ButtonText>New File...</ButtonText>
         </Strings>


### PR DESCRIPTION
**Bug**
A tester reported that our `Create File...` context menu command is showing up in C# projects. When selected, the menu item does not have any effect in these projects.

**Fix**
Add the proper attributes to hide this command by default in non-NTVS projects.