### PR TITLE
Node V8 debugger support

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -33,14 +33,14 @@ namespace Microsoft.NodejsTools {
 
         public static Version GetNodeVersion(string path)
         {
-            if (string.IsNullOrEmpty(path)) {
-                throw new ArgumentException("\'path\' is not set", "path");
-            }
-
-            var versionString = FileVersionInfo.GetVersionInfo(path).ProductVersion;
-            Version version;
-            if (Version.TryParse(versionString, out version)) {
-                return version;
+            if (!string.IsNullOrEmpty(path))
+            {
+                var versionString = FileVersionInfo.GetVersionInfo(path).ProductVersion;
+                Version version;
+                if (Version.TryParse(versionString, out version))
+                {
+                    return version;
+                }
             }
 
             return default(Version);

--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -15,6 +15,7 @@
 //*********************************************************//
 
 using System;
+using System.Diagnostics;
 using System.IO;
 #if !NO_WINDOWS
 using System.Windows.Forms;
@@ -29,6 +30,21 @@ namespace Microsoft.NodejsTools {
     public sealed class Nodejs {
         private const string NodejsRegPath = "Software\\Node.js";
         private const string InstallPath = "InstallPath";
+
+        public static Version GetNodeVersion(string path)
+        {
+            if (string.IsNullOrEmpty(path)) {
+                throw new ArgumentException("\'path\' is not set", "path");
+            }
+
+            var versionString = FileVersionInfo.GetVersionInfo(path).ProductVersion;
+            Version version;
+            if (Version.TryParse(versionString, out version)) {
+                return version;
+            }
+
+            return default(Version);
+        }
 
         public static string NodeExePath {
             get {
@@ -137,6 +153,16 @@ namespace Microsoft.NodejsTools {
                 MessageBoxIcon.Error
             );
         }
+#if !DEV15
+        public static void ShowNodeVersionNotSupported() {
+            MessageBox.Show(
+                SR.GetString(SR.NodejsNotInstalled),
+                SR.ProductName,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+        }
+#endif
 #endif
     }
 }

--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -156,7 +156,7 @@ namespace Microsoft.NodejsTools {
 #if !DEV15
         public static void ShowNodeVersionNotSupported() {
             MessageBox.Show(
-                SR.GetString(SR.NodejsNotInstalled),
+                SR.GetString(SR.NodejsVersionNotSupported),
                 SR.ProductName,
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.Designer.cs
@@ -32,14 +32,12 @@
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this._surveyNewsCheckLabel = new System.Windows.Forms.Label();
             this._surveyNewsCheckCombo = new System.Windows.Forms.ComboBox();
-            this._webkitDebugger = new System.Windows.Forms.CheckBox();
             this._topOptionsPanel.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
             // 
             // _topOptionsPanel
             // 
-            this._topOptionsPanel.Controls.Add(this._webkitDebugger);
             this._topOptionsPanel.Controls.Add(this._checkForLongPaths);
             this._topOptionsPanel.Controls.Add(this._editAndContinue);
             this._topOptionsPanel.Controls.Add(this._waitOnNormalExit);
@@ -96,12 +94,6 @@
             resources.GetString("_surveyNewsCheckCombo.Items3")});
             this._surveyNewsCheckCombo.Name = "_surveyNewsCheckCombo";
             // 
-            // _webkitDebugger
-            // 
-            resources.ApplyResources(this._webkitDebugger, "_webkitDebugger");
-            this._webkitDebugger.Name = "_webkitDebugger";
-            this._webkitDebugger.UseVisualStyleBackColor = true;
-            // 
             // NodejsGeneralOptionsControl
             // 
             resources.ApplyResources(this, "$this");
@@ -127,6 +119,5 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.Label _surveyNewsCheckLabel;
         private System.Windows.Forms.ComboBox _surveyNewsCheckCombo;
-        private System.Windows.Forms.CheckBox _webkitDebugger;
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.cs
@@ -66,11 +66,6 @@ namespace Microsoft.NodejsTools.Options {
             _waitOnNormalExit.Checked = page.WaitOnNormalExit;
             _editAndContinue.Checked = page.EditAndContinue;
             _checkForLongPaths.Checked = page.CheckForLongPaths;
-            _webkitDebugger.Checked = page.UseWebKitDebugger;
-
-#if !DEV15
-            _webkitDebugger.Enabled = false;
-#endif
         }
 
         internal void SyncPageWithControlSettings(NodejsGeneralOptionsPage page) {
@@ -79,7 +74,6 @@ namespace Microsoft.NodejsTools.Options {
             page.WaitOnNormalExit = _waitOnNormalExit.Checked;
             page.EditAndContinue = _editAndContinue.Checked;
             page.CheckForLongPaths = _checkForLongPaths.Checked;
-            page.UseWebKitDebugger = _webkitDebugger.Checked;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.resx
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsControl.resx
@@ -118,10 +118,143 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="_checkForLongPaths.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="_checkForLongPaths.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 73</value>
+  </data>
+  <data name="_checkForLongPaths.Size" type="System.Drawing.Size, System.Drawing">
+    <value>291, 17</value>
+  </data>
+  <data name="_checkForLongPaths.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="_checkForLongPaths.Text" xml:space="preserve">
+    <value>Check for paths that exceed the &amp;MAX_PATH length limit</value>
+  </data>
+  <data name="&gt;&gt;_checkForLongPaths.Name" xml:space="preserve">
+    <value>_checkForLongPaths</value>
+  </data>
+  <data name="&gt;&gt;_checkForLongPaths.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_checkForLongPaths.Parent" xml:space="preserve">
+    <value>_topOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;_checkForLongPaths.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="_editAndContinue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_editAndContinue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 50</value>
+  </data>
+  <data name="_editAndContinue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>146, 17</value>
+  </data>
+  <data name="_editAndContinue.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="_editAndContinue.Text" xml:space="preserve">
+    <value>Enable &amp;Edit and Continue</value>
+  </data>
+  <data name="&gt;&gt;_editAndContinue.Name" xml:space="preserve">
+    <value>_editAndContinue</value>
+  </data>
+  <data name="&gt;&gt;_editAndContinue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_editAndContinue.Parent" xml:space="preserve">
+    <value>_topOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;_editAndContinue.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="_waitOnNormalExit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_waitOnNormalExit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 27</value>
+  </data>
+  <data name="_waitOnNormalExit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>223, 17</value>
+  </data>
+  <data name="_waitOnNormalExit.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="_waitOnNormalExit.Text" xml:space="preserve">
+    <value>Wai&amp;t for input when process exits normally</value>
+  </data>
+  <data name="&gt;&gt;_waitOnNormalExit.Name" xml:space="preserve">
+    <value>_waitOnNormalExit</value>
+  </data>
+  <data name="&gt;&gt;_waitOnNormalExit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_waitOnNormalExit.Parent" xml:space="preserve">
+    <value>_topOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;_waitOnNormalExit.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="_waitOnAbnormalExit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_waitOnAbnormalExit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 4</value>
+  </data>
+  <data name="_waitOnAbnormalExit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>235, 17</value>
+  </data>
+  <data name="_waitOnAbnormalExit.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="_waitOnAbnormalExit.Text" xml:space="preserve">
+    <value>&amp;Wait for input when process exits abnormally</value>
+  </data>
+  <data name="&gt;&gt;_waitOnAbnormalExit.Name" xml:space="preserve">
+    <value>_waitOnAbnormalExit</value>
+  </data>
+  <data name="&gt;&gt;_waitOnAbnormalExit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_waitOnAbnormalExit.Parent" xml:space="preserve">
+    <value>_topOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;_waitOnAbnormalExit.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="_topOptionsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="_topOptionsPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="_topOptionsPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>381, 96</value>
+  </data>
+  <data name="_topOptionsPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;_topOptionsPanel.Name" xml:space="preserve">
+    <value>_topOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;_topOptionsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_topOptionsPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;_topOptionsPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel3.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -134,7 +267,6 @@
   <data name="_surveyNewsCheckLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_surveyNewsCheckLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 7</value>
   </data>
@@ -208,7 +340,7 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 120</value>
+    <value>0, 96</value>
   </data>
   <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 4, 3, 4</value>
@@ -217,7 +349,7 @@
     <value>9</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 170</value>
+    <value>381, 194</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -236,165 +368,6 @@
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_surveyNewsCheckLabel" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_surveyNewsCheckCombo" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="_webkitDebugger.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_webkitDebugger.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 96</value>
-  </data>
-  <data name="_webkitDebugger.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 17</value>
-  </data>
-  <data name="_webkitDebugger.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="_webkitDebugger.Text" xml:space="preserve">
-   <value>Use the new NodeJs debugger protocol (experimental since v7.0)</value>
-  </data>
-  <data name="&gt;&gt;_webkitDebugger.Name" xml:space="preserve">
-    <value>_webkitDebugger</value>
-  </data>
-  <data name="&gt;&gt;_webkitDebugger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_webkitDebugger.Parent" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_webkitDebugger.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="_checkForLongPaths.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_checkForLongPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 73</value>
-  </data>
-  <data name="_checkForLongPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>291, 17</value>
-  </data>
-  <data name="_checkForLongPaths.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="_checkForLongPaths.Text" xml:space="preserve">
-    <value>Check for paths that exceed the &amp;MAX_PATH length limit</value>
-  </data>
-  <data name="&gt;&gt;_checkForLongPaths.Name" xml:space="preserve">
-    <value>_checkForLongPaths</value>
-  </data>
-  <data name="&gt;&gt;_checkForLongPaths.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_checkForLongPaths.Parent" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_checkForLongPaths.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="_editAndContinue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_editAndContinue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 50</value>
-  </data>
-  <data name="_editAndContinue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 17</value>
-  </data>
-  <data name="_editAndContinue.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="_editAndContinue.Text" xml:space="preserve">
-    <value>Enable &amp;Edit and Continue</value>
-  </data>
-  <data name="&gt;&gt;_editAndContinue.Name" xml:space="preserve">
-    <value>_editAndContinue</value>
-  </data>
-  <data name="&gt;&gt;_editAndContinue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_editAndContinue.Parent" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_editAndContinue.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="_waitOnNormalExit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_waitOnNormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 27</value>
-  </data>
-  <data name="_waitOnNormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>223, 17</value>
-  </data>
-  <data name="_waitOnNormalExit.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="_waitOnNormalExit.Text" xml:space="preserve">
-    <value>Wai&amp;t for input when process exits normally</value>
-  </data>
-  <data name="&gt;&gt;_waitOnNormalExit.Name" xml:space="preserve">
-    <value>_waitOnNormalExit</value>
-  </data>
-  <data name="&gt;&gt;_waitOnNormalExit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_waitOnNormalExit.Parent" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_waitOnNormalExit.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="_waitOnAbnormalExit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="_waitOnAbnormalExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
-  </data>
-  <data name="_waitOnAbnormalExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>235, 17</value>
-  </data>
-  <data name="_waitOnAbnormalExit.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="_waitOnAbnormalExit.Text" xml:space="preserve">
-    <value>&amp;Wait for input when process exits abnormally</value>
-  </data>
-  <data name="&gt;&gt;_waitOnAbnormalExit.Name" xml:space="preserve">
-    <value>_waitOnAbnormalExit</value>
-  </data>
-  <data name="&gt;&gt;_waitOnAbnormalExit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_waitOnAbnormalExit.Parent" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_waitOnAbnormalExit.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="_topOptionsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="_topOptionsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="_topOptionsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 120</value>
-  </data>
-  <data name="_topOptionsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;_topOptionsPanel.Name" xml:space="preserve">
-    <value>_topOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;_topOptionsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_topOptionsPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;_topOptionsPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
+++ b/Nodejs/Product/Nodejs/Options/NodejsGeneralOptionsPage.cs
@@ -74,11 +74,6 @@ namespace Microsoft.NodejsTools.Options {
         public bool CheckForLongPaths { get; set; }
 
         /// <summary>
-        /// Indicates whether we should use the WebKit debugger or the default NodeJs debugger.
-        /// </summary>
-        public bool UseWebKitDebugger { get; set; }
-
-        /// <summary>
         /// The frequency at which to check for updated news. Default is once
         /// per week.
         /// </summary>
@@ -113,7 +108,6 @@ namespace Microsoft.NodejsTools.Options {
             WaitOnNormalExit = false;
             EditAndContinue = true;
             CheckForLongPaths = true;
-            UseWebKitDebugger = false;
         }
 
         public override void LoadSettingsFromStorage() {
@@ -126,7 +120,6 @@ namespace Microsoft.NodejsTools.Options {
             WaitOnNormalExit = LoadBool(WaitOnNormalExitSetting) ?? false;
             EditAndContinue = LoadBool(EditAndContinueSetting) ?? true;
             CheckForLongPaths = LoadBool(CheckForLongPathsSetting) ?? true;
-            UseWebKitDebugger = LoadBool(UseWebKitDebuggerSetting) ?? false;
 
             // Synchronize UI with backing properties.
             if (_window != null) {
@@ -147,7 +140,6 @@ namespace Microsoft.NodejsTools.Options {
             SaveBool(WaitOnAbnormalExitSetting, WaitOnAbnormalExit);
             SaveBool(EditAndContinueSetting, EditAndContinue);
             SaveBool(CheckForLongPathsSetting, CheckForLongPaths);
-            SaveBool(UseWebKitDebuggerSetting, UseWebKitDebugger);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -68,17 +68,26 @@ namespace Microsoft.NodejsTools.Project {
 
         private int Start(string file, bool debug) {
             var nodePath = GetNodePath();
+
             if (nodePath == null) {
                 Nodejs.ShowNodejsNotInstalled();
                 return VSConstants.S_OK;
             }
 
-            bool startBrowser = ShouldStartBrowser();
+            var chromeProtocolRequired = Nodejs.GetNodeVersion(nodePath) >= new Version(8, 0);
+
 #if !DEV15
+            if (chromeProtocolRequired) {
+                Nodejs.ShowNodeVersionNotSupported();
+                return VSConstants.S_OK;
+            }
+
             bool useWebKitDebugger = false;
 #else
-            bool useWebKitDebugger = NodejsPackage.Instance.GeneralOptionsPage.UseWebKitDebugger;
+            bool useWebKitDebugger = chromeProtocolRequired || NodejsPackage.Instance.GeneralOptionsPage.UseWebKitDebugger;
 #endif
+
+            bool startBrowser = ShouldStartBrowser();
 
             if (debug && !useWebKitDebugger) {
                 StartWithDebugger(file);

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -81,17 +81,13 @@ namespace Microsoft.NodejsTools.Project {
                 Nodejs.ShowNodeVersionNotSupported();
                 return VSConstants.S_OK;
             }
-
-            bool useWebKitDebugger = false;
-#else
-            bool useWebKitDebugger = chromeProtocolRequired || NodejsPackage.Instance.GeneralOptionsPage.UseWebKitDebugger;
 #endif
 
             bool startBrowser = ShouldStartBrowser();
 
-            if (debug && !useWebKitDebugger) {
+            if (debug && !chromeProtocolRequired) {
                 StartWithDebugger(file);
-            } else if (debug && useWebKitDebugger) {
+            } else if (debug && chromeProtocolRequired) {
                 StartAndAttachDebugger(file, nodePath);
             } else {
                 StartNodeProcess(file, nodePath, startBrowser);

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NodejsTools.Project {
         internal const string NodeExeDoesntExist = "NodeExeDoesntExist";
         internal const string NodejsNotInstalled = "NodejsNotInstalled";
 #if !DEV15
-        internal const string NodejsNotInstalled = "NodejsVersionNotSupported";
+        internal const string NodejsVersionNotSupported = "NodejsVersionNotSupported";
 #endif
         internal const string TestFramework = "TestFramework";
 

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -25,6 +25,9 @@ namespace Microsoft.NodejsTools.Project {
 
         internal const string NodeExeDoesntExist = "NodeExeDoesntExist";
         internal const string NodejsNotInstalled = "NodejsNotInstalled";
+#if !DEV15
+        internal const string NodejsNotInstalled = "NodejsVersionNotSupported";
+#endif
         internal const string TestFramework = "TestFramework";
 
         private static readonly Lazy<ResourceManager> _manager = new Lazy<ResourceManager>(

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -660,7 +660,16 @@ namespace Microsoft.NodejsTools {
                 return ResourceManager.GetString("NodejsToolsForVisualStudio", resourceCulture);
             }
         }
-        
+#if !DEV15
+        /// <summary>
+        ///   Looks up a localized string similar to Your project is configured to use Node V8 or newer. Debugging Node V8 is not supported in VS 2015, please upgrade to VS 2017..
+        /// </summary>
+        public static string NodejsVersionNotSupported {
+            get {
+                return ResourceManager.GetString("NodejsVersionNotSupported", resourceCulture);
+            }
+        }
+#endif
         /// <summary>
         ///   Looks up a localized string similar to Unable to parse {0} from your project.  Please fix any errors and try again..
         /// </summary>
@@ -1422,8 +1431,7 @@ namespace Microsoft.NodejsTools {
                 return ResourceManager.GetString("TestFrameworkDescription", resourceCulture);
             }
         }
-
-#if DEV14
+#if !DEV15
         /// <summary>
         ///   Looks up a localized string similar to Node.js Tools requires TypeScript for Visual Studio {0} or higher. Please ensure TypeScript is installed.
         /// </summary>
@@ -1433,7 +1441,6 @@ namespace Microsoft.NodejsTools {
             }
         }
 #endif
-        
         /// <summary>
         ///   Looks up a localized string similar to Node.js IntelliSense added a .
         /// </summary>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -621,6 +621,6 @@ Error retrieving websocket debug proxy information from web.config.</value>
     <value>Launch url '{0}' is not valid </value>
   </data>
   <data name="NodejsVersionNotSupported" xml:space="preserve">
-    <value>Your project is configured to use Node V8 or newer. Debugging Node V8 is not supported in VS 2015, please upgrade to VS 2017.</value>
+    <value>Your project is configured to use Node.js 8 or newer. Debugging Node.js 8 is not supported in VS 2015, please upgrade to VS 2017.</value>
   </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -620,4 +620,7 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="ErrorInvalidLaunchUrl" xml:space="preserve">
     <value>Launch url '{0}' is not valid </value>
   </data>
+  <data name="NodejsVersionNotSupported" xml:space="preserve">
+    <value>Your project is configured to use Node V8 or newer. Debugging Node V8 is not supported in VS 2015, please upgrade to VS 2017.</value>
+  </data>
 </root>


### PR DESCRIPTION
Check the version of the node binary and either force Webkit protocol
(VS 2017), or block debugging with Message (VS 2015).

