### PR TITLE
Fix build deadlock

### DIFF
--- a/Common/Product/SharedProject/IDEBuildLogger.cs
+++ b/Common/Product/SharedProject/IDEBuildLogger.cs
@@ -457,8 +457,6 @@ namespace Microsoft.VisualStudioTools.Project {
             // If importance is too low for current settings, ignore the event
             bool logIt = false;
 
-            this.SetVerbosity();
-
             switch (this.Verbosity) {
                 case LoggerVerbosity.Quiet:
                     logIt = false;
@@ -507,11 +505,13 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Sets the verbosity level.
         /// </summary>
-        private void SetVerbosity() {
+        public void SetVerbosity() {
             if (!this.haveCachedVerbosity) {
                 this.Verbosity = LoggerVerbosity.Normal;
 
                 try {
+                    serviceProvider.GetUIThread().MustBeCalledFromUIThread();
+
                     var settings = new ShellSettingsManager(serviceProvider);
                     var store = settings.GetReadOnlySettingsStore(SettingsScope.UserSettings);
                     if (store.CollectionExists(GeneralCollection) && store.PropertyExists(GeneralCollection, BuildVerbosityProperty)) {

--- a/Common/Product/SharedProject/IDEBuildLogger.cs
+++ b/Common/Product/SharedProject/IDEBuildLogger.cs
@@ -49,7 +49,6 @@ namespace Microsoft.VisualStudioTools.Project {
         private IVsHierarchy hierarchy;
         private IServiceProvider serviceProvider;
         private Dispatcher dispatcher;
-        private bool haveCachedVerbosity = false;
 
         // Queues to manage Tasks and Error output plus message logging
         private ConcurrentQueue<Func<ErrorTask>> taskQueue;
@@ -170,7 +169,6 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         protected virtual void BuildStartedHandler(object sender, BuildStartedEventArgs buildEvent) {
             // NOTE: This may run on a background thread!
-            ClearCachedVerbosity();
             ClearQueuedOutput();
             ClearQueuedTasks();
 
@@ -505,36 +503,30 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Sets the verbosity level.
         /// </summary>
-        public void SetVerbosity() {
-            if (!this.haveCachedVerbosity) {
-                this.Verbosity = LoggerVerbosity.Normal;
+        public void RefreshVerbosity()
+        {
+            this.Verbosity = LoggerVerbosity.Normal;
 
-                try {
-                    serviceProvider.GetUIThread().MustBeCalledFromUIThread();
+            try
+            {
+                serviceProvider.GetUIThread().MustBeCalledFromUIThread();
 
-                    var settings = new ShellSettingsManager(serviceProvider);
-                    var store = settings.GetReadOnlySettingsStore(SettingsScope.UserSettings);
-                    if (store.CollectionExists(GeneralCollection) && store.PropertyExists(GeneralCollection, BuildVerbosityProperty)) {
-                        this.Verbosity = (LoggerVerbosity)store.GetInt32(GeneralCollection, BuildVerbosityProperty, (int)LoggerVerbosity.Normal);
-                    }
-                } catch (Exception ex) {
-                    var message = string.Format(
-                        "Unable to read verbosity option from the registry.{0}{1}",
-                        Environment.NewLine,
-                        ex.ToString()
-                    );
-                    this.QueueOutputText(MessageImportance.High, message);
+                var settings = new ShellSettingsManager(serviceProvider);
+                var store = settings.GetReadOnlySettingsStore(SettingsScope.UserSettings);
+                if (store.CollectionExists(GeneralCollection) && store.PropertyExists(GeneralCollection, BuildVerbosityProperty))
+                {
+                    this.Verbosity = (LoggerVerbosity)store.GetInt32(GeneralCollection, BuildVerbosityProperty, (int)LoggerVerbosity.Normal);
                 }
-
-                this.haveCachedVerbosity = true;
             }
-        }
-
-        /// <summary>
-        /// Clear the cached verbosity, so that it will be re-evaluated from the build verbosity registry key.
-        /// </summary>
-        private void ClearCachedVerbosity() {
-            this.haveCachedVerbosity = false;
+            catch (Exception ex)
+            {
+                var message = string.Format(
+                    "Unable to read verbosity option from the registry.{0}{1}",
+                    Environment.NewLine,
+                    ex.ToString()
+                );
+                this.QueueOutputText(MessageImportance.High, message);
+            }
         }
 
         #endregion helpers

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -2456,7 +2456,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     oldLogger.Dispose();
                 }
             } else {
-                ((IDEBuildLogger)this.BuildLogger).OutputWindowPane = output;
+                this.BuildLogger.OutputWindowPane = output;
             }
 
             this.buildLogger.RefreshVerbosity();

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -2572,7 +2572,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
                 submission.ExecuteAsync(sub => {
                     Site.GetUIThread().Invoke(() => {
-                        IDEBuildLogger ideLogger = this.buildLogger as IDEBuildLogger;
+                        IDEBuildLogger ideLogger = this.buildLogger;
                         if (ideLogger != null) {
                             ideLogger.FlushBuildOutput();
                         }

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// </summary>
         private MSBuild.ProjectCollection buildEngine;
 
-        private Microsoft.Build.Utilities.Logger buildLogger;
+        private IDEBuildLogger buildLogger;
 
         private bool useProvidedLogger;
 
@@ -750,7 +750,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Gets or sets the build logger.
         /// </summary>
-        protected Microsoft.Build.Utilities.Logger BuildLogger {
+        protected IDEBuildLogger BuildLogger {
             get {
                 return this.buildLogger;
             }
@@ -2458,6 +2458,8 @@ namespace Microsoft.VisualStudioTools.Project {
             } else {
                 ((IDEBuildLogger)this.BuildLogger).OutputWindowPane = output;
             }
+
+            this.buildLogger.SetVerbosity();
         }
 
         /// <summary>

--- a/Common/Product/SharedProject/ProjectNode.cs
+++ b/Common/Product/SharedProject/ProjectNode.cs
@@ -2459,7 +2459,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 ((IDEBuildLogger)this.BuildLogger).OutputWindowPane = output;
             }
 
-            this.buildLogger.SetVerbosity();
+            this.buildLogger.RefreshVerbosity();
         }
 
         /// <summary>


### PR DESCRIPTION
`SetVerbosity` needs the UI thread to observe the verbosity setting in the registry.

We move calls to `SetVerbosity` (renamed to `RefreshVerbosity`) to occur on the UI thread. We also simplify cache invalidation of the verbosity setting stored in the logger.