### PR TITLE
Prevent crash when there is no pending breakpoint

### DIFF
--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/AD7Engine.cs
@@ -1292,17 +1292,20 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine
         private void OnBreakpointBound(object sender, BreakpointBindingEventArgs e)
         {
             var pendingBreakpoint = this._breakpointManager.GetPendingBreakpoint(e.Breakpoint);
-            var breakpointBinding = e.BreakpointBinding;
-            var codeContext = new AD7MemoryAddress(this, pendingBreakpoint.DocumentName, breakpointBinding.Target.Line, breakpointBinding.Target.Column);
-            var documentContext = new AD7DocumentContext(codeContext);
-            var breakpointResolution = new AD7BreakpointResolution(this, breakpointBinding, documentContext);
-            var boundBreakpoint = new AD7BoundBreakpoint(breakpointBinding, pendingBreakpoint, breakpointResolution, breakpointBinding.Enabled);
-            this._breakpointManager.AddBoundBreakpoint(breakpointBinding, boundBreakpoint);
-            Send(
-                new AD7BreakpointBoundEvent(pendingBreakpoint, boundBreakpoint),
-                AD7BreakpointBoundEvent.IID,
-                null
-            );
+            if (pendingBreakpoint != null)
+            {
+                var breakpointBinding = e.BreakpointBinding;
+                var codeContext = new AD7MemoryAddress(this, pendingBreakpoint.DocumentName, breakpointBinding.Target.Line, breakpointBinding.Target.Column);
+                var documentContext = new AD7DocumentContext(codeContext);
+                var breakpointResolution = new AD7BreakpointResolution(this, breakpointBinding, documentContext);
+                var boundBreakpoint = new AD7BoundBreakpoint(breakpointBinding, pendingBreakpoint, breakpointResolution, breakpointBinding.Enabled);
+                this._breakpointManager.AddBoundBreakpoint(breakpointBinding, boundBreakpoint);
+                Send(
+                    new AD7BreakpointBoundEvent(pendingBreakpoint, boundBreakpoint),
+                    AD7BreakpointBoundEvent.IID,
+                    null
+                );
+            }
         }
 
         private void OnBreakpointUnbound(object sender, BreakpointBindingEventArgs e)
@@ -1323,9 +1326,12 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine
         private void OnBreakpointBindFailure(object sender, BreakpointBindingEventArgs e)
         {
             var pendingBreakpoint = this._breakpointManager.GetPendingBreakpoint(e.Breakpoint);
-            var breakpointErrorEvent = new AD7BreakpointErrorEvent(pendingBreakpoint, this);
-            pendingBreakpoint.AddBreakpointError(breakpointErrorEvent);
-            Send(breakpointErrorEvent, AD7BreakpointErrorEvent.IID, null);
+            if (pendingBreakpoint != null)
+            {
+                var breakpointErrorEvent = new AD7BreakpointErrorEvent(pendingBreakpoint, this);
+                pendingBreakpoint.AddBreakpointError(breakpointErrorEvent);
+                Send(breakpointErrorEvent, AD7BreakpointErrorEvent.IID, null);
+            }
         }
 
         private void OnAsyncBreakComplete(object sender, ThreadEventArgs e)

--- a/Nodejs/Product/Nodejs/Debugger/DebugEngine/BreakpointManager.cs
+++ b/Nodejs/Product/Nodejs/Debugger/DebugEngine/BreakpointManager.cs
@@ -1,36 +1,35 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.VisualStudio.Debugger.Interop;
 
 namespace Microsoft.NodejsTools.Debugger.DebugEngine
 {
     // This class manages breakpoints for the engine. 
-    internal class BreakpointManager
+    internal sealed class BreakpointManager
     {
-        private AD7Engine m_engine;
-        private System.Collections.Generic.List<AD7PendingBreakpoint> m_pendingBreakpoints;
-        private Dictionary<NodeBreakpoint, AD7PendingBreakpoint> _breakpointMap = new Dictionary<NodeBreakpoint, AD7PendingBreakpoint>();
-        private Dictionary<NodeBreakpointBinding, AD7BoundBreakpoint> _breakpointBindingMap = new Dictionary<NodeBreakpointBinding, AD7BoundBreakpoint>();
+        private readonly AD7Engine engine;
+        private readonly List<AD7PendingBreakpoint> pendingBreakpoints = new List<AD7PendingBreakpoint>();
+        private readonly Dictionary<NodeBreakpoint, AD7PendingBreakpoint> breakpointMap = new Dictionary<NodeBreakpoint, AD7PendingBreakpoint>();
+        private readonly Dictionary<NodeBreakpointBinding, AD7BoundBreakpoint> breakpointBindingMap = new Dictionary<NodeBreakpointBinding, AD7BoundBreakpoint>();
 
         public BreakpointManager(AD7Engine engine)
         {
-            this.m_engine = engine;
-            this.m_pendingBreakpoints = new System.Collections.Generic.List<AD7PendingBreakpoint>();
+            this.engine = engine;
         }
 
         // A helper method used to construct a new pending breakpoint.
         public void CreatePendingBreakpoint(IDebugBreakpointRequest2 pBPRequest, out IDebugPendingBreakpoint2 ppPendingBP)
         {
-            var pendingBreakpoint = new AD7PendingBreakpoint(pBPRequest, this.m_engine, this);
-            ppPendingBP = (IDebugPendingBreakpoint2)pendingBreakpoint;
-            this.m_pendingBreakpoints.Add(pendingBreakpoint);
+            ppPendingBP = new AD7PendingBreakpoint(pBPRequest, this.engine, this);
+            this.pendingBreakpoints.Add((AD7PendingBreakpoint)ppPendingBP);
         }
 
         // Called from the engine's detach method to remove the debugger's breakpoint instructions.
         public void ClearBreakpointBindingResults()
         {
-            foreach (var pendingBreakpoint in this.m_pendingBreakpoints)
+            foreach (var pendingBreakpoint in this.pendingBreakpoints)
             {
                 pendingBreakpoint.ClearBreakpointBindingResults();
             }
@@ -38,32 +37,32 @@ namespace Microsoft.NodejsTools.Debugger.DebugEngine
 
         public void AddPendingBreakpoint(NodeBreakpoint breakpoint, AD7PendingBreakpoint pendingBreakpoint)
         {
-            this._breakpointMap[breakpoint] = pendingBreakpoint;
+            this.breakpointMap[breakpoint] = pendingBreakpoint;
         }
 
         public void RemovePendingBreakpoint(NodeBreakpoint breakpoint)
         {
-            this._breakpointMap.Remove(breakpoint);
+            this.breakpointMap.Remove(breakpoint);
         }
 
         public AD7PendingBreakpoint GetPendingBreakpoint(NodeBreakpoint breakpoint)
         {
-            return this._breakpointMap[breakpoint];
+            return this.breakpointMap.TryGetValue(breakpoint, out var pendingBreakpoint) ? pendingBreakpoint : null;
         }
 
         public void AddBoundBreakpoint(NodeBreakpointBinding breakpointBinding, AD7BoundBreakpoint boundBreakpoint)
         {
-            this._breakpointBindingMap[breakpointBinding] = boundBreakpoint;
+            this.breakpointBindingMap[breakpointBinding] = boundBreakpoint;
         }
 
         public void RemoveBoundBreakpoint(NodeBreakpointBinding breakpointBinding)
         {
-            this._breakpointBindingMap.Remove(breakpointBinding);
+            this.breakpointBindingMap.Remove(breakpointBinding);
         }
 
         public AD7BoundBreakpoint GetBoundBreakpoint(NodeBreakpointBinding breakpointBinding)
         {
-            return this._breakpointBindingMap.TryGetValue(breakpointBinding, out var boundBreakpoint) ? boundBreakpoint : null;
+            return this.breakpointBindingMap.TryGetValue(breakpointBinding, out var boundBreakpoint) ? boundBreakpoint : null;
         }
     }
 }


### PR DESCRIPTION
fixes 

[Watson] clr20r3: CLR_EXCEPTION_System.Collections.Generic.KeyNotFoundException_80131577_UNKNOWN!Microsoft.NodejsTools.Debugger.DebugEngine.AD7Engine.OnBreakpointBound+1e