### PR TITLE
Fixing  BuildRelease Script for Vs15 Post Preview 3

### DIFF
--- a/Build/VisualStudioHelpers.psm1
+++ b/Build/VisualStudioHelpers.psm1
@@ -1,6 +1,8 @@
-function get_target_vs_versions {
-    param($vstarget)
- 
+function get_target_vs_versions($vstarget, $vsroot) {
+    if ($vstarget -eq "15.0") {
+        return get_target_vs15_version $vsroot
+    }
+
     $supported_vs_versions = (
         @{number="15.0"; name="VS 15"; build_by_default=$true},    
         @{number="14.0"; name="VS 2015"; build_by_default=$true}
@@ -22,7 +24,7 @@ function get_target_vs_versions {
                 $target_versions += @{
                     number=$target_vs.number;
                     name=$target_vs.name;
-                    vsoot=$vspath.InstallDir;
+                    vsroot=$vspath.InstallDir;
                     msbuildroot=$msbuildroot
                 }
             }
@@ -40,13 +42,12 @@ function get_target_vs_versions {
     return $target_versions
 }
 
-function get_target_vs15_version {
-    param($vsroot)
+function get_target_vs15_version($vsroot) {
     $msbuildroot="${vsroot}\MSBuild\Microsoft\VisualStudio\v15.0\Node.js Tools\Microsoft.NodejsTools.targets"
     return @{
         number="15.0";
         name="VS 15";
-        vsoot=$root;
+        vsroot=$vsroot;
         msbuildroot=$msbuildroot
     }; 
 }

--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -44,12 +44,7 @@ Write-Output "Repository root: $($rootDir)"
 
 
 Import-Module -Force $rootDir\Build\VisualStudioHelpers.psm1
-$target_versions = (, '')
-if ([string]::IsNullOrEmpty($vsroot)) {
-    $target_versions = get_target_vs_versions (, $vstarget)
-} else {
-    $target_versions = get_target_vs15_version $vsroot
-}
+$target_versions = get_target_vs_versions $vstarget $vsroot
 
 Write-Output "Setting up NTVS development environment for $([String]::Join(", ", ($target_versions | % { $_.name })))"
 Write-Output "============================================================"

--- a/Nodejs/Product/AssemblyVersion.cs
+++ b/Nodejs/Product/AssemblyVersion.cs
@@ -39,7 +39,7 @@ class AssemblyVersionInfo {
 
     // This version should never change from "4100.00"; BuildRelease.ps1
     // will replace it with a generated value.
-    public const string BuildNumber = "4100.00";
+    public const string BuildNumber = "41031.00";
 #if DEV14
     public const string VSMajorVersion = "14";
     const string VSVersionSuffix = "2015";

--- a/Nodejs/Product/AssemblyVersion.cs
+++ b/Nodejs/Product/AssemblyVersion.cs
@@ -39,7 +39,7 @@ class AssemblyVersionInfo {
 
     // This version should never change from "4100.00"; BuildRelease.ps1
     // will replace it with a generated value.
-    public const string BuildNumber = "41031.00";
+    public const string BuildNumber = "4100.00";
 #if DEV14
     public const string VSMajorVersion = "14";
     const string VSVersionSuffix = "2015";


### PR DESCRIPTION
Issue #1400 

**Bug**
Build release script currently does not support building using vs15 post preview 3

**Fixes**
Add support for specifying install location for vs and picking up correct tools from the target vs15 instance.

Closes #1400