### PR TITLE
Use hashed file contents as unique test ID

### DIFF
--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -214,7 +214,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 }
 
                 // All tests being run are for the same test file, so just use the first test listed to get the working dir
-                NodejsTestInfo testInfo = new NodejsTestInfo(tests.First().FullyQualifiedName);
+                NodejsTestInfo testInfo = new NodejsTestInfo(tests.First().FullyQualifiedName, tests.First().CodeFilePath);
                 var workingDir = Path.GetDirectoryName(CommonUtils.GetAbsoluteFilePath(settings.WorkingDir, testInfo.ModulePath));
 
                 foreach (var test in tests) {
@@ -314,7 +314,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
         }
 
         private IEnumerable<string> GetInterpreterArgs(TestCase test, string workingDir, string projectRootDir) {
-            TestFrameworks.NodejsTestInfo testInfo = new TestFrameworks.NodejsTestInfo(test.FullyQualifiedName);
+            TestFrameworks.NodejsTestInfo testInfo = new TestFrameworks.NodejsTestInfo(test.FullyQualifiedName, test.CodeFilePath);
             TestFrameworks.FrameworkDiscover discover = new TestFrameworks.FrameworkDiscover();
             return discover.Get(testInfo.TestFramework).ArgumentsToRunTests(testInfo.TestName, testInfo.ModulePath, workingDir, projectRootDir);
         }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -15,15 +15,18 @@
 //*********************************************************//
 
 using System;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
     class NodejsTestInfo {
-        public NodejsTestInfo(string fullyQualifiedName) {
+        public NodejsTestInfo(string fullyQualifiedName, string modulePath) {
             string[] parts = fullyQualifiedName.Split(new string[] { "::" }, StringSplitOptions.None);
             if (parts.Length != 3) {
                 throw new ArgumentException("Invalid fully qualified test name");
             }
-            ModulePath = parts[0];
+            ModulePath = modulePath;
+            ModuleName = parts[0];
             TestName = parts[1];
             TestFramework = parts[2];
         }
@@ -31,18 +34,50 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks {
         public NodejsTestInfo(string modulePath, string testName, string testFramework, int line, int column)
         {
             ModulePath = modulePath;
+            SetModuleName(ModulePath);
             TestName = testName;
             TestFramework = testFramework;
             SourceLine = line;
             SourceColumn = column;
         }
 
+        private void SetModuleName(string modulePath)
+        {
+            ModuleName = String.Format("{0}[{1}]",
+                (string)Path.GetFileName(modulePath).Split('.').GetValue(0),
+                GetHash(modulePath));
+        }
+
+        private string GetHash(string filePath)
+        {
+            try
+            {
+                using (FileStream stream = File.OpenRead(filePath))
+                {
+                    SHA1Managed sha = new SHA1Managed();
+                    byte[] hash = sha.ComputeHash(stream);
+
+                    // chop hash in half since we just need a unique ID
+                    Int32 startIndex = hash.Length / 2;
+                    sha.Dispose();
+
+                    return BitConverter.ToString(hash, startIndex).Replace("-", String.Empty);
+                }
+            } catch (FileNotFoundException)
+            {
+                // Just return some default value and let node handle it later
+                return "FILE_NOT_FOUND";
+            }
+        }
+
         public string FullyQualifiedName {
             get {
-                return ModulePath + "::" + TestName + "::" + TestFramework;
+                return ModuleName + "::" + TestName + "::" + TestFramework;
             }
         }
         public string ModulePath { get; private set; }
+
+        public string ModuleName { get; private set; }
 
         public string TestName { get; private set; }
 

--- a/Nodejs/Tests/TestAdapterTests/NodejsTestInfoTests.cs
+++ b/Nodejs/Tests/TestAdapterTests/NodejsTestInfoTests.cs
@@ -16,7 +16,7 @@ namespace TestAdapterTests {
             //Act
             NodejsTestInfo testInfo = new NodejsTestInfo(testFile, testName, testFramework, 0, 0);
             //Assert
-            string expected = testFile + "::" + testName + "::" + testFramework;
+            string expected = testInfo.ModuleName + "::" + testName + "::" + testFramework;
             Assert.AreEqual(expected, testInfo.FullyQualifiedName);
             Assert.AreEqual(testName, testInfo.TestName);
             Assert.AreEqual(testFramework, testInfo.TestFramework);
@@ -29,9 +29,10 @@ namespace TestAdapterTests {
         public void ConstructFromQualifiedName_ThrowOnInValidInput() {
             //Arrange
             string badDummy = "c:\\dummy.js::dummy::dumm2::test1";
+            string dummyPath = "c:\\dummyTest.js";
 
             //Act
-            NodejsTestInfo testInfo = new NodejsTestInfo(badDummy);
+            NodejsTestInfo testInfo = new NodejsTestInfo(badDummy, dummyPath);
 
             //Assert: N/A
         }


### PR DESCRIPTION
Issue #1561

##### Bug
TFS unable to detect the same test failing in a previous build if the path of the `*.js` file differs.

Since a test's path is used in its `FullyQualifiedName`, the same test run on two different agents with different drive names (i.e: `D:/` vs. `C:/` drives) will not be recognized as the same test by TFS.

##### Fix
Hash the contents of the test file using SHA1 (so as not to slow down test discovery significantly) and use this as a `ModuleName` / unique ID.

Previous `FullyQualifiedId`: `C:\some\path\to\my\test.js::Suite 1 Test 1::Mocha`
New `FullyQualifiedId`: `test[60E439FF4023183BDC8C]::Suite 1 Test 1::Mocha`

**NOTE:** An assumption using this method is that two test files do not exist in the same project with the exact same name and contents.

##### Testing

1. Create sample test project
2. Copy project to a different path
3. Open both projects
4. The same test in both projects should have the same `FullyQualifiedId`

This will ensure intended TFS behavior of failed test detection in current vs. previous builds.

Please let me know if there are any improvements or changes I should make. Thanks!