### PR TITLE
Don't Show Create File Menu Item for Non NTVS Projects For VS15

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsTools.vsct
+++ b/Nodejs/Product/Nodejs/NodejsTools.vsct
@@ -97,6 +97,8 @@
         
       <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewJavaScriptFileCommand" priority="0x0550" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <ButtonText>JavaScript File...</ButtonText>
         </Strings>
@@ -104,6 +106,8 @@
 
       <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewTypeScriptFileCommand" priority="0x0551" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <ButtonText>TypeScript File...</ButtonText>
         </Strings>
@@ -111,6 +115,8 @@
 
       <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewHTMLFileCommand" priority="0x0552" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <ButtonText>HTML File...</ButtonText>
         </Strings>
@@ -118,6 +124,8 @@
 
       <Button guid="guidNodeToolsCmdSet" id="cmdidAddNewCSSFileCommand" priority="0x0553" type="Button">
         <Parent guid="guidNodeToolsCmdSet" id="AddNewFileGroup"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <ButtonText>CSS File...</ButtonText>
         </Strings>

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -914,11 +914,11 @@ namespace Microsoft.NodejsTools.Project {
                             }
                         }
                         break;
-						case PkgCmdId.cmdidAddNewJavaScriptFileCommand: 
-					case PkgCmdId.cmdidAddNewTypeScriptFileCommand: 
-					case PkgCmdId.cmdidAddNewHTMLFileCommand: 
-					case PkgCmdId.cmdidAddNewCSSFileCommand: 
-						return QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED; 
+                    case PkgCmdId.cmdidAddNewJavaScriptFileCommand: 
+                    case PkgCmdId.cmdidAddNewTypeScriptFileCommand: 
+                    case PkgCmdId.cmdidAddNewHTMLFileCommand: 
+                    case PkgCmdId.cmdidAddNewCSSFileCommand: 
+                        return QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED; 
                 }
             }
 


### PR DESCRIPTION
**Bug**
A tester reported that our `Create JavaScript...` context menu commands are showing up in C# projects. When selected, these menu items do not have any effect in these projects.

**Fix**
Add the proper attributes to hide these command by default in non-NTVS projects.