### PR TITLE
Remove profiling from build

### DIFF
--- a/Build/UpdateVsixVersion.ps1
+++ b/Build/UpdateVsixVersion.ps1
@@ -50,4 +50,3 @@ function Update-Manifest
 
 Update-Manifest 'InteractiveWindow'
 Update-Manifest 'NodeJs'
-Update-Manifest 'Profiling'

--- a/Nodejs/Product/dirs.proj
+++ b/Nodejs/Product/dirs.proj
@@ -8,13 +8,7 @@
     <ProjectFile Include="Npm\Npm.csproj"/>
     <ProjectFile Include="PressAnyKey\PressAnyKey.csproj"/>
     <ProjectFile Include="WebRole\WebRole.csproj"/>
-    
-    <ProjectFile Include="LogConverter\LogConverter.csproj"/>
-    
     <ProjectFile Include="Nodejs\Nodejs.csproj"/>
-    
-    <ProjectFile Include="Profiling\Profiling.csproj"/>
-    
     <ProjectFile Include="TestAdapter\TestAdapter.csproj"/>
   </ItemGroup>
 

--- a/Nodejs/Setup/setup-swix.proj
+++ b/Nodejs/Setup/setup-swix.proj
@@ -4,7 +4,6 @@
   <ItemGroup>
     <ProjectFile Include="swix\Microsoft.VisualStudio.NodejsTools.Targets.swixproj"/>
     <ProjectFile Include="swix\NodejsTools.vsmanproj"/>
-    <ProjectFile Include="swix\NodejsTools.Profiling.vsmanproj" />
   </ItemGroup>
 
   <Import Project="$(TargetsPath)\Common.Build.Traversal.targets" />


### PR DESCRIPTION
Profiler has a build issue. So we should stop building it while we figure out what to do with it.