### PR TITLE
Don't Register as Language(VsTemplate)="JavaScript" in Vs15

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -71,7 +71,13 @@ namespace Microsoft.NodejsTools {
 #endif
     [ProvideDebugLanguage(NodejsConstants.Nodejs, Guids.NodejsDebugLanguageString, NodeExpressionEvaluatorGuid, AD7Engine.DebugEngineId)]
     [WebSiteProject("JavaScript", "JavaScript")]
-    [ProvideProjectFactory(typeof(NodejsProjectFactory), null, null, null, null, ".\\NullPath", LanguageVsTemplate = NodejsConstants.JavaScript, SortPriority=0x17)]   // outer flavor, no file extension
+    [ProvideProjectFactory(typeof(NodejsProjectFactory), null, null, null, null, ".\\NullPath",
+#if DEV14
+        LanguageVsTemplate = NodejsConstants.JavaScript,
+#else
+        LanguageVsTemplate = NodejsConstants.Nodejs,
+#endif
+        SortPriority = 0x17)]   // outer flavor, no file extension
     [ProvideDebugPortSupplier("Node remote debugging", typeof(NodeRemoteDebugPortSupplier), NodeRemoteDebugPortSupplier.PortSupplierId)]
     [ProvideMenuResource(1000, 1)]                              // This attribute is needed to let the shell know that this package exposes some menus.
     [ProvideProjectItem(typeof(BaseNodeProjectFactory), NodejsConstants.Nodejs, "FileTemplates\\NewItem", 0)]


### PR DESCRIPTION
Same change as #1396, but cherry-picked into the vs15 branch

**Bug**
The Uwp team contacted us about some of their tests breaking when NTVS is installed in VS15. The root cause seems to be that they attempt to retrieve their "JavaScript" file templates using the vssdk, and this only ends up returning the NTVS templates.

**Fix**
Only in VS15, don't register as a "JavaScript" language template provider.