### PR TITLE
Fixed escaping for @types in .vstemplate files

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.vstemplate
@@ -16,7 +16,7 @@
   <TemplateContent>
     <Project File="TypeScriptExpressApp.njsproj" ReplaceParameters="true">
       <Folder Name="node_modules">
-        <Folder Name="@types">
+        <Folder Name="%40types">
           <Folder Name="node">
             <ProjectItem TargetFileName="package.json">node.package.json</ProjectItem>
             <ProjectItem TargetFileName="LICENSE">node.LICENSE</ProjectItem>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.vstemplate
@@ -17,7 +17,7 @@
   <TemplateContent>
     <Project File="TypeScriptWebApp.njsproj" ReplaceParameters="true">
       <Folder Name="node_modules">
-        <Folder Name="@types">
+        <Folder Name="%40types">
           <Folder Name="node">
             <ProjectItem TargetFileName="package.json">node.package.json</ProjectItem>
             <ProjectItem TargetFileName="LICENSE">node.LICENSE</ProjectItem>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.vstemplate
@@ -16,7 +16,7 @@
   <TemplateContent>
     <Project File="NodejsConsoleApp.njsproj" ReplaceParameters="true">
       <Folder Name="node_modules">
-        <Folder Name="@types">
+        <Folder Name="%40types">
           <Folder Name="node">
             <ProjectItem TargetFileName="package.json">node.package.json</ProjectItem>
             <ProjectItem TargetFileName="LICENSE">node.LICENSE</ProjectItem>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.vstemplate
@@ -33,7 +33,7 @@
         <ProjectItem>error.pug</ProjectItem>
       </Folder>
       <Folder Name="node_modules">
-        <Folder Name="@types">
+        <Folder Name="%40types">
           <Folder Name="node">
             <ProjectItem TargetFileName="package.json">node.package.json</ProjectItem>
             <ProjectItem TargetFileName="LICENSE">node.LICENSE</ProjectItem>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.vstemplate
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.vstemplate
@@ -21,7 +21,7 @@
       <ProjectItem ReplaceParameters="true">README.md</ProjectItem>
       <ProjectItem>tsconfig.json</ProjectItem>
       <Folder Name="node_modules">
-        <Folder Name="@types">
+        <Folder Name="%40types">
           <Folder Name="node">
             <ProjectItem TargetFileName="package.json">node.package.json</ProjectItem>
             <ProjectItem TargetFileName="LICENSE">node.LICENSE</ProjectItem>


### PR DESCRIPTION
Certain symbols need to be escaped in the template and project files. `@` is one of them.