### PR TITLE
Fix typings installer for most modules

### DIFF
--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -18,13 +18,6 @@ var argv = minimist(process.argv.slice(2), {
 
 var emitter = new events.EventEmitter();
 
-var options = {
-    save: argv.save,
-    global: true,
-    emitter: emitter,
-    cwd: argv.cwd || process.cwd()
-};
-
 var packagesToInstall = argv._;
 
 if (!packagesToInstall.length) {
@@ -32,6 +25,12 @@ if (!packagesToInstall.length) {
     typingsTool.installTypingsForProject(options)
 } else {
     typingsTool.runAll(packagesToInstall.map(function (name) {
+        var options = {
+            save: argv.save,
+            emitter: emitter,
+            global: name === "node", // Assume everything else refers to a CommonJS module
+            cwd: argv.cwd || process.cwd()
+        };
         return typingsTool.installTypingsForPackage(name, options);
     }));
 }


### PR DESCRIPTION
The typings installer used on VS 2015 was trying to install all type definitions as global. This causes ones that aren't (most Node.js modules) to fail with messages (internally) such as `"Attempted to compile "commander" as a global module, but it looks like an external module. You'll need to remove the global option to continue."`

This fix treats everything other than the Node.js types themselves as non-global.

CC @RyanCavanaugh 