### PR TITLE
Perf issues on project load and external file changes

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -326,7 +326,12 @@ namespace Microsoft.NodejsTools.Project
 
                 base.Reload();
 
-                SyncFileSystem();
+                if (this.IsShowingAllFiles)
+                {
+                    // We only need to sync the files on load if we're actually showing them
+                    // otherwise we'll sync on idle.
+                    this.SyncFileSystem();
+                }
 
                 this.ModulesNode.ReloadHierarchySafe();
             }

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.FileSystemChange.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.FileSystemChange.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudioTools.Project
                         {
                             if (child != null)
                             {
-                                // attributes must of changed to hidden, remove the file
+                                // attributes must have changed to hidden, remove the file
                                 ChildDeleted(child);
                             }
                         }
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudioTools.Project
                         {
                             if (child == null)
                             {
-                                // attributes must of changed from hidden, add the file
+                                // attributes must have changed from hidden, add the file
                                 ChildCreated(child);
                             }
                         }

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -437,7 +437,8 @@ namespace Microsoft.VisualStudioTools.Project
             {
                 InternalBufferSize = 1024 * 4,  // 4k is minimum buffer size
                 IncludeSubdirectories = true
-                /* don't need to set NotifyFilters, since default LastWrite, FileName, and DirectoryName works for us */
+                // don't need to set NotifyFilters, 
+                // since the default (LastWrite, FileName, and DirectoryName) works for us
             };
 
             // Set Event Handlers

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -44,7 +44,6 @@ namespace Microsoft.VisualStudioTools.Project
         private int suppressFileWatcherCount;
         private bool isShowingAllFiles;
         private object automationObject;
-        private readonly Dictionary<string, FileSystemEventHandler> fileChangedHandlers = new Dictionary<string, FileSystemEventHandler>();
         private ConcurrentQueue<FileSystemChange> fileSystemChanges = new ConcurrentQueue<FileSystemChange>();
 
         private readonly Dictionary<string, FileSystemWatcher> symlinkWatchers = new Dictionary<string, FileSystemWatcher>();
@@ -438,13 +437,12 @@ namespace Microsoft.VisualStudioTools.Project
             {
                 InternalBufferSize = 1024 * 4,  // 4k is minimum buffer size
                 IncludeSubdirectories = true
+                /* don't need to set NotifyFilters, since default LastWrite, FileName, and DirectoryName works for us */
             };
 
             // Set Event Handlers
             watcher.Created += this.FileExistanceChanged;
             watcher.Deleted += this.FileExistanceChanged;
-            watcher.Changed += this.FileContentsChanged;
-            watcher.Renamed += this.FileContentsChanged;
             watcher.Renamed += this.FileNameChanged;
             watcher.Error += this.WatcherError;
 
@@ -783,19 +781,6 @@ namespace Microsoft.VisualStudioTools.Project
             parent.AddChild(newNode);
         }
 
-        private void FileContentsChanged(object sender, FileSystemEventArgs e)
-        {
-            if (this.IsClosed)
-            {
-                return;
-            }
-
-            if (this.fileChangedHandlers.TryGetValue(e.FullPath, out var handler))
-            {
-                handler(sender, e);
-            }
-        }
-
         private void FileAttributesChanged(object sender, FileSystemEventArgs e)
         {
             if (NoPendingFileSystemRescan())
@@ -808,16 +793,6 @@ namespace Microsoft.VisualStudioTools.Project
         private bool NoPendingFileSystemRescan()
         {
             return !this.fileSystemChanges.TryPeek(out var change) || change.Type != WatcherChangeTypes.All;
-        }
-
-        internal void RegisterFileChangeNotification(FileNode node, FileSystemEventHandler handler)
-        {
-            this.fileChangedHandlers[node.Url] = handler;
-        }
-
-        internal void UnregisterFileChangeNotification(FileNode node)
-        {
-            this.fileChangedHandlers.Remove(node.Url);
         }
 
         protected override ReferenceContainerNode CreateReferenceContainerNode()
@@ -1004,8 +979,6 @@ namespace Microsoft.VisualStudioTools.Project
                 this.attributesWatcher.Dispose();
                 this.attributesWatcher = null;
             }
-
-            this.fileChangedHandlers.Clear();
 
             foreach (var pair in this.symlinkWatchers)
             {


### PR DESCRIPTION
These changes make loading projects significantly faster, when the user has opted out of 'Show All Files' (the default).

And no longer listening for filechanges reduces the number of full project cone scans, to sync the Solution Explorer with the Disk. (because we will hit the FileSystemWatcher error case a lot less often)

This improves #1128, #1506, and #1606 