### PR TITLE
Fix for missing intellisense property for VS 2015

### DIFF
--- a/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsIntellisenseOptionsPage.cs
@@ -84,6 +84,10 @@ namespace Microsoft.NodejsTools.Options {
             }
 
             // Save settings.
+#if DEV14
+            // This setting needs to be present for the TypeScript editor to handle .js files in NTVS
+            SaveString("AnalysisLevel", "Preview");
+#endif
             SaveBool(EnableAutomaticTypingsAcquisitionSetting, EnableAutomaticTypingsAcquisition);
             SaveBool(ShowTypingsInfoBarSetting, ShowTypingsInfoBar);
             SaveBool(SaveChangesToConfigFileSetting, SaveChangesToConfigFile);


### PR DESCRIPTION
Partial fix for issue #1464. (Still need to figure out why later versions of TypeScript break)

Basically on VS 2015 the TypeScript editor only takes over if "Preview" mode of intellisense is enabled. With #1255 this setting got removed, so the setting is never enabled (but is still present if you happened to upgrade from earlier versions). This effectively brakes intellisense as the old analyse engine has been removed already.

This simple fix just ensures it is always present on VS 2015. I tested this gets set as soon as you open any NTVS project, or the Tools / Options dialog.

cc @paulvanbrenk @mjbvz 