### PR TITLE
Fix resources on Dev14

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -44,7 +44,11 @@
     <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootSuffix Exp /Log</StartArguments>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <UICulture>en</UICulture>
+    <!--
+    Setting the UICulture places the resources in satellite assemblies, so only do this for Dev15 and later
+    For details on WPF localization, see https://msdn.microsoft.com/en-us/library/ms788718(v=vs.110).aspx
+    -->
+    <UICulture Condition="'$(VSTarget)'=='15.0'">en</UICulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
Adding the `<UICulture>` element caused the WPF resources to be moved to a satellite assembly (see https://msdn.microsoft.com/en-us/library/ms788718(v=vs.110).aspx). This is as intended for VS 2017 which we now localize, but for VS 2015 this broke the install, and setup doesn't bundle the satellite assembly.

Making this property conditional moves the resources back into the product DLL on Dev14 builds.

Addresses #1510 

CC @RyanCavanaugh 