### PR TITLE
Replace packages.config with project.json

### DIFF
--- a/EnvironmentSetup.ps1
+++ b/EnvironmentSetup.ps1
@@ -68,7 +68,7 @@ if ($microbuild -or ($vstarget -eq "15.0" -and -not $skipRestore)) {
     Write-Output ""
     Write-Output "Installing Nuget MicroBuild packages"
 
-    & "$rootdir\Nodejs\.nuget\nuget.exe" restore "$rootdir\Nodejs\Setup\swix\packages.config" -PackagesDirectory "$packagedir"
+    & "$rootdir\Nodejs\.nuget\nuget.exe" restore "$rootdir\Nodejs\Setup\swix\project.json" -PackagesDirectory "$packagedir" -ConfigFile "$rootdir\Nodejs\.nuget\nuget.config"
 
     # If using the -microbuild switch, ONLY do the microbuild restore (this behavior is expected by the build servers).
     if($microbuild) {

--- a/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
+++ b/Nodejs/Setup/swix/Microsoft.VisualStudio.NodejsTools.Targets.swixproj
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?> 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+      <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <Import Project="..\SetupProjectBefore.settings" />
   <Import Project="$(PackagesPath)\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" />
 

--- a/Nodejs/Setup/swix/NodejsTools.Profiling.vsmanproj
+++ b/Nodejs/Setup/swix/NodejsTools.Profiling.vsmanproj
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    </PropertyGroup>
+
     <Import Project="..\SetupProjectBefore.settings" />
 
     <PropertyGroup>

--- a/Nodejs/Setup/swix/NodejsTools.vsmanproj
+++ b/Nodejs/Setup/swix/NodejsTools.vsmanproj
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    </PropertyGroup>
+
     <Import Project="..\SetupProjectBefore.settings" />
 
     <PropertyGroup>

--- a/Nodejs/Setup/swix/packages.config
+++ b/Nodejs/Setup/swix/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MicroBuild.Core" version="0.2.0"/>
-  <package id="MicroBuild.Plugins.SwixBuild" version="1.0.115"/>
-</packages>

--- a/Nodejs/Setup/swix/project.json
+++ b/Nodejs/Setup/swix/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "MicroBuild.Core": "0.2.0",
+    "MicroBuild.Plugins.SwixBuild": "1.0.*"
+  },
+  "frameworks": {
+    "net461": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}


### PR DESCRIPTION
This way we can use a wildcard for the version, which helps
prevent issues when referencing MicroBuild packages.

The latest version of the package requires the Framework version to be set to 4.6.1 so, doing that for all the SWIX/VSMAN projects. It doesn't have any affect on the build though.
