### PR TITLE
Fixing Building NTVS on VS2017 on Build Machines

### DIFF
--- a/Build/Common.Build.VSSDK.targets
+++ b/Build/Common.Build.VSSDK.targets
@@ -49,7 +49,12 @@
   </PropertyGroup>
 
   <!-- Import the normal VS SDK headers -->
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" />
+  <ImportGroup Condition="Exists('$(DevEnvDir)..\..\VSSDK')">
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\VSSDK\Microsoft.VsSDK.targets" />
+  </ImportGroup>
+  <ImportGroup Condition="!Exists('$(DevEnvDir)..\..\VSSDK')">
+    <Import Project="$(VSSDKInstall)\Microsoft.VsSDK.targets" />
+  </ImportGroup>
 
   <!-- For non-debug builds, don't copy debug symbols -->
   <Target Name="_ClearVSIXSourceItemLocalOnly"

--- a/Nodejs/Setup/SetupProjectBefore.settings
+++ b/Nodejs/Setup/SetupProjectBefore.settings
@@ -5,8 +5,4 @@
     <IntermediateOutputPathSuffix>obj\Setup_$(MSBuildProjectName)\</IntermediateOutputPathSuffix>
   </PropertyGroup>
   <Import Project="$(BuildRoot)\Build\Common.Build.settings" />
-
-  <Target Name="Build"></Target>
-  <Target Name="Clean"></Target>
-  <Target Name="GetNativeManifest"/>
 </Project>

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.InteractiveWindow.swixproj
@@ -13,8 +13,11 @@
   </PropertyGroup> 
   
   <ItemGroup> 
-      <Package Include="InteractiveWindow_files.swr" /> 
+    <Package Include="InteractiveWindow_files.swr" /> 
   </ItemGroup>
+  
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetTargetFrameworkProperties" />
   
   <Import Project="$(PackagesPath)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets"/>
 </Project>

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.NodejsTools.swixproj
@@ -15,6 +15,9 @@
   <ItemGroup> 
     <Package Include="Nodejs_files.swr" /> 
   </ItemGroup>
-
+  
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetTargetFrameworkProperties" />
+  
   <Import Project="$(PackagesPath)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets"/>
 </Project>

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Profiling.swixproj
@@ -16,5 +16,8 @@
     <Package Include="Profiling_files.swr" /> 
   </ItemGroup>
 
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetTargetFrameworkProperties" />
+  
   <Import Project="$(PackagesPath)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets"/>
 </Project>

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
@@ -36,6 +36,9 @@
           SkipUnchangedFiles="true" />
   </Target> 
 
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetTargetFrameworkProperties" />
+  
   <ItemGroup> 
     <Package Include="Targets_files.swr" /> 
   </ItemGroup>


### PR DESCRIPTION
**Bug**
We currently cannot build NTVS using our build scripts using VS2017 on our build machines. Building from VS itself works, but continious integration builds do not work.

**Fix**
* Update the VSSDK path to use the correct one for VS2017
* Add an empty `GetTargetFrameworkProperties` target to all swixproj files.