### PR TITLE
Some guids used in the registry require '{' and '}'

### DIFF
--- a/Nodejs/Product/Nodejs/Guids.cs
+++ b/Nodejs/Product/Nodejs/Guids.cs
@@ -13,13 +13,11 @@ namespace Microsoft.NodejsTools
 
         public const string NodejsPackageString = "FE8A8C3D-328A-476D-99F9-2A24B75F8C7F";
         public const string NodejsCmdSetString = "695e37e2-c6df-4e0a-8833-f688e4c65f1f";
-        public const string NodejsDebugLanguageString = "65791609-BA29-49CF-A214-DBFF8AEC3BC2";
         public const string NodejsNpmCmdSetString = "9F4B31B4-09AC-4937-A2E7-F4BC02BB7DBA";
         public const string NodeToolsWorkspaceCmdSetString = "0D701F33-94A3-421C-9865-6F65E7E4B689";
         public const string NodejsProjectFactoryString = "3AF33F2E-1136-4D97-BBB7-1795711AC8B8";
         public const string NodejsBaseProjectFactoryString = "9092AA53-FB77-4645-B42D-1CCCA6BD08BD";
         public const string TypeScriptLanguageInfoString = "4a0dddb5-7a95-4fbf-97cc-616d07737a77";
-        public const string TypeScriptDebuggerLanguageInfoString = "87bdf188-e6e8-4fcf-a82a-9b8506e01847";
         public const string JadeEditorFactoryString = "6CB69EF8-1329-4DC0-84B4-FA134EA59BE3";
         public const string DefaultLanguageServiceString = "8239BEC4-EE87-11D0-8C98-00C04FC2AB22";
 
@@ -28,11 +26,14 @@ namespace Microsoft.NodejsTools
         //Guid for our formatting service
         internal const string JavaScriptFormattingServiceString = "F414C260-6AC0-11CF-B6D1-00AA00BBBB58";
 
-        public const string ScriptDebugLanguageString = "F7FA31DA-C32A-11D0-B442-00A0244A1DD2";
-
         // Debug guids
-        public const string DebugEngine = "FC5B45BA-5B9C-46EA-887A-82073AE065FE";
+        // However the debugger requires the '{' and '}'
+        public const string NodejsDebugLanguageString = "{65791609-BA29-49CF-A214-DBFF8AEC3BC2}";
+        public const string TypeScriptDebuggerLanguageInfoString = "{87bdf188-e6e8-4fcf-a82a-9b8506e01847}";
+        public const string ScriptDebugLanguageString = "{F7FA31DA-C32A-11D0-B442-00A0244A1DD2}";
+
         public const string DebugProgramProvider = "472CD331-218C-451E-929E-98C9408F11DD";
+        public const string DebugEngine = "FC5B45BA-5B9C-46EA-887A-82073AE065FE";
         public const string RemoteDebugPortSupplier = "A241707C-7DB3-464F-8D3E-F3D33E86AE99";
 
         public static readonly Guid NodejsBaseProjectFactory = new Guid(NodejsBaseProjectFactoryString);


### PR DESCRIPTION
Issue #

##### Bug


##### Fix


##### Testing
