### PR TITLE
Scoped packages

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.IO;
@@ -25,6 +25,7 @@ namespace Microsoft.NodejsTools
         internal const string ProjectFileFilter = "Node.js Project File (*.njsproj)\n*.njsproj\nAll Files (*.*)\n*.*\n";
 
         internal const string NodeModulesFolder = "node_modules";
+        internal const string NodeModulesFolderWithSeparators = "\\" + NodeModulesFolder + "\\";
         internal const string NodeModulesStagingFolder = "node_modules\\.staging\\";
         internal const string BowerComponentsFolder = "bower_components";
 

--- a/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;
@@ -106,7 +106,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
             TelemetryHelper.LogSearchNpm();
 
-            var relativeUri = string.Format("/-/v1/search?text=\"{0}\"", WebUtility.UrlEncode(filterText));
+            var relativeUri = $"/-/v1/search?text={WebUtility.UrlEncode(filterText)}";
             var searchUri = new Uri(defaultRegistryUri, relativeUri);
 
             var request = WebRequest.Create(searchUri);

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -12,11 +13,11 @@ namespace Microsoft.NodejsTools.Npm.SPI
     internal class RootPackage : IRootPackage
     {
         public RootPackage(
-             string fullPathToRootDirectory,
-             bool showMissingDevOptionalSubPackages,
-             Dictionary<string, ModuleInfo> allModules = null,
-             int depth = 0,
-             int maxDepth = 1)
+            string fullPathToRootDirectory,
+            bool showMissingDevOptionalSubPackages,
+            Dictionary<string, ModuleInfo> allModules = null,
+            int depth = 0,
+            int maxDepth = 1)
         {
             this.Path = fullPathToRootDirectory;
             var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
@@ -57,10 +58,13 @@ The following error was reported:
             {
                 // this is the root package so the full folder name after node_nodules is the name
                 // of the package
-                var index = this.Path.IndexOf(NodejsConstants.NodeModulesFolder, StringComparison.OrdinalIgnoreCase);
-                var name = this.Path.Substring(index + NodejsConstants.NodeModulesFolder.Length);
+                var index = this.Path.IndexOf(NodejsConstants.NodeModulesFolderWithSeparators, StringComparison.OrdinalIgnoreCase);
 
-                this.Name = name.TrimStart('\\', '/');
+                Debug.Assert(index > -1, "Failed to find the node_modules folder.");
+
+                var name = this.Path.Substring(index + NodejsConstants.NodeModulesFolderWithSeparators.Length);
+
+                this.Name = name;
             }
         }
 

--- a/Nodejs/Product/Npm/SPI/RootPackage.cs
+++ b/Nodejs/Product/Npm/SPI/RootPackage.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -11,11 +12,11 @@ namespace Microsoft.NodejsTools.Npm.SPI
     internal class RootPackage : IRootPackage
     {
         public RootPackage(
-            string fullPathToRootDirectory,
-            bool showMissingDevOptionalSubPackages,
-            Dictionary<string, ModuleInfo> allModules = null,
-            int depth = 0,
-            int maxDepth = 1)
+             string fullPathToRootDirectory,
+             bool showMissingDevOptionalSubPackages,
+             Dictionary<string, ModuleInfo> allModules = null,
+             int depth = 0,
+             int maxDepth = 1)
         {
             this.Path = fullPathToRootDirectory;
             var packageJsonFile = System.IO.Path.Combine(fullPathToRootDirectory, "package.json");
@@ -47,6 +48,20 @@ The following error was reported:
             {
                 // otherwise we fail to create it completely...
             }
+
+            if (this.PackageJson != null)
+            {
+                this.Name = this.PackageJson.Name;
+            }
+            else
+            {
+                // this is the root package so the full folder name after node_nodules is the name
+                // of the package
+                var index = this.Path.IndexOf(NodejsConstants.NodeModulesFolder, StringComparison.OrdinalIgnoreCase);
+                var name = this.Path.Substring(index + NodejsConstants.NodeModulesFolder.Length);
+
+                this.Name = name.TrimStart('\\', '/');
+            }
         }
 
         public IPackageJson PackageJson { get; }
@@ -55,13 +70,13 @@ The following error was reported:
 
         public string Path { get; }
 
+        public string Name { get; }
+
         public IEnumerable<string> Homepages => this.PackageJson?.Homepages ?? Enumerable.Empty<string>();
 
         public bool HasPackageJson => this.PackageJson != null;
 
-        public string Name => this.PackageJson?.Name ?? new DirectoryInfo(this.Path).Name;
-
-        public SemverVersion Version => this.PackageJson?.Version ?? new SemverVersion();
+        public SemverVersion Version => this.PackageJson?.Version ?? SemverVersion.UnknownVersion;
 
         public IPerson Author => this.PackageJson?.Author;
 


### PR DESCRIPTION
* No longer Quote Search queries, this fixes the issue where scoped packages couldn't be installed using the UI
* Use the /<packagename>/latest endpoint for single letter queries
* Correctly infer the name for packages not yet installed, this only affects scoped packages

This fixes at least: 

#1341, #1340, #1339, #635