### PR TITLE
Fix test case discovery in Jasmine

### DIFF
--- a/Nodejs/Product/TestAdapterImpl/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapterImpl/TestFrameworks/Jasmine/jasmine.js
@@ -92,7 +92,7 @@ function enumerateSpecs(suite, testList, testFile) {
             enumerateSpecs(child, testList, testFile);
         } else {
             testList.push({
-                test: child.getSpecName(child),
+                test: child.getFullName(),
                 suite: suite.description,
                 file: testFile,
                 line: 0,
@@ -114,9 +114,8 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
         return;
     }
     var jasmineInstance = initializeJasmine(Jasmine, projectFolder);
-    jasmineInstance.env.specFilter = (spec) => {
-        return false;
-    };
+    jasmineInstance.env.specFilter = _ => false;
+
     var testList = [];
     testFileList.split(";").forEach((testFile) => {
         try {


### PR DESCRIPTION
Instead of depending on specFilter, which is broken in 3.0,
we now enumerate the topSuite property, and it's children
to discover the test cases in Jasmine unit tests.
