### PR TITLE
Replace FileSystemWatcher with IVsFileChangeEx

### DIFF
--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -289,6 +289,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             {
                 this.isDisposed = true;
                 this.testFilesAddRemoveListener.Dispose();
+                this.testFilesUpdateWatcher.Dispose();
                 this.solutionListener.Dispose();
             }
         }
@@ -460,7 +461,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                     {
                         if (!string.IsNullOrEmpty(root) && CommonUtils.IsSubpathOf(root, p))
                         {
-                            this.testFilesUpdateWatcher.AddDirectoryWatch(root);
+                            this.testFilesUpdateWatcher.AddFolderWatch(root);
                             this.fileRootMap[p] = root;
                         }
                         else
@@ -540,7 +541,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
                             if (!string.IsNullOrEmpty(root) && CommonUtils.IsSubpathOf(root, e.File))
                             {
-                                this.testFilesUpdateWatcher.AddDirectoryWatch(root);
+                                this.testFilesUpdateWatcher.AddFolderWatch(root);
                                 this.fileRootMap[e.File] = root;
                             }
                             else

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,7 @@ namespace Microsoft.NodejsTools.TestAdapter
         private TestContainerDiscoverer([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, [Import(typeof(IOperationState))]IOperationState operationState)
             : this(serviceProvider,
                    new SolutionEventsListener(serviceProvider),
-                   new TestFilesUpdateWatcher(),
+                   new TestFilesUpdateWatcher(serviceProvider),
                    new TestFileAddRemoveListener(serviceProvider, Guids.NodejsBaseProjectFactory),
                    operationState)
         {
@@ -289,7 +289,6 @@ namespace Microsoft.NodejsTools.TestAdapter
             {
                 this.isDisposed = true;
                 this.testFilesAddRemoveListener.Dispose();
-                this.testFilesUpdateWatcher.Dispose();
                 this.solutionListener.Dispose();
             }
         }

--- a/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/TestContainerDiscoverer.cs
@@ -161,9 +161,9 @@ namespace Microsoft.NodejsTools.TestAdapter
                 return null;
             }
 
-            if (ErrorHandler.Succeeded(vsHierarchy.GetProperty(itemId, propid, out var o)))
+            if (ErrorHandler.Succeeded(vsHierarchy.GetProperty(itemId, propid, out var result)))
             {
-                return o;
+                return result;
             }
             return null;
         }
@@ -387,14 +387,10 @@ namespace Microsoft.NodejsTools.TestAdapter
                 {
                     continue;
                 }
+
                 var solution = (IVsSolution)this.serviceProvider.GetService(typeof(SVsSolution));
                 ErrorHandler.ThrowOnFailure(
-                    solution.SaveSolutionElement(
-                        0,
-                        (IVsHierarchy)project,
-                        0
-                    )
-                );
+                    solution.SaveSolutionElement((uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_SaveIfDirty, (IVsHierarchy)project, /* save entire project */ 0));
             }
         }
 
@@ -469,7 +465,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                         }
                         else
                         {
-                            this.testFilesUpdateWatcher.AddWatch(p);
+                            this.testFilesUpdateWatcher.AddFileWatch(p);
                         }
                     }
                 }
@@ -506,13 +502,13 @@ namespace Microsoft.NodejsTools.TestAdapter
                     {
                         if (string.IsNullOrEmpty(root) || !CommonUtils.IsSubpathOf(root, p))
                         {
-                            this.testFilesUpdateWatcher.RemoveWatch(p);
+                            this.testFilesUpdateWatcher.RemoveFileWatch(p);
                         }
                         this.fileRootMap.Remove(p);
                     }
                     if (!string.IsNullOrEmpty(root))
                     {
-                        this.testFilesUpdateWatcher.RemoveWatch(root);
+                        this.testFilesUpdateWatcher.RemoveFolderWatch(root);
                     }
                 }
             }
@@ -549,7 +545,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                             }
                             else
                             {
-                                this.testFilesUpdateWatcher.AddWatch(e.File);
+                                this.testFilesUpdateWatcher.AddFileWatch(e.File);
                             }
 
                             OnTestContainersChanged(e.Project);
@@ -563,12 +559,12 @@ namespace Microsoft.NodejsTools.TestAdapter
                             this.fileRootMap.Remove(e.File);
                             if (!this.fileRootMap.Values.Contains(root))
                             {
-                                this.testFilesUpdateWatcher.RemoveWatch(root);
+                                this.testFilesUpdateWatcher.RemoveFolderWatch(root);
                             }
                         }
                         else
                         {
-                            this.testFilesUpdateWatcher.RemoveWatch(e.File);
+                            this.testFilesUpdateWatcher.RemoveFileWatch(e.File);
                         }
 
                         // https://pytools.codeplex.com/workitem/1546

--- a/Nodejs/Product/TestAdapter/TestFilesUpdateWatcher.cs
+++ b/Nodejs/Product/TestAdapter/TestFilesUpdateWatcher.cs
@@ -140,6 +140,8 @@ namespace Microsoft.VisualStudioTools.TestAdapter
                 {
                     this.fileWatcher.UnadviseDirChange(cookie);
                 }
+                this.watchedFiles.Clear();
+                this.watchedFolders.Clear();
                 this.fileWatcher = null;
             }
         }

--- a/Nodejs/Product/TestAdapter/TestFilesUpdateWatcher.cs
+++ b/Nodejs/Product/TestAdapter/TestFilesUpdateWatcher.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Diagnostics;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -18,13 +18,16 @@ namespace Microsoft.VisualStudioTools.TestAdapter
 
         public TestFilesUpdateWatcher(IServiceProvider serviceProvider)
         {
-            this.fileWatcher = (IVsFileChangeEx)serviceProvider.GetService<SVsFileChangeEx>();
+            this.fileWatcher = serviceProvider.GetService<IVsFileChangeEx>(typeof(SVsFileChangeEx));
         }
 
-        public bool AddWatch(string path)
+        public bool AddFileWatch(string path)
         {
             ValidateArg.NotNull(path, "path");
-            if (!this.watchedFiles.ContainsKey(path) && ErrorHandler.Succeeded(this.fileWatcher.AdviseFileChange(path, (uint)_VSFILECHANGEFLAGS.VSFILECHG_Add, this, out uint cookie)))
+
+            const uint mask = (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Time);
+
+            if (!this.watchedFiles.ContainsKey(path) && ErrorHandler.Succeeded(this.fileWatcher.AdviseFileChange(path, mask, this, out uint cookie)))
             {
                 this.watchedFiles.Add(path, cookie);
                 return true;
@@ -44,21 +47,26 @@ namespace Microsoft.VisualStudioTools.TestAdapter
             return false;
         }
 
-        public bool RemoveWatch(string path)
+        public bool RemoveFileWatch(string path)
         {
             ValidateArg.NotNull(path, "path");
 
             if (this.watchedFiles.TryGetValue(path, out uint cookie))
             {
                 this.watchedFiles.Remove(path);
-                if (Path.HasExtension(path))
-                {
-                    return ErrorHandler.Succeeded(this.fileWatcher.UnadviseFileChange(cookie));
-                }
-                else
-                {
-                    return ErrorHandler.Succeeded(this.fileWatcher.UnadviseDirChange(cookie));
-                }
+                return ErrorHandler.Succeeded(this.fileWatcher.UnadviseFileChange(cookie));
+            }
+            return false;
+        }
+
+        public bool RemoveFolderWatch(string path)
+        {
+            ValidateArg.NotNull(path, "path");
+
+            if (this.watchedFiles.TryGetValue(path, out uint cookie))
+            {
+                this.watchedFiles.Remove(path);
+                return ErrorHandler.Succeeded(this.fileWatcher.UnadviseDirChange(cookie));
             }
             return false;
         }
@@ -67,7 +75,7 @@ namespace Microsoft.VisualStudioTools.TestAdapter
         {
             for (var i = 0; i < cChanges; i++)
             {
-                FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(null, rgpszFile[i], TestFileChangedReason.Changed));
+                FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(null, rgpszFile[i], ConvertVSFILECHANGEFLAGS(rggrfChange[i])));
             }
 
             return VSConstants.S_OK;
@@ -77,6 +85,25 @@ namespace Microsoft.VisualStudioTools.TestAdapter
         {
             FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(null, pszDirectory, TestFileChangedReason.Changed));
             return VSConstants.S_OK;
+        }
+
+        private static TestFileChangedReason ConvertVSFILECHANGEFLAGS(uint flag)
+        {
+            if ((flag & (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Attr)) != 0)
+            {
+                return TestFileChangedReason.Changed;
+            }
+            if ((flag & (uint)_VSFILECHANGEFLAGS.VSFILECHG_Add) != 0)
+            {
+                return TestFileChangedReason.Added;
+            }
+            if ((flag & (uint)_VSFILECHANGEFLAGS.VSFILECHG_Del) != 0)
+            {
+                return TestFileChangedReason.Removed;
+            }
+
+            Debug.Fail($"Unexpected value for the file changed event \'{flag}\'");
+            return TestFileChangedReason.Changed;
         }
     }
 }


### PR DESCRIPTION
This uses less memory and plays nicer with VS

(this fixes internal bug 259728)

> Microsoft.VisualStudioTools.TestAdapter.TestFilesUpdateWatcher.AddWatch uses FileSystemWatcher to watch individual files, which is extremely inefficient, causing 25MB of virtual alloc in the solution I'm looking at. (as well as pinning tons of objects in GC heap, etc) 
> 
> If possible, please switch to using VS's file watcher system (IVsFileChangeEx). Contact Jeff Robison for more details on the VS file watcher.
> 
> Call stack:
> 392 25,640,960 System.dll!System.IO.FileSystemWatcher.Monitor
>  392 25,640,960 System.dll!System.IO.FileSystemWatcher.StartRaisingEvents
>   392 25,640,960 System.dll!System.IO.FileSystemWatcher.set_EnableRaisingEvents
>    391 25,575,424 Microsoft.NodejsTools.TestAdapter.dll!Microsoft.VisualStudioTools.TestAdapter.TestFilesUpdateWatcher.AddWatch
> 	391 25,575,424 Microsoft.NodejsTools.TestAdapter.dll!Microsoft.NodejsTools.TestAdapter.TestContainerDiscoverer.OnProjectLoaded
> 	 391 25,575,424 Microsoft.NodejsTools.TestAdapter.dll!Microsoft.VisualStudioTools.SolutionEventsListener.OnAfterOpenProject
> 	  391 25,575,424 f:\dd\ndp\clr\src\vm\comtoclrcall.cpp(874) : clr.dll!COMToCLRWorker + 1018 bytes
> 	   391 25,575,424 !0x01A5D060 SymErr = 0x7e
> 		354 23,150,592 f:\dd\src\env\msenv\core\vsslnpst.cpp(18737) : msenv.dll!CSolution::FireOnAfterOpenProject + 68 bytes
> 		37 2,424,832 f:\dd\src\env\msenv\core\vsslnpst.cpp(18091) : msenv.dll!CSolution::NotifySolutionEventsSinks<<lambda_f249d9ee35e9fc74cd77e99afb337efd> > + 95 bytes
> 
> Memspect Snapshot: \\visia-d15p4\share\openclosesln\3
> 
