### PR TITLE
Stamp latest supported TypeScript version into new projects

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -73,7 +73,16 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.8.24\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -149,8 +158,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -82,6 +82,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -554,7 +554,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard
                     .First();
             }
 
-            return null;
+            return "";
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
+++ b/Nodejs/Product/Nodejs/Project/ImportWizard/ImportSettings.cs
@@ -12,6 +12,7 @@ using System.Windows;
 using System.Xml;
 using Microsoft.NodejsTools.Telemetry;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudioTools;
 
 namespace Microsoft.NodejsTools.Project.ImportWizard
@@ -256,9 +257,10 @@ namespace Microsoft.NodejsTools.Project.ImportWizard
                 Guid projectGuid;
                 try
                 {
+                    string typeScriptVersion = GetLatestAvailableTypeScriptVersionFromSetup();
                     using (var writer = GetDefaultWriter(projectPath))
                     {
-                        WriteProjectXml(writer, projectPath, sourcePath, filters, startupFile, true, out projectGuid);
+                        WriteProjectXml(writer, projectPath, sourcePath, filters, startupFile, typeScriptVersion, true, out projectGuid);
                     }
                     NodejsPackage.Instance?.TelemetryLogger.LogProjectImported(projectGuid);
                     success = true;
@@ -304,6 +306,7 @@ namespace Microsoft.NodejsTools.Project.ImportWizard
             string sourcePath,
             string filters,
             string startupFile,
+            string typeScriptVersion,
             bool excludeNodeModules,
             out Guid projectGuid
         )
@@ -346,6 +349,10 @@ namespace Microsoft.NodejsTools.Project.ImportWizard
                 writer.WriteElementString("TypeScriptSourceMap", "true");
                 writer.WriteElementString("TypeScriptModuleKind", "CommonJS");
                 writer.WriteElementString("EnableTypeScript", "true");
+                if (typeScriptVersion != null)
+                {
+                    writer.WriteElementString("TypeScriptToolsVersion", typeScriptVersion);
+                }
             }
 
             writer.WriteStartElement("VisualStudioVersion");
@@ -519,6 +526,35 @@ namespace Microsoft.NodejsTools.Project.ImportWizard
                 .Distinct(StringComparer.OrdinalIgnoreCase);
 
             return res;
+        }
+
+        private const string tsSdkSetupPackageIdPrefix = "Microsoft.VisualStudio.Component.TypeScript.";
+
+        private static string GetLatestAvailableTypeScriptVersionFromSetup()
+        {
+            var setupCompositionService = (IVsSetupCompositionService)CommonPackage.GetGlobalService(typeof(SVsSetupCompositionService));
+
+            // Populate the package status
+            uint count = 0;
+            uint sizeNeeded = 0;
+            IVsSetupPackageInfo[] packages = null;
+            setupCompositionService.GetSetupPackagesInfo(count, packages, out sizeNeeded);
+
+            if (sizeNeeded > 0)
+            {
+                packages = new IVsSetupPackageInfo[sizeNeeded];
+                count = sizeNeeded;
+                setupCompositionService.GetSetupPackagesInfo(count, packages, out sizeNeeded);
+
+                return packages.Where(p => (__VsSetupPackageState)p.CurrentState == __VsSetupPackageState.INSTALL_PACKAGE_PRESENT)
+                    .Select(p => p.PackageId)
+                    .Where(p => p.StartsWith(tsSdkSetupPackageIdPrefix))
+                    .Select(p => p.Substring(tsSdkSetupPackageIdPrefix.Length, p.Length - tsSdkSetupPackageIdPrefix.Length))
+                    .OrderByDescending(v => v)
+                    .First();
+            }
+
+            return null;
         }
     }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
@@ -20,6 +20,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/Worker.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/Worker.njsproj
@@ -21,6 +21,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/Worker.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorkerRole/Worker.njsproj
@@ -21,6 +21,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
@@ -21,6 +21,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/TypeScriptWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/TypeScriptWebApp.njsproj
@@ -21,6 +21,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
@@ -20,6 +20,7 @@
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
@@ -20,6 +20,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptFromExistingCode/FromExistingCode.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptFromExistingCode/FromExistingCode.njsproj
@@ -20,6 +20,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
   </PropertyGroup>
 

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
@@ -21,6 +21,7 @@
     <NodejsPort>1337</NodejsPort>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>true</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Product/ProjectWizard/NodejsPackageParametersExtension.cs
+++ b/Nodejs/Product/ProjectWizard/NodejsPackageParametersExtension.cs
@@ -90,7 +90,7 @@ namespace Microsoft.NodejsTools.ProjectWizard
                     .First();
             }
 
-            return null;
+            return "";
         }
     }
 }

--- a/Nodejs/Product/ProjectWizard/NodejsPackageParametersExtension.cs
+++ b/Nodejs/Product/ProjectWizard/NodejsPackageParametersExtension.cs
@@ -2,18 +2,23 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TemplateWizard;
 
 namespace Microsoft.NodejsTools.ProjectWizard
 {
     internal class NodejsPackageParametersExtension : IWizard
     {
+        private const string tsSdkSetupPackageIdPrefix = "Microsoft.VisualStudio.Component.TypeScript.";
+
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
         {
             var projectName = replacementsDictionary["$projectname$"];
             replacementsDictionary.Add("$npmsafeprojectname$", NormalizeNpmPackageName(projectName));
+            replacementsDictionary.Add("$typescriptversion$", GetLatestAvailableTypeScriptVersionFromSetup());
         }
 
         public void ProjectFinishedGenerating(EnvDTE.Project project)
@@ -59,6 +64,33 @@ namespace Microsoft.NodejsTools.ProjectWizard
             npmProjectNameTransform = Regex.Replace(npmProjectNameTransform, "([a-z0-9])([A-Z])", "$1-$2").ToLowerInvariant();
 
             return npmProjectNameTransform.Substring(0, Math.Min(npmProjectNameTransform.Length, NpmPackageNameMaxLength));
+        }
+
+        private static string GetLatestAvailableTypeScriptVersionFromSetup()
+        {
+            var setupCompositionService = (IVsSetupCompositionService)Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider.GetService(typeof(SVsSetupCompositionService));
+
+            // Populate the package status
+            uint count = 0;
+            uint sizeNeeded = 0;
+            IVsSetupPackageInfo[] packages = null;
+            setupCompositionService.GetSetupPackagesInfo(count, packages, out sizeNeeded);
+
+            if (sizeNeeded > 0)
+            {
+                packages = new IVsSetupPackageInfo[sizeNeeded];
+                count = sizeNeeded;
+                setupCompositionService.GetSetupPackagesInfo(count, packages, out sizeNeeded);
+
+                return packages.Where(p => (__VsSetupPackageState)p.CurrentState == __VsSetupPackageState.INSTALL_PACKAGE_PRESENT)
+                    .Select(p => p.PackageId)
+                    .Where(p => p.StartsWith(tsSdkSetupPackageIdPrefix))
+                    .Select(p => p.Substring(tsSdkSetupPackageIdPrefix.Length, p.Length - tsSdkSetupPackageIdPrefix.Length))
+                    .OrderByDescending(v => v)
+                    .First();
+            }
+
+            return null;
         }
     }
 }

--- a/Nodejs/Product/ProjectWizard/ProjectWizard.csproj
+++ b/Nodejs/Product/ProjectWizard/ProjectWizard.csproj
@@ -36,6 +36,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Nodejs/Tests/TestData/CopyPasteRenameProject/CopyPasteRenameProject/CopyPasteRenameProjectTypeScript.njsproj
+++ b/Nodejs/Tests/TestData/CopyPasteRenameProject/CopyPasteRenameProject/CopyPasteRenameProjectTypeScript.njsproj
@@ -24,6 +24,7 @@
     <ProjectView>ShowAllFiles</ProjectView>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>false</StartWebBrowser>
   </PropertyGroup>

--- a/Nodejs/Tests/TestData/NodejsTypeScriptProfileTestNeedsBuild/NodejsProfileTest.njsproj
+++ b/Nodejs/Tests/TestData/NodejsTypeScriptProfileTestNeedsBuild/NodejsProfileTest.njsproj
@@ -21,6 +21,7 @@
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Nodejs/Tests/TestData/NodejsTypeScriptProfileTestWithErrors/NodejsProfileTest.njsproj
+++ b/Nodejs/Tests/TestData/NodejsTypeScriptProfileTestWithErrors/NodejsProfileTest.njsproj
@@ -21,6 +21,7 @@
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
+    <TypeScriptToolsVersion>$typescriptversion$</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
Query the latest installed TypeScript version from VS setup (_not_ from disk as the latest on disk is not guaranteed to work with templates that ship in VS), and stamp that into new project files. 