### PR TITLE
Make sure we send options for the install_typings in both cases.

### DIFF
--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+,#!/usr/bin/env node
 /**
     Tool to aquire typings used for NTVS IntelliSense.
 
@@ -30,7 +30,7 @@ if (!packagesToInstall.length) {
         var options = {
             save: argv.save,
             emitter: emitter,
-            options.global = name === "node"; // Assume everything else refers to a CommonJS module
+            options.global = name === "node", // Assume everything else refers to a CommonJS module
             cwd: argv.cwd || process.cwd()
         };
 

--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -30,7 +30,7 @@ if (!packagesToInstall.length) {
         var options = {
             save: argv.save,
             emitter: emitter,
-            options.global = name === "node", // Assume everything else refers to a CommonJS module
+            global: name === "node", // Assume everything else refers to a CommonJS module
             cwd: argv.cwd || process.cwd()
         };
 

--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -18,6 +18,13 @@ var argv = minimist(process.argv.slice(2), {
 
 var emitter = new events.EventEmitter();
 
+var options = {
+    save: argv.save,
+    emitter: emitter,
+    global: true,
+    cwd: argv.cwd || process.cwd()
+};
+
 var packagesToInstall = argv._;
 
 if (!packagesToInstall.length) {
@@ -25,12 +32,7 @@ if (!packagesToInstall.length) {
     typingsTool.installTypingsForProject(options)
 } else {
     typingsTool.runAll(packagesToInstall.map(function (name) {
-        var options = {
-            save: argv.save,
-            emitter: emitter,
-            global: name === "node", // Assume everything else refers to a CommonJS module
-            cwd: argv.cwd || process.cwd()
-        };
+        options.global = name === "node"; // Assume everything else refers to a CommonJS module
         return typingsTool.installTypingsForPackage(name, options);
     }));
 }

--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -1,4 +1,4 @@
-,#!/usr/bin/env node
+#!/usr/bin/env node
 /**
     Tool to aquire typings used for NTVS IntelliSense.
 

--- a/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
+++ b/Nodejs/Product/Nodejs/TypingsAcquisitionTool/bin/install_typings
@@ -17,22 +17,23 @@ var argv = minimist(process.argv.slice(2), {
 });
 
 var emitter = new events.EventEmitter();
-
-var options = {
-    save: argv.save,
-    emitter: emitter,
-    global: true,
-    cwd: argv.cwd || process.cwd()
-};
-
 var packagesToInstall = argv._;
 
 if (!packagesToInstall.length) {
     // top level package install
-    typingsTool.installTypingsForProject(options)
+    typingsTool.installTypingsForProject({ save: argv.save,
+                                           emitter: emitter,
+                                           global: true,
+                                           cwd: argv.cwd || process.cwd()})
 } else {
     typingsTool.runAll(packagesToInstall.map(function (name) {
-        options.global = name === "node"; // Assume everything else refers to a CommonJS module
+        var options = {
+            save: argv.save,
+            emitter: emitter,
+            options.global = name === "node"; // Assume everything else refers to a CommonJS module
+            cwd: argv.cwd || process.cwd()
+        };
+
         return typingsTool.installTypingsForPackage(name, options);
     }));
 }


### PR DESCRIPTION
This fixes a null reference on options in the case of `installTypingsForProject`