### PR TITLE
Scroll focused control into visible area

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.de.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.de.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.en.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.en.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.es.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.es.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.fr.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.fr.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.it.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.it.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ja.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ja.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ko.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ko.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.pl.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.pl.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.pt-BR.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.pt-BR.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ru.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.ru.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.tr.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.tr.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.zh-Hans.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.zh-Hans.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.zh-Hant.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.zh-Hant.resx
@@ -549,6 +549,9 @@
   <data name="_browsePath.Text" xml:space="preserve">
     <value>...</value>
   </data>
+  <data name="_browsePath.AccessibleName" xml:space="preserve">
+    <value>Browse for node.exe</value>
+  </data>
   <data name="&gt;&gt;_browsePath.Name" xml:space="preserve">
     <value>_browsePath</value>
   </data>
@@ -584,6 +587,9 @@
   </data>
   <data name="_browseDirectory.Text" xml:space="preserve">
     <value>...</value>
+  </data>
+  <data name="_browseDirectory.AccessibleName" xml:space="preserve">
+    <value>Browse for working directory</value>
   </data>
   <data name="&gt;&gt;_browseDirectory.Name" xml:space="preserve">
     <value>_browseDirectory</value>


### PR DESCRIPTION
This fixes an issue where when tabbing through the controls in the propertypage the focused control is not automatically scrolled into focus. 