### PR TITLE
Fix vsix vs15 build error

### DIFF
--- a/Build/Common.Build.VSSDK.targets
+++ b/Build/Common.Build.VSSDK.targets
@@ -219,7 +219,8 @@
       <_Container>%(VSIX.Container)</_Container>
     </PropertyGroup>
 
-    <CreateZipPackage Files="@(_VSIXSourceItems)"
+    <CreateZipPackage SourceManifest="%(VSIX.SourceDir)extension.vsixmanifest"
+                      Files="@(_VSIXSourceItems)"
                       ZipPackage="$(_Container)"
                       CompressionLevel="$(ZipPackageCompressionLevel)">
         <Output TaskParameter="ZipPackage" ItemName="FileWrites" />

--- a/Build/Common.Build.VSSDK.targets
+++ b/Build/Common.Build.VSSDK.targets
@@ -222,7 +222,8 @@
     <CreateZipPackage SourceManifest="%(VSIX.SourceDir)extension.vsixmanifest"
                       Files="@(_VSIXSourceItems)"
                       ZipPackage="$(_Container)"
-                      CompressionLevel="$(ZipPackageCompressionLevel)">
+                      CompressionLevel="$(ZipPackageCompressionLevel)"
+                      ItemsToConsider="@(None)">
         <Output TaskParameter="ZipPackage" ItemName="FileWrites" />
     </CreateZipPackage>
 


### PR DESCRIPTION
**Bug**
Vsix signing fails when rezipping the vsixs on new VS2017 releases.

**Fix**
Pass additional required parameters to the `CreateZipPackage` task.