### PR TITLE
Test Adapter Improvements - Register test results incrementally

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/ExportRunner/exportrunner.js
@@ -77,11 +77,10 @@ var run_tests = function (testCases, callback) {
     }
 
     for (var test of testCases) {
-        event = {
+        post({
             type: 'test start',
             title: test.testName
-        }
-        post(event);
+        });
         try {
             var testCase = require(test.testFile);
             testCase[test.testName]();
@@ -92,9 +91,11 @@ var run_tests = function (testCases, callback) {
             console.error(err.name);
             console.error(err.message);
         }
-        event.type = 'result';
-        event.result = result;
-        post(event);
+        post({
+            type: 'result',
+            title: test.testName,
+            result: result
+        });
         result = {
             'title': '',
             'passed': false,

--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -78,6 +78,7 @@ var run_tests = function (testCases, callback) {
         callback(event);
         hook_outputs();
     }
+
     function escapeRegExp(string) {
         return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
     }
@@ -93,27 +94,30 @@ var run_tests = function (testCases, callback) {
     var testGrepString = '^(' + testCases.map(function (testCase) {
         return testCase.testName
     }).join('|') + ')$';
-
+    
     if (testGrepString) {
         mocha.grep(new RegExp(testGrepString));
     }
-
     mocha.addFile(testCases[0].testFile);
 
-    // run tests
-    var runner = mocha.run(function (code) { process.exit(code); });
+    var runner = mocha.run(function (code) {
+        process.exit(code);
+    });
+
     runner.on('suite', function (suite) {
         post({
             type: 'suite start',
             result: result
         });
     });
+
     runner.on('suite end', function (suite) {
         post({
             type: 'suite end',
             result: result
         });
     });
+
     runner.on('hook', function (hook) {
         post({
             type: 'hook start',
@@ -121,6 +125,7 @@ var run_tests = function (testCases, callback) {
             result: result
         });
     });
+
     runner.on('hook end', function (hook) {
         post({
             type: 'hook end',
@@ -128,6 +133,7 @@ var run_tests = function (testCases, callback) {
             result: result
         });
     });
+
     runner.on('start', function () {
         post({
             type: 'start',
@@ -142,12 +148,14 @@ var run_tests = function (testCases, callback) {
             title: result.title
         });
     });
+
     runner.on('end', function () {
         post({
             type: 'end',
             result: result
         });
     });
+
     runner.on('pass', function (test) {
         result.passed = true;
         post({
@@ -162,6 +170,7 @@ var run_tests = function (testCases, callback) {
             'stdErr': ''
         }
     });
+
     runner.on('fail', function (test, err) {
         result.passed = false;
         post({

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -23,18 +23,16 @@ rl.on('line', (line) => {
         process.exit(1);
     }
     
-    function returnResult(result) {
+    function postResult(result) {
         // unhook stdout and stderr
         process.stdout.write = old_stdout;
         process.stderr.write = old_stderr;
         if (result) {
             console.log(JSON.stringify(result));
         }
-        // end process, tests are done running.
-        process.exit(0);
     }
     // run the test
-    framework.run_tests(testCases, returnResult);
+    framework.run_tests(testCases, postResult);
     
     // close readline interface
     rl.close();

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -246,8 +246,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                         //    }
                         //}
 #if DEBUG
-                    }
-                    catch (COMException ex) {
+                    } catch (COMException ex) {
                         frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
                         frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
                         KillNodeProcess();
@@ -295,8 +294,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
             List<ResultObject> jsonResults = null;
             try {
                 jsonResults = JsonConvert.DeserializeObject<List<ResultObject>>(line);
-            }
-            catch (Exception) { }
+            } catch (Exception) { }
             return jsonResults;
         }
 

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -366,12 +366,14 @@ namespace Microsoft.NodejsTools.TestAdapter {
         }
 
         private void RecordEnd(IFrameworkHandle frameworkHandle, TestCase test, TestResult result, ResultObject resultObject) {
+            String[] standardOutputLines = resultObject.stdout.Split('\n');
+            String[] standardErrorLines = resultObject.stderr.Split('\n');
             result.EndTime = DateTimeOffset.Now;
             result.Duration = result.EndTime - result.StartTime;
             result.Outcome = resultObject.passed ? TestOutcome.Passed : TestOutcome.Failed;
-            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, resultObject.stdout));
-            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, resultObject.stderr));
-            result.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, resultObject.stderr));
+            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, String.Join(Environment.NewLine, standardOutputLines)));
+            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, String.Join(Environment.NewLine, standardErrorLines)));
+            result.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, String.Join(Environment.NewLine, standardErrorLines)));
             frameworkHandle.RecordResult(result);
             frameworkHandle.RecordEnd(test, result.Outcome);
             _currentTests.Remove(test);


### PR DESCRIPTION
Hello,
In this set of changes I have modified `TestExecutor` and `run_tests.js` to be able to communicate with each other via `TestEvent` objects. This is to allow the incremental logging of test results and to allow us to accurately record test duration by emitting `test start` events (or other events).

The overall goal of the changes in this branch is to fix issues #518 and #1157 (test efficiency and Mocha running `before()` and `after()` hooks multiple times per test suite.)

We have been using a version of these changes internally for the past month (running Mocha tests on TFS 2015 build definition) and... so far, so good. At this point I believe it is necessary to get a second pair of eyes on the code since fixing the Test Adapter issues required such a significant code change. I've been working with @mjbvz on this for the past couple of months (not sure if he is still working on `nodejstools` or not?) and through his guidance led the development of these changes.

##### Testing
More extensive testing is certainly needed, but here is a summary of some of the cases I've tested and their current statuses. Text highlighted in **bold** are issues that need investigation/fixes.

|TestCase|Mocha v2|Mocha v3|ExportRunner|Tape|
|---|---|---|---|---|
|Basic passing test|Passes|Passes|Passes|Passes|
|Basic failing test|Fails|Fails|Fails|**Passes** -- not a regression, see #1429|
|Run All Tests|Works as expected|Works as expected|Works as expected|Runs all tests but **tests always pass**.. not a regression-- see #1429|
|Run Selected Tests|Works as expected|Works as expected|Works as expected|Runs only selected tests but **tests always pass**|
|Multiple tests in multiple files|Works as expected|Works as expected|Works as expected|Runs tests but **tests always pass**|
|Tests that write to stdout/stderr|Logs are preserved in test result data|''|''|''|
|Long Running Tests|Works as expected|''|''|''|
|Tests with RegExp characters in the title|**Test fails prior to being run**|''|''|''|
|Tests with odd characters in the title|**Test fails prior to being run**|''|''|''|
|Multiple test frameworks in a single project|Works as expected|''|''|''|
|Tests with the same name|Displays exception|''|Restricted by compiler|Registers only one test **without displaying exception**|
|...||||

Please let me know if there are any areas of the code you would like me to elaborate on, or any improvements necessary in order to get this code up to snuff for merging.