### PR TITLE
Fix node version in option string.

### DIFF
--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.en.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.en.resx
@@ -250,7 +250,7 @@
     <value>5</value>
   </data>
   <data name="_webkitDebugger.Text" xml:space="preserve">
-   <value>Use the new NodeJs debugger protocol (experimental since v6.8)</value>
+   <value>Use the new NodeJs debugger protocol (experimental since v7.0)</value>
   </data>
   <data name="&gt;&gt;_webkitDebugger.Name" xml:space="preserve">
     <value>_webkitDebugger</value>

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.resx
@@ -250,7 +250,7 @@
     <value>5</value>
   </data>
   <data name="_webkitDebugger.Text" xml:space="preserve">
-   <value>Use the new NodeJs debugger protocol (experimental since v6.8)</value>
+   <value>Use the new NodeJs debugger protocol (experimental since v7.0)</value>
   </data>
   <data name="&gt;&gt;_webkitDebugger.Name" xml:space="preserve">
     <value>_webkitDebugger</value>


### PR DESCRIPTION
Testing shows that this only works reliably for Node v7.0 and up.