### PR TITLE
Remove solution folders correctly

### DIFF
--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -929,7 +929,6 @@ namespace Microsoft.VisualStudioTools.Project {
 
             RaiseOnItemRemoved(documentToRemove, filesToBeDeleted);
 
-            // When we don't call this it behaves properly also in Solution Explorer search result set
             // Notify hierarchy event listeners that items have been invalidated
             ProjectMgr.OnInvalidateItems(this);
 

--- a/Common/Product/SharedProject/HierarchyNode.cs
+++ b/Common/Product/SharedProject/HierarchyNode.cs
@@ -931,7 +931,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
             // When we don't call this it behaves properly also in Solution Explorer search result set
             // Notify hierarchy event listeners that items have been invalidated
-            //ProjectMgr.OnInvalidateItems(this);
+            ProjectMgr.OnInvalidateItems(this);
 
             // Dispose the node now that is deleted.
             this.Dispose(true);
@@ -996,8 +996,12 @@ namespace Microsoft.VisualStudioTools.Project {
             ProjectMgr.OnItemDeleted(this);
 
             // Remove child if any before removing from the hierarchy
-            for (HierarchyNode child = this.FirstChild; child != null; child = child.NextSibling) {
+            HierarchyNode child = this.FirstChild;
+            while (child != null) {
+                // Need to read NextSibling before calling Remove
+                var next = child.NextSibling;
                 child.Remove(removeFromStorage);
+                child = next;
             }
 
             // the project node has no parentNode

--- a/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
+++ b/Nodejs/Product/InteractiveWindow/source.extension.vsixmanifest
@@ -1,6 +1,6 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8" Version="1.3.0.3" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="29102E6C-34F2-4FF1-BA2F-C02ADE3846E8" Version="1.3.0.4" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools - Interactive Window</DisplayName>
     <Description xml:space="preserve">Node.js Tools - Interactive Window.</Description>
     <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -1,6 +1,6 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.3.0.3" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="FE8A8C3D-328A-476D-99F9-2A24B75F8C7F" Version="1.3.0.4" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools</DisplayName>
     <Description xml:space="preserve">Provides support for editing and debugging Node.js programs.</Description>
     <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>

--- a/Nodejs/Product/Profiling/source.extension.vsixmanifest
+++ b/Nodejs/Product/Profiling/source.extension.vsixmanifest
@@ -1,6 +1,6 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="B515653F-FB69-4B64-9D3F-F1FCF8421DD0" Version="1.3.0.3" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="B515653F-FB69-4B64-9D3F-F1FCF8421DD0" Version="1.3.0.4" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Node.js Tools - Profiling</DisplayName>
     <Description xml:space="preserve">Provides support for profiling Node.js projects</Description>
     <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=785971</MoreInfo>


### PR DESCRIPTION
Fixes internal bug 374959

---

Create a Node.js app from the Basic Node.js Express 4 Application.
Add a new folder to the solution.
Add a new TypeScript file to the folder.
Enter some code.
Compile.
Delete the folder.
Compile.

Expected: compilation succeeds.
Actual:

Severity Code Description Project File Line Suppression State
Error Build:File 'C:/Users/USER/documents/visual studio 2017/Projects/ExpressApp1/ExpressApp1/stuff/stuff.ts' not found. ExpressApp1 tsc 0 

The project file still contains this after deleting the folder:
