### PR TITLE
Added double quotes to npm search for allowing one character queries.

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
@@ -106,7 +106,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
             TelemetryHelper.LogSearchNpm();
 
-            var relativeUri = string.Format("/-/v1/search?text={0}", WebUtility.UrlEncode(filterText));
+            var relativeUri = string.Format("/-/v1/search?text=\"{0}\"", WebUtility.UrlEncode(filterText));
             var searchUri = new Uri(defaultRegistryUri, relativeUri);
 
             var request = WebRequest.Create(searchUri);


### PR DESCRIPTION
Work around for NPM registry issue where one character queries display 0 results.

Details on: https://github.com/npm/registry/issues/194
