### PR TITLE
Add UI culture so resources localize appropriately

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -44,6 +44,7 @@
     <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootSuffix Exp /Log</StartArguments>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <UICulture>en</UICulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
This causes the satellite assemblies to get built with the correct XAML resource manifest names so things load as expected. Verified on EN (which was also broken) and hand-loc'd Chinese since the Install NPM Packages dialog isn't loc'd yet

![image](https://cloud.githubusercontent.com/assets/6685088/21704171/4327b062-d36c-11e6-9c11-e6cf007e3951.png)

/cc @billti  @paulvanbrenk 