### PR TITLE
Enable sourcelink support for NodeTools

### DIFF
--- a/Build/Common.Build.CSharp.settings
+++ b/Build/Common.Build.CSharp.settings
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/Nodejs/Product/InteractiveWindow/InteractiveWindow.csproj
+++ b/Nodejs/Product/InteractiveWindow/InteractiveWindow.csproj
@@ -7,6 +7,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
@@ -93,6 +95,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -252,4 +255,11 @@
   </PropertyGroup>
   <Import Project="$(BuildRoot)\Common\Product\ReplWindow\ReplWindow.proj" />
   <Import Project="..\ProjectAfter.settings" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
+  </Target>
 </Project>

--- a/Nodejs/Product/InteractiveWindow/packages.config
+++ b/Nodejs/Product/InteractiveWindow/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1268,6 +1268,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -1304,4 +1305,5 @@
     <Delete Files="@(_CopiedForCreatePkgdef)" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets" Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
 </Project>

--- a/Nodejs/Product/Nodejs/packages.config
+++ b/Nodejs/Product/Nodejs/packages.config
@@ -11,4 +11,5 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspaces" version="15.0.215-pre" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
+  <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>

--- a/Nodejs/Product/Npm/Npm.csproj
+++ b/Nodejs/Product/Npm/Npm.csproj
@@ -7,6 +7,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
@@ -154,6 +156,13 @@
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Nodejs/Product/PressAnyKey/PressAnyKey.csproj
+++ b/Nodejs/Product/PressAnyKey/PressAnyKey.csproj
@@ -7,6 +7,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
@@ -46,8 +48,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Nodejs/Product/PressAnyKey/packages.config
+++ b/Nodejs/Product/PressAnyKey/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>

--- a/Nodejs/Product/ProjectWizard/ProjectWizard.csproj
+++ b/Nodejs/Product/ProjectWizard/ProjectWizard.csproj
@@ -7,6 +7,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
@@ -111,8 +113,19 @@
     <EmbeddedResource Include="ProjectWizardResources.zh-Hans.resx" />
     <EmbeddedResource Include="ProjectWizardResources.zh-Hant.resx" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="..\Nodejs\SharedResources.proj" />
   <Import Project="..\ProjectAfter.settings" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Nodejs/Product/ProjectWizard/app.config
+++ b/Nodejs/Product/ProjectWizard/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Nodejs/Product/ProjectWizard/packages.config
+++ b/Nodejs/Product/ProjectWizard/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -176,6 +176,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets" Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.16-beta\build\portable-net45+win8+wpa81\Microsoft.Diagnostics.Tracing.EventSource.Redist.targets')" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
 </Project>

--- a/Nodejs/Product/TestAdapter/packages.config
+++ b/Nodejs/Product/TestAdapter/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.VisualStudio.Telemetry" version="15.3.789-masterCC863119" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Utilities.Internal" version="14.0.72-masterF9EB1D39" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
+  <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>

--- a/Nodejs/Product/WebRole/WebRole.csproj
+++ b/Nodejs/Product/WebRole/WebRole.csproj
@@ -1,13 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-      <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
-      <FileUpgradeFlags>
-      </FileUpgradeFlags>
-      <UpgradeBackupLocation>
-      </UpgradeBackupLocation>
-      <OldToolsVersion>4.0</OldToolsVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
   <Import Project="..\ProjectBefore.settings" />
   <PropertyGroup>
     <UseIISExpress>false</UseIISExpress>
@@ -66,8 +68,18 @@
     </Compile>
     <EmbeddedResource Include="WebSocketProxy.html" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="..\ProjectAfter.settings" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VSTarget)\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets" Condition="Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SourceLink.Create.CommandLine.2.1.2\build\SourceLink.Create.CommandLine.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Nodejs/Product/WebRole/packages.config
+++ b/Nodejs/Product/WebRole/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="SourceLink.Create.CommandLine" version="2.1.2" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This requires portable PDBs, and VS 15.3/VS Code

This only affects our MicroBuilds, since those set a property in the build which enables the newly added target.
