### PR TITLE
Checkout package.json before editing it

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/ErrorHelper.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/ErrorHelper.cs
@@ -89,5 +89,12 @@ namespace Microsoft.NodejsTools.NpmUI
                     MessageBoxImage.Error);
             }
         }
+
+        public static void ReportPackageJsonNotCheckedOut(Window owner)
+        {
+            var message = Resources.PackageJsonNotCheckedOutMessage;
+            var caption = Resources.PackageJsonNotCheckedOutCaption;
+            MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 }

--- a/Nodejs/Product/Nodejs/NpmUI/ErrorHelper.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/ErrorHelper.cs
@@ -94,7 +94,7 @@ namespace Microsoft.NodejsTools.NpmUI
         {
             var message = Resources.PackageJsonNotCheckedOutMessage;
             var caption = Resources.PackageJsonNotCheckedOutCaption;
-            MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show(owner, message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -512,14 +512,16 @@ namespace Microsoft.NodejsTools.Project
 
         private bool EnsurePackageJsonCheckedOut()
         {
-            // No need to check if the files exist or is actually under sourcecontrol before the call to check them out,
+            // No need to check if the files exist or is actually under source control before the call to check them out,
             // since the API handles that and returns QER_EditOK.
-            var packageJsonFileName = Path.Combine(this.NpmController.RootPackage.Path, "package.json");
-            var packageJsonLockFileName = Path.Combine(this.NpmController.RootPackage.Path, "package-lock.json");
+
+            var rootPath = this.NpmController.RootPackage.Path;
+            var packageJsonFileName = Path.Combine(rootPath, "package.json");
+            var packageJsonLockFileName = Path.Combine(rootPath, "package-lock.json");
 
             var queryEditService = (IVsQueryEditQuerySave2)this._projectNode.GetService(typeof(SVsQueryEditQuerySave));
-            queryEditService.QueryEditFiles((uint)tagVSQueryEditFlags.QEF_DisallowInMemoryEdits, 1, new[] { packageJsonFileName, packageJsonLockFileName }, null, null, out var result, out var _);
-            return result == (uint)tagVSQueryEditResult.QER_EditOK;
+            var hr = queryEditService.QueryEditFiles((uint)tagVSQueryEditFlags.QEF_DisallowInMemoryEdits, 1, new[] { packageJsonFileName, packageJsonLockFileName }, null, null, out var result, out var _);
+            return ErrorHandler.Succeeded(hr) && result == (uint)tagVSQueryEditResult.QER_EditOK;
         }
 
         private bool CheckValidCommandTarget(DependencyNode node)

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -1647,5 +1647,23 @@ namespace Microsoft.NodejsTools {
                 return ResourceManager.GetString("WorkingDirToolTip", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Package.json not checked out.
+        /// </summary>
+        public static string PackageJsonNotCheckedOutCaption {
+            get {
+                return ResourceManager.GetString("PackageJsonNotCheckedOutCaption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to checkout 'package.json'. Please ..
+        /// </summary>
+        public static string PackageJsonNotCheckedOutMessage {
+            get {
+                return ResourceManager.GetString("PackageJsonNotCheckedOutMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/Nodejs/Product/Nodejs/Resources.en.resx
+++ b/Nodejs/Product/Nodejs/Resources.en.resx
@@ -656,4 +656,10 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="PropertiesBrowseDirectoryAccessibleName" xml:space="preserve">
     <value>Browse for working directory</value>
   </data>
+  <data name="PackageJsonNotCheckedOutCaption" xml:space="preserve">
+    <value>Package.json not checked out</value>
+  </data>
+  <data name="PackageJsonNotCheckedOutMessage" xml:space="preserve">
+    <value>Failed to checkout 'package.json'. Please ensure the file is checked out, before adding or removing NPM packages.</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.en.resx
+++ b/Nodejs/Product/Nodejs/Resources.en.resx
@@ -660,6 +660,6 @@ Error retrieving websocket debug proxy information from web.config.</value>
     <value>Package.json not checked out</value>
   </data>
   <data name="PackageJsonNotCheckedOutMessage" xml:space="preserve">
-    <value>Failed to checkout 'package.json'. Please ensure the file is checked out, before adding or removing NPM packages.</value>
+    <value>Failed to check out 'package.json'. Please ensure the file is checked out, before adding or removing NPM packages.</value>
   </data>
 </root>


### PR DESCRIPTION
This fixes issue #485 

This ensures we checkout the `package.json` and `package-lock.json` before trying to edit it by installing/updating packages.

