### PR TITLE
Put the progressbar back in the Npm UI

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -233,11 +233,9 @@ namespace Microsoft.NodejsTools.NpmUI
 
             if (filtered.Any())
             {
-                var rootPackage = this.npmController?.RootPackage;
-
                 newItems.AddRange(filtered.Select(package => new ReadOnlyPackageCatalogEntryViewModel(
                     package,
-                    rootPackage?.Modules[package.Name])));
+                    this.npmController?.RootPackage?.Modules[package.Name])));
             }
 
             await this.dispatcher.BeginInvoke((Action)(() =>
@@ -375,10 +373,13 @@ namespace Microsoft.NodejsTools.NpmUI
             }
             set
             {
-                this.isExecutingCommand = value;
+                if (this.isExecutingCommand != value)
+                {
+                    this.isExecutingCommand = value;
 
-                OnPropertyChanged();
-                OnPropertyChanged("ExecutionProgressVisibility");
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(ExecutionProgressVisibility));
+                }
             }
         }
 
@@ -403,18 +404,18 @@ namespace Microsoft.NodejsTools.NpmUI
                 if (disposing)
                 {
                     this.filterTimer?.Dispose();
-                }
 
-                var controller = this.npmController;
-                if (controller != null)
-                {
-                    this.npmController.FinishedRefresh -= this.NpmController_FinishedRefresh;
-                }
-                var worker = this.npmWorker;
-                if (worker != null)
-                {
-                    this.npmWorker.CommandStarted -= this.NpmWorker_CommandStarted;
-                    this.npmWorker.CommandCompleted -= this.NpmWorker_CommandCompleted;
+                    var controller = this.npmController;
+                    if (controller != null)
+                    {
+                        controller.FinishedRefresh -= this.NpmController_FinishedRefresh;
+                    }
+                    var worker = this.npmWorker;
+                    if (worker != null)
+                    {
+                        worker.CommandStarted -= this.NpmWorker_CommandStarted;
+                        worker.CommandCompleted -= this.NpmWorker_CommandCompleted;
+                    }
                 }
                 disposed = true;
             }

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -1,11 +1,11 @@
-﻿<vsui1:DialogWindow
+﻿<vsui:DialogWindow
     x:Class="Microsoft.NodejsTools.NpmUI.NpmPackageInstallWindow"
     x:ClassModifier="public"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:npmUi="clr-namespace:Microsoft.NodejsTools.NpmUI"
     xmlns:ui="clr-namespace:Microsoft.VisualStudioTools"
-    xmlns:vsui1="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
     xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
     xmlns:resx="clr-namespace:Microsoft.NodejsTools.NpmUI"
@@ -233,7 +233,10 @@
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-
+            <ProgressBar Name="_progress"
+                             Height="4"
+                             IsIndeterminate="true"
+                             Visibility="{Binding Path=ExecutionProgressVisibility}" Grid.Row="1" Grid.ColumnSpan="2"/>
             <Button x:Name="CloseButton"
                         Grid.Column="1"
                         Command="ApplicationCommands.Close"
@@ -435,4 +438,4 @@
         </Grid>
     </Grid>
 
-</vsui1:DialogWindow>
+</vsui:DialogWindow>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
         public void Dispose()
         {
-            this.viewModel.NpmController = null;
+            this.viewModel.Dispose();
 
             // The catalog refresh operation spawns many long-lived Gen 2 objects,
             // so the garbage collector will take a while to get to them otherwise.


### PR DESCRIPTION
Add the progress bar back when installing npm packages from the npm UI.

This fixes:

https://developercommunity.visualstudio.com/content/problem/154181/no-visual-feedback-when-installing-npm-package.html