### PR TITLE
Prop page update

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -118,7 +118,7 @@
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Debugger.InteropA, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Designer.Interfaces, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Editor, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -1185,6 +1185,9 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.AppDesigner">
+      <Version>15.3.0-rc-6162104</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">
       <Version>15.3.799-masterDDDBA9E4</Version>

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Microsoft.VisualStudioTools;
 using Microsoft.VisualStudioTools.Project;
 
@@ -10,14 +11,21 @@ namespace Microsoft.NodejsTools.Project
     [Guid("62E8E091-6914-498E-A47B-6F198DC1873D")]
     internal class NodejsGeneralPropertyPage : CommonPropertyPage
     {
-        private readonly NodejsGeneralPropertyPageControl _control;
+        private readonly NodejsGeneralPropertyPageControl control;
 
         public NodejsGeneralPropertyPage()
         {
-            this._control = new NodejsGeneralPropertyPageControl(this);
+            this.control = new NodejsGeneralPropertyPageControl(this);
         }
 
-        public override System.Windows.Forms.Control Control => this._control;
+        protected override Control CreateControl()
+        {
+            return this.control;
+        }
+
+        public override Control Control => this.control;
+
+        protected override Type ControlType => typeof(NodejsGeneralPropertyPageControl);
 
         internal override CommonProjectNode Project
         {
@@ -38,49 +46,42 @@ namespace Microsoft.NodejsTools.Project
                 }
             }
         }
-        public override void Apply()
+
+        protected override void Apply()
         {
-            this.Project.SetProjectProperty(NodeProjectProperty.NodeExePath, this._control.NodeExePath);
-            this.Project.SetProjectProperty(NodeProjectProperty.NodeExeArguments, this._control.NodeExeArguments);
-            this.Project.SetProjectProperty(CommonConstants.StartupFile, this._control.ScriptFile);
-            this.Project.SetProjectProperty(NodeProjectProperty.ScriptArguments, this._control.ScriptArguments);
-            this.Project.SetProjectProperty(NodeProjectProperty.NodejsPort, this._control.NodejsPort);
-            this.Project.SetProjectProperty(NodeProjectProperty.StartWebBrowser, this._control.StartWebBrowser.ToString());
-            this.Project.SetProjectProperty(CommonConstants.WorkingDirectory, this._control.WorkingDirectory);
-            this.Project.SetProjectProperty(NodeProjectProperty.LaunchUrl, this._control.LaunchUrl);
-            this.Project.SetProjectProperty(NodeProjectProperty.DebuggerPort, this._control.DebuggerPort);
-            this.Project.SetProjectProperty(NodeProjectProperty.Environment, this._control.Environment);
-            this.IsDirty = false;
+            this.Project.SetProjectProperty(NodeProjectProperty.NodeExePath, this.control.NodeExePath);
+            this.Project.SetProjectProperty(NodeProjectProperty.NodeExeArguments, this.control.NodeExeArguments);
+            this.Project.SetProjectProperty(CommonConstants.StartupFile, this.control.ScriptFile);
+            this.Project.SetProjectProperty(NodeProjectProperty.ScriptArguments, this.control.ScriptArguments);
+            this.Project.SetProjectProperty(NodeProjectProperty.NodejsPort, this.control.NodejsPort);
+            this.Project.SetProjectProperty(NodeProjectProperty.StartWebBrowser, this.control.StartWebBrowser.ToString());
+            this.Project.SetProjectProperty(CommonConstants.WorkingDirectory, this.control.WorkingDirectory);
+            this.Project.SetProjectProperty(NodeProjectProperty.LaunchUrl, this.control.LaunchUrl);
+            this.Project.SetProjectProperty(NodeProjectProperty.DebuggerPort, this.control.DebuggerPort);
+            this.Project.SetProjectProperty(NodeProjectProperty.Environment, this.control.Environment);
+            this.control.IsDirty = false;
         }
 
         public override void LoadSettings()
         {
-            this.Loading = true;
-            try
-            {
-                this._control.NodeExeArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExeArguments);
-                this._control.NodeExePath = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExePath);
-                this._control.ScriptFile = this.Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
-                this._control.ScriptArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.ScriptArguments);
-                this._control.WorkingDirectory = this.Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
-                this._control.LaunchUrl = this.Project.GetUnevaluatedProperty(NodeProjectProperty.LaunchUrl);
-                this._control.NodejsPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodejsPort);
-                this._control.DebuggerPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.DebuggerPort);
-                this._control.Environment = this.Project.GetUnevaluatedProperty(NodeProjectProperty.Environment);
+            this.control.NodeExeArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExeArguments);
+            this.control.NodeExePath = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExePath);
+            this.control.ScriptFile = this.Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
+            this.control.ScriptArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.ScriptArguments);
+            this.control.WorkingDirectory = this.Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
+            this.control.LaunchUrl = this.Project.GetUnevaluatedProperty(NodeProjectProperty.LaunchUrl);
+            this.control.NodejsPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodejsPort);
+            this.control.DebuggerPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.DebuggerPort);
+            this.control.Environment = this.Project.GetUnevaluatedProperty(NodeProjectProperty.Environment);
 
-                // Attempt to parse the boolean.  If we fail, assume it is true.
-                if (!Boolean.TryParse(this.Project.GetUnevaluatedProperty(NodeProjectProperty.StartWebBrowser), out var startWebBrowser))
-                {
-                    startWebBrowser = true;
-                }
-                this._control.StartWebBrowser = startWebBrowser;
-            }
-            finally
+            // Attempt to parse the boolean.  If we fail, assume it is true.
+            if (!bool.TryParse(this.Project.GetUnevaluatedProperty(NodeProjectProperty.StartWebBrowser), out var startWebBrowser))
             {
-                this.Loading = false;
+                startWebBrowser = true;
             }
+            this.control.StartWebBrowser = startWebBrowser;
         }
 
-        public override string Name => "General";
+        protected override string Title => "General";
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -6,11 +6,12 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Microsoft.VisualStudio.Editors.PropertyPages;
 using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Project
 {
-    internal partial class NodejsGeneralPropertyPageControl : UserControl
+    internal partial class NodejsGeneralPropertyPageControl : PropPageUserControlBase
     {
         private readonly NodejsGeneralPropertyPage _propPage;
         private const string _exeFilter = "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*";
@@ -65,6 +66,10 @@ namespace Microsoft.NodejsTools.Project
             this._tooltip.SetToolTip(this._debuggerPort, Resources.DebuggerPort);
             this._tooltip.SetToolTip(this._envVars, Resources.EnvironmentVariables);
         }
+
+        protected override bool DisableOnBuild => false;
+
+        protected override bool DisableOnDebug => false;
 
         public string NodeExePath
         {
@@ -192,7 +197,7 @@ namespace Microsoft.NodejsTools.Project
 
         private void Changed(object sender, EventArgs e)
         {
-            this._propPage.IsDirty = true;
+            this.IsDirty = true;
         }
 
         private void SetCueBanner()

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Project
 {
-    internal partial class NodejsGeneralPropertyPageControl : PropPageUserControlBase
+    internal sealed partial class NodejsGeneralPropertyPageControl : PropPageUserControlBase
     {
         private readonly NodejsGeneralPropertyPage _propPage;
         private const string _exeFilter = "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*";

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NodejsTools.Project
             this._startBrowser.Text = Resources.PropertiesStartBrowser;
 
             this._browsePath.AccessibleName = Resources.PropertiesBrowsePathAccessibleName;
-            this._browsePath.AccessibleName = Resources.PropertiesBrowseDirectoryAccessibleName;
+            this._browseDirectory.AccessibleName = Resources.PropertiesBrowseDirectoryAccessibleName;
         }
 
         private void AddToolTips()

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -396,7 +396,7 @@ namespace Microsoft.NodejsTools.Project
                     default:
                         if (propPage != null)
                         {
-                            this.PropertyPage.IsDirty = true;
+                            propPage.IsDirty = true;
                         }
                         break;
                 }

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
@@ -21,36 +21,24 @@ namespace Microsoft.VisualStudioTools.Project
 
         internal virtual CommonProjectNode Project { get; set; }
 
-        protected override void SetObjects(uint count, object[] punk)
+        protected override void SetObjects(uint count, object[] objects)
         {
-            if (punk == null)
+            if (objects == null)
             {
                 return;
             }
 
             if (count > 0)
             {
-                if (punk[0] is ProjectConfig)
+                if (this.Project == null)
                 {
-                    if (this.Project == null)
+                    if (objects[0] is CommonProjectConfig projectConfig)
                     {
-                        this.Project = (CommonProjectNode)((CommonProjectConfig)punk.First()).ProjectMgr;
+                        this.Project = (CommonProjectNode)projectConfig.ProjectMgr;
                     }
-
-                    var configs = new List<CommonProjectConfig>();
-
-                    for (var i = 0; i < count; i++)
+                    else if (objects[0] is NodeProperties properties)
                     {
-                        var config = (CommonProjectConfig)punk[i];
-
-                        configs.Add(config);
-                    }
-                }
-                else if (punk[0] is NodeProperties)
-                {
-                    if (this.Project == null)
-                    {
-                        this.Project = (CommonProjectNode)(punk[0] as NodeProperties).HierarchyNode.ProjectMgr;
+                        this.Project = (CommonProjectNode)(properties).HierarchyNode.ProjectMgr;
                     }
                 }
             }

--- a/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.Editors.PropertyPages;
 
 namespace Microsoft.VisualStudioTools.Project
@@ -16,213 +13,13 @@ namespace Microsoft.VisualStudioTools.Project
     /// </summary>
     public abstract class CommonPropertyPage : PropPageBase
     {
-        private CommonProjectNode _project;
-
         protected override Size DefaultSize { get; set; } = new Size(800, 600);
 
         public abstract void LoadSettings();
 
         public abstract Control Control { get; }
 
-        internal virtual CommonProjectNode Project
-        {
-            get
-            {
-                return this._project;
-            }
-            set
-            {
-                this._project = value;
-            }
-        }
-
-        internal virtual IEnumerable<CommonProjectConfig> SelectedConfigs
-        {
-            get; set;
-        }
-
-        protected void SetProjectProperty(string propertyName, string propertyValue)
-        {
-            // SetProjectProperty's implementation will check whether the value
-            // has changed.
-            this.Project.SetProjectProperty(propertyName, propertyValue);
-        }
-
-        protected string GetProjectProperty(string propertyName)
-        {
-            return this.Project.GetUnevaluatedProperty(propertyName);
-        }
-
-        protected void SetUserProjectProperty(string propertyName, string propertyValue)
-        {
-            // SetUserProjectProperty's implementation will check whether the value
-            // has changed.
-            this.Project.SetUserProjectProperty(propertyName, propertyValue);
-        }
-
-        protected string GetUserProjectProperty(string propertyName)
-        {
-            return this.Project.GetUserProjectProperty(propertyName);
-        }
-
-        protected string GetConfigUserProjectProperty(string propertyName)
-        {
-            if (this.SelectedConfigs == null)
-            {
-                var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                    ConfigProvider.configPlatformString,
-                    this.Project.CurrentConfig.GetPropertyValue("Configuration"),
-                    this.Project.CurrentConfig.GetPropertyValue("Platform"));
-
-                return GetUserPropertyUnderCondition(propertyName, condition);
-            }
-            else
-            {
-                var values = new StringCollection();
-
-                foreach (var config in this.SelectedConfigs)
-                {
-                    var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        ConfigProvider.configPlatformString,
-                        config.ConfigName,
-                        config.PlatformName);
-
-                    values.Add(GetUserPropertyUnderCondition(propertyName, condition));
-                }
-
-                switch (values.Count)
-                {
-                    case 0:
-                        return null;
-                    case 1:
-                        return values[0];
-                    default:
-                        return "<different values>";
-                }
-            }
-        }
-
-        protected void SetConfigUserProjectProperty(string propertyName, string propertyValue)
-        {
-            if (this.SelectedConfigs == null)
-            {
-                var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                    ConfigProvider.configPlatformString,
-                    this.Project.CurrentConfig.GetPropertyValue("Configuration"),
-                    this.Project.CurrentConfig.GetPropertyValue("Platform"));
-
-                SetUserPropertyUnderCondition(propertyName, propertyValue, condition);
-            }
-            else
-            {
-                foreach (var config in this.SelectedConfigs)
-                {
-                    var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        ConfigProvider.configPlatformString,
-                        config.ConfigName,
-                        config.GetConfigurationProperty("Platform", false));
-
-                    SetUserPropertyUnderCondition(propertyName, propertyValue, condition);
-                }
-            }
-        }
-
-        private string GetUserPropertyUnderCondition(string propertyName, string condition)
-        {
-            var conditionTrimmed = (condition == null) ? string.Empty : condition.Trim();
-
-            if (this.Project.UserBuildProject != null)
-            {
-                if (conditionTrimmed.Length == 0)
-                {
-                    return this.Project.UserBuildProject.GetProperty(propertyName).UnevaluatedValue;
-                }
-
-                // New OM doesn't have a convenient equivalent for setting a property with a particular property group condition. 
-                // So do it ourselves.
-                ProjectPropertyGroupElement matchingGroup = null;
-
-                foreach (var group in this.Project.UserBuildProject.Xml.PropertyGroups)
-                {
-                    if (StringComparer.OrdinalIgnoreCase.Equals(group.Condition.Trim(), conditionTrimmed))
-                    {
-                        matchingGroup = group;
-                        break;
-                    }
-                }
-
-                if (matchingGroup != null)
-                {
-                    foreach (var property in matchingGroup.PropertiesReversed) // If there's dupes, pick the last one so we win
-                    {
-                        if (StringComparer.OrdinalIgnoreCase.Equals(property.Name, propertyName)
-                            && (property.Condition == null || property.Condition.Length == 0))
-                        {
-                            return property.Value;
-                        }
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Emulates the behavior of SetProperty(name, value, condition) on the old MSBuild object model.
-        /// This finds a property group with the specified condition (or creates one if necessary) then sets the property in there.
-        /// </summary>
-        private void SetUserPropertyUnderCondition(string propertyName, string propertyValue, string condition)
-        {
-            var conditionTrimmed = (condition == null) ? string.Empty : condition.Trim();
-            const string userProjectCreateProperty = "UserProject";
-
-            if (this.Project.UserBuildProject == null)
-            {
-                this.Project.SetUserProjectProperty(userProjectCreateProperty, null);
-            }
-
-            if (conditionTrimmed.Length == 0)
-            {
-                var userProp = this.Project.UserBuildProject.GetProperty(userProjectCreateProperty);
-                if (userProp != null)
-                {
-                    this.Project.UserBuildProject.RemoveProperty(userProp);
-                }
-                this.Project.UserBuildProject.SetProperty(propertyName, propertyValue);
-                return;
-            }
-
-            // New OM doesn't have a convenient equivalent for setting a property with a particular property group condition. 
-            // So do it ourselves.
-            ProjectPropertyGroupElement newGroup = null;
-
-            foreach (var group in this.Project.UserBuildProject.Xml.PropertyGroups)
-            {
-                if (StringComparer.OrdinalIgnoreCase.Equals(group.Condition.Trim(), conditionTrimmed))
-                {
-                    newGroup = group;
-                    break;
-                }
-            }
-
-            if (newGroup == null)
-            {
-                newGroup = this.Project.UserBuildProject.Xml.AddPropertyGroup(); // Adds after last existing PG, else at start of project
-                newGroup.Condition = condition;
-            }
-
-            foreach (var property in newGroup.PropertiesReversed) // If there's dupes, pick the last one so we win
-            {
-                if (StringComparer.OrdinalIgnoreCase.Equals(property.Name, propertyName)
-                    && (property.Condition == null || property.Condition.Length == 0))
-                {
-                    property.Value = propertyValue;
-                    return;
-                }
-            }
-
-            newGroup.AddProperty(propertyName, propertyValue);
-        }
+        internal virtual CommonProjectNode Project { get; set; }
 
         protected override void SetObjects(uint count, object[] punk)
         {
@@ -235,9 +32,9 @@ namespace Microsoft.VisualStudioTools.Project
             {
                 if (punk[0] is ProjectConfig)
                 {
-                    if (this._project == null)
+                    if (this.Project == null)
                     {
-                        this._project = (CommonProjectNode)((CommonProjectConfig)punk.First()).ProjectMgr;
+                        this.Project = (CommonProjectNode)((CommonProjectConfig)punk.First()).ProjectMgr;
                     }
 
                     var configs = new List<CommonProjectConfig>();
@@ -248,12 +45,10 @@ namespace Microsoft.VisualStudioTools.Project
 
                         configs.Add(config);
                     }
-
-                    this.SelectedConfigs = configs;
                 }
                 else if (punk[0] is NodeProperties)
                 {
-                    if (this._project == null)
+                    if (this.Project == null)
                     {
                         this.Project = (CommonProjectNode)(punk[0] as NodeProperties).HierarchyNode.ProjectMgr;
                     }
@@ -264,7 +59,7 @@ namespace Microsoft.VisualStudioTools.Project
                 this.Project = null;
             }
 
-            if (this._project != null)
+            if (this.Project != null)
             {
                 LoadSettings();
             }


### PR DESCRIPTION
Prepare property pages to make theming easier for a future Visual Studio update.

Because we now derive from a baseclass I could delete a lot of code, which we previously copied from that baseclass.