### PR TITLE
Explicitly load the VS assemblies on Dev15 to fix unit test debugging

### DIFF
--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -17,9 +17,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -30,9 +32,9 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
 using MSBuild = Microsoft.Build.Evaluation;
-using System.Globalization;
 
-namespace Microsoft.NodejsTools.TestAdapter {
+namespace Microsoft.NodejsTools.TestAdapter
+{
     [ExtensionUri(TestExecutor.ExecutorUriString)]
     class TestExecutor : ITestExecutor {
         public const string ExecutorUriString = "executor://NodejsTestExecutor/v1";
@@ -157,6 +159,24 @@ namespace Microsoft.NodejsTools.TestAdapter {
                     TestOutcome.Failed);
                 return;
             }
+
+#if DEV15
+            // VS 2017 doesn't install some assemblies to the GAC that are needed to work with the
+            // debugger, and as the tests don't execute in the devenv.exe process, those assemblies
+            // fail to load - so load them manually from PublicAssemblies.
+
+            var currentProc = Process.GetCurrentProcess().MainModule.FileName;
+            if(Path.GetFileName(currentProc).ToLowerInvariant().Equals("vstest.executionengine.x86.exe"))
+            {
+                string baseDir = Path.GetDirectoryName(currentProc);
+                string publicAssemblies = Path.Combine(baseDir, "..\\..\\..\\PublicAssemblies");
+
+                Assembly.LoadFrom(Path.Combine(publicAssemblies, "Microsoft.VisualStudio.OLE.Interop.dll"));
+                Assembly.LoadFrom(Path.Combine(publicAssemblies, "envdte90.dll"));
+                Assembly.LoadFrom(Path.Combine(publicAssemblies, "envdte80.dll"));
+                Assembly.LoadFrom(Path.Combine(publicAssemblies, "envdte.dll"));
+            }
+#endif
 
             NodejsTestInfo testInfo = new NodejsTestInfo(test.FullyQualifiedName);
             List<string> args = new List<string>();

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -165,7 +165,9 @@ namespace Microsoft.NodejsTools.TestAdapter
             // debugger, and as the tests don't execute in the devenv.exe process, those assemblies
             // fail to load - so load them manually from PublicAssemblies.
 
-            var currentProc = Process.GetCurrentProcess().MainModule.FileName;
+            // Use the executable name, as this is only needed for the out of proc test execution
+            // that may interact with the debugger (vstest.executionengine.x86.exe).
+            string currentProc = Process.GetCurrentProcess().MainModule.FileName;
             if(Path.GetFileName(currentProc).ToLowerInvariant().Equals("vstest.executionengine.x86.exe"))
             {
                 string baseDir = Path.GetDirectoryName(currentProc);


### PR DESCRIPTION
See issue description in the comment at https://github.com/Microsoft/nodejstools/pull/1524#issuecomment-293761532 .

This may not be the most elegant solution, or the right one long term, but it does work and is simple enough. If in the test executor process, then by loading the assemblies explicitly when it attempts to run tests, but before hitting any code that would cause .NET to try and locate the assemblies, they are already loaded when required.