### PR TITLE
Allow mocha to be installed globally or on any parent folder node_mod…

### DIFF
--- a/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/mocha/mocha.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 
 // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
-// 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
+// 'min' produces undisplayable text to stdout and stderr under piped/redirect,
 // and 'xunit' does not print the stack trace from the test.
 var defaultMochaOptions = { ui: 'tdd', reporter: 'tap', timeout: 2000 };
 
@@ -83,27 +83,45 @@ function logError() {
     console.error.apply(console, errorArgs);
 }
 
+// cache mocha module to avoid resolving it all the time
+var _mochaModule = null;
+
 function detectMocha(projectFolder) {
-    try {
-        var node_modulesFolder = projectFolder;
-        var mochaJsonPath = path.join(node_modulesFolder, 'test', 'mocha.json');
-        if (fs.existsSync(mochaJsonPath)) {
-            var opt = require(mochaJsonPath);
-            if (opt && opt.path) {
-                node_modulesFolder = path.resolve(projectFolder, opt.path);
+    if (!_mochaModule) {
+        // perform require look up on working directory and up the tree
+        var cd = projectFolder + "/." // adds /. to make loop easier on edge case;
+        var mochaModule = null;
+        do {
+            // get parent
+            cd = path.dirname(cd);
+            var mochaPath = path.join(cd, 'node_modules', 'mocha');
+            if (fs.existsSync(mochaPath)) {
+                try {
+                    mochaModule = require(mochaPath);
+                    break; // we found mocha
+                } catch (ex) {
+                    // ignore, not found
+                }
+            }
+        } while (cd != path.dirname(cd)); // stop when cd is root
+
+        if (!mochaModule) {
+            // if not found, try global
+            try {
+                mochaModule = require("mocha");
+            } catch (ex) {
+                // ignore, not found
             }
         }
 
-        var mochaPath = path.join(node_modulesFolder, 'node_modules', 'mocha');
-        var Mocha = new require(mochaPath);
-        return Mocha;
-    } catch (ex) {
-        logError(
-            'Failed to find Mocha package.  Mocha must be installed in the project locally.' + EOL +
-            'Install Mocha locally using the npm manager via solution explorer' + EOL +
-            'or with ".npm install mocha --save-dev" via the Node.js interactive window.');
-        return null;
+        if (mochaModule) {
+            _mochaModule = mochaModule;
+        } else {
+            logError("Failed to find Mocha package.  Mocha must be installed either in the project locally, in a parent node_modules folder or globably.  Mocha can be installed locally with the npm manager via solution explorer or with \".npm install mocha\" via the Node.js interactive window.");
+        }
     }
+
+    return _mochaModule;
 }
 
 function initializeMocha(Mocha, projectFolder) {


### PR DESCRIPTION
#### Issue
#403  (Allow Mocha to be installed Globally) 

##### Fix
This PR changes how mocha module is found. Instead of only looking on the project folder node_modules, I transverse the file system tree looking at node_modules folder on parent directories. If the module is not found in any parent node_modules folder, then a global require is issued.

##### Testing
1. No globally installed mocha package, no mode_modules on project folder or parent folder -> Expects error message (module not found).
2. Mocha locally installed (previous behavior) -> Expects to loads local module as before.
3. Mocha installed on some parent node_modules folder -> Expects to load module from parent node_module folder.
4. Mocha not installed locally or on parent folder, but installed globally -> Expects to load global module. (**NOTE:**: on Windows one might need to set the NODE_PATH environment variable to point to NPM global install folder).