### PR TITLE
Move the enumeration of the files on disk to the BG thread

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -22,7 +22,7 @@ using VsCommands = Microsoft.VisualStudio.VSConstants.VSStd97CmdID;
 
 namespace Microsoft.NodejsTools.Project
 {
-    internal class NodejsProjectNode : CommonProjectNode, VsWebSite.VSWebSite, INodePackageModulesCommands, IVsBuildPropertyStorage
+    internal sealed class NodejsProjectNode : CommonProjectNode, VsWebSite.VSWebSite, INodePackageModulesCommands, IVsBuildPropertyStorage
     {
         private readonly HashSet<string> _warningFiles = new HashSet<string>();
         private readonly HashSet<string> _errorFiles = new HashSet<string>();
@@ -317,7 +317,7 @@ namespace Microsoft.NodejsTools.Project
 
         protected override void Reload()
         {
-            using (new DebugTimer("Project Load"))
+            using (new DebugTimer("NodeJs Project Load"))
             {
                 // Populate values from project properties before we do anything else.
                 // Otherwise we run into race conditions where, for instance, _analysisIgnoredDirectories
@@ -330,7 +330,7 @@ namespace Microsoft.NodejsTools.Project
                 {
                     // We only need to sync the files on load if we're actually showing them
                     // otherwise we'll sync on idle.
-                    this.SyncFileSystem();
+                    this.WaitForSyncFileSystem();
                 }
 
                 this.ModulesNode.ReloadHierarchySafe();

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.FileSystemChange.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.FileSystemChange.cs
@@ -45,8 +45,10 @@ namespace Microsoft.VisualStudioTools.Project
                 var child = this.project.FindNodeByFullPath(this.path);
                 if ((this.Type == WatcherChangeTypes.Deleted || this.Type == WatcherChangeTypes.Changed) && child == null)
                 {
+                    // see if it's a folder, which we store with a directory separator
                     child = this.project.FindNodeByFullPath(this.path + Path.DirectorySeparatorChar);
                 }
+
                 switch (this.Type)
                 {
                     case WatcherChangeTypes.Deleted:

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -53,6 +53,7 @@ namespace Microsoft.VisualStudioTools.Project
         private IVsHierarchyItemManager hierarchyManager;
         private Dictionary<uint, bool> needBolding;
         private int idleTriggered;
+        private bool isDisposed;
 
         public CommonProjectNode(IServiceProvider serviceProvider, ImageList imageList)
             : base(serviceProvider)
@@ -421,6 +422,11 @@ namespace Microsoft.VisualStudioTools.Project
 
         private void BoldStartupItem()
         {
+            if (this.isDisposed)
+            {
+                return;
+            }
+
             var startupPath = GetStartupFile();
             if (!string.IsNullOrEmpty(startupPath))
             {
@@ -509,6 +515,11 @@ namespace Microsoft.VisualStudioTools.Project
 
         protected override void Dispose(bool disposing)
         {
+            if (this.isDisposed)
+            {
+                return;
+            }
+
             if (disposing)
             {
                 this.HierarchyManager = null;
@@ -534,6 +545,7 @@ namespace Microsoft.VisualStudioTools.Project
                 {
                     this.diskMerger.Dispose();
                 }
+                this.isDisposed = true;
             }
 
             base.Dispose(disposing);

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.IOleCommandTarget.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.IOleCommandTarget.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudioTools.Project
                 {
                     case VsCommands2K.SHOWALLFILES:
                         handled = true;
-                        return this.ShowAllFiles();
+                        return this.ToggleShowAllFiles();
                     case VsCommands2K.ADDREFERENCE:
                         handled = true;
                         return this.AddProjectReference();

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -2419,7 +2419,7 @@ namespace Microsoft.VisualStudioTools.Project
         /// Handles the shows all objects command.
         /// </summary>
         /// <returns></returns>
-        protected internal virtual int ShowAllFiles()
+        protected internal virtual int ToggleShowAllFiles()
         {
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
@@ -6248,8 +6248,6 @@ If the files in the existing folder have the same names as files in the folder y
         /// </summary>
         internal HierarchyNode FindNodeByFullPath(string name)
         {
-            this.Site.GetUIThread().MustBeCalledFromUIThread();
-
             Debug.Assert(Path.IsPathRooted(name));
 
             this.DiskNodes.TryGetValue(name, out var node);


### PR DESCRIPTION
This change moves the enumeration of files to a BG thread. This way
we no longer block the UI thread when there's a large number of changes
when the user invokes a build/test outside of VS.
