### PR TITLE
Support Running EnvironmentSetup.ps1 in VS15 Post Preview 3

### DIFF
--- a/Build/VisualStudioHelpers.psm1
+++ b/Build/VisualStudioHelpers.psm1
@@ -1,6 +1,6 @@
 function get_target_vs_versions {
     param($vstarget)
-        
+ 
     $supported_vs_versions = (
         @{number="15.0"; name="VS 15"; build_by_default=$true},    
         @{number="14.0"; name="VS 2015"; build_by_default=$true}
@@ -9,16 +9,22 @@ function get_target_vs_versions {
     $target_versions = @()
 
     if ($vstarget) {
-        $vstarget = $vstarget | %{ "{0:00.0}" -f [float]::Parse($_) }
+        $vstarget = "{0:00.0}" -f [float]::Parse($vstarget)
     }
     foreach ($target_vs in $supported_vs_versions) {
-            if ((-not $vstarget -and $target_vs.build_by_default) -or ($target_vs.number -in $vstarget)) {
+        if ((-not $vstarget -and $target_vs.build_by_default) -or ($target_vs.number -in $vstarget)) {
             $vspath = Get-ItemProperty -Path "HKLM:\Software\Wow6432Node\Microsoft\VisualStudio\$($target_vs.number)" -EA 0
             if (-not $vspath) {
                 $vspath = Get-ItemProperty -Path "HKLM:\Software\Microsoft\VisualStudio\$($target_vs.number)" -EA 0
             }
             if ($vspath -and $vspath.InstallDir -and (Test-Path -Path $vspath.InstallDir)) {
-                $target_versions += $target_vs
+				$msbuildroot = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\v$($vstarget)"
+                $target_versions += @{
+					number=$target_vs.number;
+					name=$target_vs.name;
+					vsoot=$vspath.InstallDir;
+					msbuildroot=$msbuildroot
+				}
             }
         }
     }
@@ -32,4 +38,15 @@ function get_target_vs_versions {
     }
     
     return $target_versions
+}
+
+function get_target_vs15_version {
+	param($vsroot)
+	$msbuildroot="${vsroot}\MSBuild\Microsoft\VisualStudio\v15.0\Node.js Tools\Microsoft.NodejsTools.targets"
+	return @{
+		number="15.0";
+		name="VS 15";
+		vsoot=$root;
+		msbuildroot=$msbuildroot
+	}; 
 }

--- a/Build/VisualStudioHelpers.psm1
+++ b/Build/VisualStudioHelpers.psm1
@@ -18,13 +18,13 @@ function get_target_vs_versions {
                 $vspath = Get-ItemProperty -Path "HKLM:\Software\Microsoft\VisualStudio\$($target_vs.number)" -EA 0
             }
             if ($vspath -and $vspath.InstallDir -and (Test-Path -Path $vspath.InstallDir)) {
-				$msbuildroot = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\v$($vstarget)"
+                $msbuildroot = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\v$($vstarget)"
                 $target_versions += @{
-					number=$target_vs.number;
-					name=$target_vs.name;
-					vsoot=$vspath.InstallDir;
-					msbuildroot=$msbuildroot
-				}
+                    number=$target_vs.number;
+                    name=$target_vs.name;
+                    vsoot=$vspath.InstallDir;
+                    msbuildroot=$msbuildroot
+                }
             }
         }
     }
@@ -41,12 +41,12 @@ function get_target_vs_versions {
 }
 
 function get_target_vs15_version {
-	param($vsroot)
-	$msbuildroot="${vsroot}\MSBuild\Microsoft\VisualStudio\v15.0\Node.js Tools\Microsoft.NodejsTools.targets"
-	return @{
-		number="15.0";
-		name="VS 15";
-		vsoot=$root;
-		msbuildroot=$msbuildroot
-	}; 
+    param($vsroot)
+    $msbuildroot="${vsroot}\MSBuild\Microsoft\VisualStudio\v15.0\Node.js Tools\Microsoft.NodejsTools.targets"
+    return @{
+        number="15.0";
+        name="VS 15";
+        vsoot=$root;
+        msbuildroot=$msbuildroot
+    }; 
 }

--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -8,6 +8,13 @@
     
     Valid values: "14.0", "15.0"
     
+.Parameter vsroot
+    [Optional] For VS15 only. Specifies the installation root directory of visual studio
+    
+    Example: "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
+    
+    Must be specified when building for VS15.
+    
 .Example
     .\EnvironmentSetup.ps1
     

--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -22,7 +22,7 @@
 [CmdletBinding()]
 param(
     [string] $vstarget,
-	[string] $vsroot,
+    [string] $vsroot,
     [switch] $microbuild,
     [switch] $skipTestHost
 )
@@ -39,9 +39,9 @@ Write-Output "Repository root: $($rootDir)"
 Import-Module -Force $rootDir\Build\VisualStudioHelpers.psm1
 $target_versions = (, '')
 if ([string]::IsNullOrEmpty($vsroot)) {
-	$target_versions = get_target_vs_versions (, $vstarget)
+    $target_versions = get_target_vs_versions (, $vstarget)
 } else {
-	$target_versions = get_target_vs15_version $vsroot
+    $target_versions = get_target_vs15_version $vsroot
 }
 
 Write-Output "Setting up NTVS development environment for $([String]::Join(", ", ($target_versions | % { $_.name })))"
@@ -69,8 +69,8 @@ Write-Output "Copying required files"
 foreach ($version in $target_versions) {    
     # Copy Microsoft.NodejsTools.targets file to relevant location
     $from = "$rootDir\Nodejs\Product\Nodejs\Microsoft.NodejsTools.targets"
-	$to = "$($version.msbuildroot)\Node.js Tools\Microsoft.NodejsTools.targets"
-	Write-Output $version
+    $to = "$($version.msbuildroot)\Node.js Tools\Microsoft.NodejsTools.targets"
+    Write-Output $version
     Write-Output "    $($from) -> $($to)"
     New-Item -Force $to > $null
     Copy-Item -Force $from $to

--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -37,12 +37,11 @@ Write-Output "Repository root: $($rootDir)"
 
 
 Import-Module -Force $rootDir\Build\VisualStudioHelpers.psm1
-$target_versions = ''
-
+$target_versions = (, '')
 if ([string]::IsNullOrEmpty($vsroot)) {
 	$target_versions = get_target_vs_versions (, $vstarget)
 } else {
-	$target_versions = (, $vstarget)
+	$target_versions = get_target_vs15_version $vsroot
 }
 
 Write-Output "Setting up NTVS development environment for $([String]::Join(", ", ($target_versions | % { $_.name })))"
@@ -70,12 +69,8 @@ Write-Output "Copying required files"
 foreach ($version in $target_versions) {    
     # Copy Microsoft.NodejsTools.targets file to relevant location
     $from = "$rootDir\Nodejs\Product\Nodejs\Microsoft.NodejsTools.targets"
-	$to = ''
-	if ([string]::IsNullOrEmpty($vsroot)) {
-		$to = "${env:ProgramFiles(x86)}\MSBuild\Microsoft\VisualStudio\v$($version.number)\Node.js Tools\Microsoft.NodejsTools.targets"
-	} else {
-		$to = "${vsroot}\Microsoft\VisualStudio\v$($version.number)\Node.js Tools\Microsoft.NodejsTools.targets"
-    }
+	$to = "$($version.msbuildroot)\Node.js Tools\Microsoft.NodejsTools.targets"
+	Write-Output $version
     Write-Output "    $($from) -> $($to)"
     New-Item -Force $to > $null
     Copy-Item -Force $from $to


### PR DESCRIPTION
**Bug**
The current `EnvironmentSetup.ps1` script does not work for VS15 post preview 3. It also does not support multiple installs of VS in different locations (something that is a lot more common in VS15)

**Fix**
Add an optional `vsroot` param to the script to point to where the root dir where VS is installed. Update scripts to use this.

Also updates the script to install the msbuild files into the correct local location for vs15, instead of the global msbuild directory.