### PR TITLE
Don't crash when node is missing from hierarchy when trying to remove

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsFolderNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsFolderNode.cs
@@ -10,30 +10,25 @@ namespace Microsoft.NodejsTools.Project
 {
     internal class NodejsFolderNode : CommonFolderNode
     {
-        private readonly CommonProjectNode _project;
+        private readonly CommonProjectNode project;
 
         public NodejsFolderNode(CommonProjectNode root, ProjectElement element) : base(root, element)
         {
-            this._project = root;
+            this.project = root;
         }
 
         public override string Caption => base.Caption;
-
-        public override void RemoveChild(HierarchyNode node)
-        {
-            base.RemoveChild(node);
-        }
 
         internal override int IncludeInProject(bool includeChildren)
         {
             // Include node_modules folder is generally unecessary and can cause VS to hang.
             // http://nodejstools.codeplex.com/workitem/1432
             // Check if the folder is node_modules, and warn the user to ensure they don't run into this issue or at least set expectations appropriately.
-            var nodeModulesPath = Path.Combine(this._project.FullPathToChildren, NodejsConstants.NodeModulesFolder);
+            var nodeModulesPath = Path.Combine(this.project.FullPathToChildren, NodejsConstants.NodeModulesFolder);
             if (CommonUtils.IsSameDirectory(nodeModulesPath, this.ItemNode.Url))
             {
                 Utilities.ShowMessageBox(
-                    this._project.Site, Resources.IncludeNodeModulesContent, SR.ProductName, OLEMSGICON.OLEMSGICON_WARNING, OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                    this.project.Site, Resources.IncludeNodeModulesContent, SR.ProductName, OLEMSGICON.OLEMSGICON_WARNING, OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
                 return VSConstants.S_OK;
             }
             return base.IncludeInProject(includeChildren);

--- a/Nodejs/Product/Nodejs/SharedProject/HierarchyNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/HierarchyNode.cs
@@ -574,28 +574,28 @@ namespace Microsoft.VisualStudioTools.Project
             this.projectMgr.Site.GetUIThread().MustBeCalledFromUIThread();
             this.projectMgr.ItemIdMap.Remove(node);
 
-            HierarchyNode last = null;
-            for (var n = this.firstChild; n != null; n = n.nextSibling)
+            HierarchyNode previous = null;
+            for (var current = this.firstChild; current != null; current = current.nextSibling)
             {
-                if (n == node)
+                if (current == node)
                 {
-                    if (last != null)
+                    if (previous != null)
                     {
-                        last.nextSibling = n.nextSibling;
+                        previous.nextSibling = current.nextSibling;
                     }
-                    if (n == this.firstChild)
+                    if (current == this.firstChild)
                     {
-                        this.firstChild = n.nextSibling;
+                        this.firstChild = current.nextSibling;
                     }
                     if (object.ReferenceEquals(node, this.lastChild))
                     {
-                        this.lastChild = last;
+                        this.lastChild = previous;
                     }
                     return;
                 }
-                last = n;
+                previous = current;
             }
-            throw new InvalidOperationException("Node not found");
+            // Node is no longer in the tree
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #

##### Bug


##### Fix


##### Testing
