### PR TITLE
Warn user when Node is not installed

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -114,6 +114,10 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.3.83\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Utilities.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Utilities.Internal.14.0.72-masterF9EB1D39\lib\net45\Microsoft.VisualStudio.Utilities.Internal.dll</HintPath>
@@ -134,6 +138,7 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Workspaces.15.0.215-pre\lib\net46\Microsoft.VisualStudio.Workspace.Extensions.VS.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Workspace.VSIntegration.Contracts, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
@@ -195,7 +200,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -608,6 +608,15 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from &apos;https://nodejs.org&apos;, or specify the location of your Node.exe in the &apos;{0}&apos;..
+        /// </summary>
+        internal static string NodejsNotInstalledAnyCode {
+            get {
+                return ResourceManager.GetString("NodejsNotInstalledAnyCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Node.js has not been detected on your computer.
         /// </summary>
         internal static string NodejsNotInstalledShort {

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -608,7 +608,7 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from &apos;https://nodejs.org&apos;, or specify the location of your Node.exe in the &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from &apos;https://nodejs.org&apos;, or specify the location of your Node.exe in the &apos;{0}&apos; file..
         /// </summary>
         internal static string NodejsNotInstalledAnyCode {
             get {

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -668,4 +668,8 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="NpmExecuteCommand" xml:space="preserve">
     <value>Executes npm command. If solution contains multiple projects, specify target project using .npm [ProjectName] &lt;npm arguments&gt;</value>
   </data>
+  <data name="NodejsNotInstalledAnyCode" xml:space="preserve">
+    <value>Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from 'https://nodejs.org', or specify the location of your Node.exe in the '{0}'.</value>
+    <comment>Template contains a filename, like launch.json</comment>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -669,7 +669,7 @@ Error retrieving websocket debug proxy information from web.config.</value>
     <value>Executes npm command. If solution contains multiple projects, specify target project using .npm [ProjectName] &lt;npm arguments&gt;</value>
   </data>
   <data name="NodejsNotInstalledAnyCode" xml:space="preserve">
-    <value>Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from 'https://nodejs.org', or specify the location of your Node.exe in the '{0}'.</value>
+    <value>Could not find a Node.js runtime on your computer.  Please download and install the current Node.js release from 'https://nodejs.org', or specify the location of your Node.exe in the '{0}' file.</value>
     <comment>Template contains a filename, like launch.json</comment>
   </data>
 </root>

--- a/Nodejs/Product/Nodejs/packages.config
+++ b/Nodejs/Product/Nodejs/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.VisualStudio.RemoteControl" version="14.0.262-masterA5CACE98" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2273" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Telemetry" version="15.3.789-masterCC863119" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.3.83" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Utilities.Internal" version="14.0.72-masterF9EB1D39" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspaces" version="15.0.215-pre" targetFramework="net46" />


### PR DESCRIPTION
Show a dialog when the user tries to debug a js file in Open Folder,
and Node.js is not installed.

Fixes this feedback item

https://developercommunity.visualstudio.com/content/problem/88324/cannot-start-node-application.html