### PR TITLE
Add test window location to assembly resolver

### DIFF
--- a/Nodejs/Product/TestAdapterShim/AssemblyResolver.cs
+++ b/Nodejs/Product/TestAdapterShim/AssemblyResolver.cs
@@ -36,6 +36,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 Path.Combine(ideFolder, "PrivateAssemblies"),
                 Path.Combine(ideFolder, "PublicAssemblies"),
                 Path.Combine(installPath, "MSBuild","15.0","Bin"),
+                Path.Combine(ideFolder, "CommonExtensions","Microsoft","TestWindow"),
                 Path.Combine(ideFolder, "CommonExtensions","Microsoft","WebClient","Project System") };
 
             // This is what comes in for args.Name, but we really just want the dll file name:


### PR DESCRIPTION
The adapters are loaded in an out-of-process component for test run. The host process may not
be in the same location as Test Window (e.g. in the newer test platform, this ships in `Common7\IDE\Extensions\TestPlatform` since it is built as an external component). Adding test window location explicitly so that `Microsoft.VisualStudio.TestWindow.Interfaces` assembly can be resolved appropriately.

Please let me know if I need to create an issue for this.

##### Bug
See description above.

##### Fix
Explicitly add TestWindow location for assembly resolution.

##### Testing
Validated sample mocha test project from test explorer.