### PR TITLE
Replace the dynamic TypeScript version check with a package prerequisite

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -110,16 +110,6 @@ namespace Microsoft.NodejsTools {
         // after the initialization
         private List<EnvDTE.CommandEvents> _subscribedCommandEvents = new List<EnvDTE.CommandEvents>();
 
-        private static readonly Version _minRequiredTypescriptVersion = new Version("1.8");
-
-        private readonly Lazy<bool> _hasRequiredTypescriptVersion = new Lazy<bool>(() => {
-            Version version;
-            var versionString = GetTypeScriptToolsVersion();
-            return !string.IsNullOrEmpty(versionString)
-                && Version.TryParse(versionString, out version)
-                && version.CompareTo(_minRequiredTypescriptVersion) > -1;
-        });
-
         /// <summary>
         /// Default constructor of the package.
         /// Inside this method you can place any initialization code that does not require 
@@ -174,14 +164,6 @@ namespace Microsoft.NodejsTools {
         protected override void Initialize() {
             Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", this.ToString()));
             base.Initialize();
-
-            if (!_hasRequiredTypescriptVersion.Value) {
-                MessageBox.Show(
-                   string.Format(CultureInfo.CurrentCulture, Resources.TypeScriptMinVersionNotInstalled, _minRequiredTypescriptVersion.ToString()),
-                   Project.SR.ProductName,
-                   MessageBoxButtons.OK,
-                   MessageBoxIcon.Error);
-            }
 
             SubscribeToVsCommandEvents(
                 (int)VSConstants.VSStd97CmdID.AddNewProject,
@@ -548,44 +530,6 @@ namespace Microsoft.NodejsTools {
 
         internal static void NavigateTo(string filename, int pos) {
             VsUtilities.NavigateTo(Instance, filename, Guid.Empty, pos);
-        }
-
-        private static string GetTypeScriptToolsVersion() {
-            var toolsVersion = string.Empty;
-            try {
-                object installDirAsObject = null;
-                var shell = NodejsPackage.Instance.GetService(typeof(SVsShell)) as IVsShell;
-                if (shell != null) {
-                    shell.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out installDirAsObject);
-                }
-
-                var idePath = CommonUtils.NormalizeDirectoryPath((string)installDirAsObject) ?? string.Empty;
-                if (string.IsNullOrEmpty(idePath)) {
-                    return toolsVersion;
-                }
-
-                var typeScriptServicesPath = Path.Combine(idePath, @"CommonExtensions\Microsoft\TypeScript\typescriptServices.js");
-                if (!File.Exists(typeScriptServicesPath)) {
-                    return toolsVersion;
-                }
-
-                var regex = new Regex(@"toolsVersion = ""(?<version>\d.\d?)"";");
-                var fileText = File.ReadAllText(typeScriptServicesPath);
-                var match = regex.Match(fileText);
-
-                var version = match.Groups["version"].Value;
-                if (!string.IsNullOrWhiteSpace(version)) {
-                    toolsVersion = version;
-                }
-            } catch (Exception ex) {
-                if (ex.IsCriticalException()) {
-                    throw;
-                }
-
-                Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Failed to obtain TypeScript tools version: {0}", ex.ToString()));
-            }
-
-            return toolsVersion;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -1424,15 +1424,6 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Node.js Tools requires TypeScript for Visual Studio {0} or higher. Please ensure TypeScript is installed.
-        /// </summary>
-        public static string TypeScriptMinVersionNotInstalled {
-            get {
-                return ResourceManager.GetString("TypeScriptMinVersionNotInstalled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Node.js IntelliSense added a .
         /// </summary>
         public static string TypingsInfoBarSpan1 {

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -1422,6 +1422,17 @@ namespace Microsoft.NodejsTools {
                 return ResourceManager.GetString("TestFrameworkDescription", resourceCulture);
             }
         }
+
+#if DEV14
+        /// <summary>
+        ///   Looks up a localized string similar to Node.js Tools requires TypeScript for Visual Studio {0} or higher. Please ensure TypeScript is installed.
+        /// </summary>
+        public static string TypeScriptMinVersionNotInstalled {
+            get {
+                return ResourceManager.GetString("TypeScriptMinVersionNotInstalled", resourceCulture);
+            }
+        }
+#endif
         
         /// <summary>
         ///   Looks up a localized string similar to Node.js IntelliSense added a .

--- a/Nodejs/Product/Nodejs/source.extension.vsixmanifest
+++ b/Nodejs/Product/Nodejs/source.extension.vsixmanifest
@@ -22,6 +22,7 @@
   </Dependencies>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.JavaScript.TypeScript" Version="[15.0,16.0)" DisplayName="JavaScript and TypeScript language support" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Package" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />


### PR DESCRIPTION
##### Bug
NTVS uses typescriptServices.js to get the current TypeScript version, complains if the file is missing

##### Fix
Remove the dynamic check, properly declare a dependency on TypeScript using the vsixmanifest (Dev15 only)
