### PR TITLE
Add time out when starting browser

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -421,7 +421,7 @@ namespace Microsoft.NodejsTools.Project
                 var uri = new Uri(webBrowserUrl);
                 OnPortOpenedHandler.CreateHandler(
                     uri.Port,
-                    shortCircuitPredicate: () => false,
+                    timeout: 5_000, // 5 seconds
                     action: () =>
                     {
                         VsShellUtilities.OpenBrowser(webBrowserUrl, (uint)__VSOSPFLAGS.OSP_LaunchNewBrowser);


### PR DESCRIPTION
Add a time out when starting browser while debugging, if we can't figure
out the process id of the node process we've started.

Fixes #1711
