### PR TITLE
Add manifest build version to make insertions into VS easier

### DIFF
--- a/Nodejs/Setup/NodejsTools.vsmanproj
+++ b/Nodejs/Setup/NodejsTools.vsmanproj
@@ -14,13 +14,13 @@
     <!-- Define properties that drive the manifest creation here. -->
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
-    <BuildNumber>$(VSTarget).$(BuildNumber)</BuildNumber>
     <TargetName>$(MSBuildProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NTVS uses BuildVersion as 'major.minor.build.revision' and BuildNumber is 'build.revision'.
              But VS Manifest task wants BuildNumber to be 'major.minor.build.revision' -->
     <BuildNumber>$(BuildVersion)</BuildNumber>
+    <ManifestBuildVersion>$(BuildVersion)</ManifestBuildVersion>
     <OutputPath>$(BinDirectory)\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This adds the following entry to the manifest, which is used for insertions into VS and should make merge conflict resolution easier.


![image](https://user-images.githubusercontent.com/5273975/40018676-d3f07f04-5771-11e8-81fd-5f0aa3e785d3.png)
