### PR TITLE
Fix NTVS Item Templates Not Showing up in Web Enabled Projects

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -330,6 +330,7 @@
     <Compile Include="Debugger\Communication\TcpNetworkClient.cs" />
     <Compile Include="Debugger\ExceptionHitTreatment.cs" />
     <Compile Include="Debugger\ExceptionHandler.cs" />
+    <Compile Include="ProvideLanguageTemplates.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -80,6 +80,8 @@ namespace Microsoft.NodejsTools {
         SortPriority = 0x17)]   // outer flavor, no file extension
     [ProvideDebugPortSupplier("Node remote debugging", typeof(NodeRemoteDebugPortSupplier), NodeRemoteDebugPortSupplier.PortSupplierId)]
     [ProvideMenuResource(1000, 1)]                              // This attribute is needed to let the shell know that this package exposes some menus.
+    [WebSiteProject("JavaScript", "JavaScript")]
+    [ProvideLanguageTemplates("{349C5851-65DF-11DA-9384-00065B846F21}", NodejsConstants.JavaScript, Guids.NodejsPackageString, "Web", "Node.js Project Templates", "{" + Guids.NodejsBaseProjectFactoryString + "}", ".js", NodejsConstants.Nodejs, "{" + Guids.NodejsBaseProjectFactoryString + "}")]
     [ProvideProjectItem(typeof(BaseNodeProjectFactory), NodejsConstants.Nodejs, "FileTemplates\\NewItem", 0)]
     [ProvideTextEditorAutomation(NodejsConstants.Nodejs, 106, 102, ProfileMigrationType.PassThrough)]
     [ProvideLanguageService(typeof(JadeLanguageInfo), JadeContentTypeDefinition.JadeLanguageName, 3041, RequestStockColors = true, ShowSmartIndent = false, ShowCompletion = false, DefaultToInsertSpaces = true, HideAdvancedMembersByDefault = false, EnableAdvancedMembersOption = false, ShowDropDownOptions = false)]

--- a/Nodejs/Product/Nodejs/ProvideLanguageTemplates.cs
+++ b/Nodejs/Product/Nodejs/ProvideLanguageTemplates.cs
@@ -1,0 +1,83 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************//
+
+using System;
+using System.Globalization;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.NodejsTools {
+
+    /// <include file='doc\ProvideEditorExtensionAttribute.uex' path='docs/doc[@for="ProvideEditorExtensionAttribute"]' />
+    /// <devdoc>
+    ///     This attribute associates a file extension to a given editor factory.  
+    ///     The editor factory may be specified as either a GUID or a type and 
+    ///     is placed on a package.
+    ///     
+    /// This differs from the normal one in that more than one extension can be supplied and
+    /// a linked editor GUID can be supplied.
+    /// </devdoc>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    internal sealed class ProvideLanguageTemplatesAttribute : RegistrationAttribute {
+        private readonly string _projectFactory, _languageName, _package, _languageGuid, _description,
+            _codeFileExtension, _templateFolder, _webProjectGuid;
+
+        public ProvideLanguageTemplatesAttribute(string projectFactory, string languageName, string package,
+            string templateGroup, string description, string languageProjectGuid, string codeFileExtension, string templateFolder, string webProjectGuid) {
+            _projectFactory = projectFactory;
+            _languageName = languageName;
+            _package = package;
+            _description = description;
+            _languageGuid = languageProjectGuid;
+            _codeFileExtension = codeFileExtension;
+            _templateFolder = templateGroup;
+            _webProjectGuid = webProjectGuid;
+        }
+
+
+        /// <include file='doc\ProvideEditorExtensionAttribute.uex' path='docs/doc[@for="Register"]' />
+        /// <devdoc>
+        ///     Called to register this attribute with the given context.  The context
+        ///     contains the location where the registration inforomation should be placed.
+        ///     it also contains such as the type being registered, and path information.
+        ///
+        ///     This method is called both for registration and unregistration.  The difference is
+        ///     that unregistering just uses a hive that reverses the changes applied to it.
+        /// </devdoc>
+        public override void Register(RegistrationContext context) {
+            string langTemplates = string.Format(CultureInfo.InvariantCulture, "Projects\\{0}\\LanguageTemplates", _projectFactory);
+
+            using (Key projectKey = context.CreateKey(langTemplates)) {
+                projectKey.SetValue(_languageGuid, _webProjectGuid);
+            }
+
+            var newProject = string.Format(CultureInfo.InvariantCulture, "Projects\\{0}", _webProjectGuid);
+            using (Key projectKey = context.CreateKey(newProject)) {
+                projectKey.SetValue(null, _description);
+                projectKey.SetValue("Language(VsTemplate)", _languageName);
+                projectKey.SetValue("Package", _package);
+                projectKey.SetValue("ShowOnlySpecifiedTemplates(VsTemplate)", 0);
+
+                using (Key propKey = projectKey.CreateSubkey("WebApplicationProperties")) {
+                    propKey.SetValue("CodeFileExtension", _codeFileExtension);
+                    propKey.SetValue("TemplateFolder", _templateFolder);
+                }
+            }
+        }
+
+        public override void Unregister(RegistrationContext context) {
+        }
+    }
+}


### PR DESCRIPTION
**Bug**
Item templates not showing up in web enabled NTVS projects.

While investigating an issue with templates in VS15 (duplicate/false template entries showing up), I removed some pkgdef config options around web project templates #1285 because I believed this refered to the old add website flows. I did not notice this cause any regressions because VS had cached the old config but I believe this removal is the root cause of why item templates do not show up in web enabled projects

**Fix**
Revert #1285.

**Testing**
See item templates in all projects now.