### PR TITLE
Make sure we get a fresh hierarchy id map per project instance

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/HierarchyIdMap.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/HierarchyIdMap.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudioTools.Project
         private readonly ConcurrentDictionary<uint, WeakReference<HierarchyNode>> nodes = new ConcurrentDictionary<uint, WeakReference<HierarchyNode>>();
         private readonly ConcurrentStack<uint> freedIds = new ConcurrentStack<uint>();
 
-        public readonly static HierarchyIdMap Instance = new HierarchyIdMap();
-
-        private HierarchyIdMap() { }
+        public HierarchyIdMap()
+        {
+        }
 
         /// <summary>
         /// Must be called from the UI thread

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -585,9 +585,10 @@ namespace Microsoft.VisualStudioTools.Project
         }
 
         /// <summary>
-        /// Gets a collection of integer ids that maps to project item instances
+        /// Gets a collection of integer ids that maps to project item instances. 
+        /// This should be a new instance for each hierarchy.
         /// </summary>
-        internal HierarchyIdMap ItemIdMap => HierarchyIdMap.Instance;
+        internal HierarchyIdMap ItemIdMap { get; } = new HierarchyIdMap();
 
         /// <summary>
         /// Get the helper object that track document changes.


### PR DESCRIPTION
If we use a static instance the map won't be cleared when we close the project, this results in empty nodes in the map.