### PR TITLE
Get Node.js and npm paths from VS package

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -135,6 +135,32 @@ namespace Microsoft.NodejsTools
                 }
             }
 
+            const string nodeJsPackageRegistryKey = "Microsoft.VisualStudio.Package.NodeJs";
+            const string node32Value = "NodeExecutablePath32";
+            const string node64Value = "NodeExecutablePath64";
+            const string npmValue = "NpmExecutablePath";
+
+            // Attempt to find Node.js/NPM from the VS package
+            using (var nodeJsPackageKey = VSRegistry.RegistryRoot(__VsLocalRegistryType.RegType_Configuration, true).CreateSubKey(nodeJsPackageRegistryKey))
+            {
+                if (executable == "node.exe")
+                {
+                    var key;
+                    if (Environment.Is64BitOperatingSystem)
+                    {
+                        return nodeJsPackageKey.GetValue(node64Value) as string;
+                    }
+                    else
+                    {
+                        return nodeJsPackageKey.GetValue(node32Value) as string;
+                    }
+                }
+                else if (executable == "npm.cmd")
+                {
+                    return nodeJsPackageKey.GetValue(npmValue) as string;
+                }
+            }
+
             // we didn't find the path.
             return null;
         }


### PR DESCRIPTION
Attempt to find bundled node.exe and npm.cmd from Visual Studio

@paulvanbrenk Please note I didn't test this.