### PR TITLE
Fixes PORT env Capitalization in Simple Web Templates

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/AzureNodejsApp/server.js
@@ -1,6 +1,6 @@
 'use strict';
 var http = require('http');
-var port = process.env.port || 1337;
+var port = process.env.PORT || 1337;
 
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/NodejsWebApp/server.js
@@ -1,6 +1,6 @@
 'use strict';
 var http = require('http');
-var port = process.env.port || 1337;
+var port = process.env.PORT || 1337;
 
 http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' });


### PR DESCRIPTION
Issue #1410

**Bug**
`env.port` is lower case in our web templates.

**Fix**
Uppercase env var.

Closes #1410