### PR TITLE
Remove telemetry infra since it was never invoked.

### DIFF
--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -134,14 +134,6 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             var nodeVersion = Nodejs.GetNodeVersion(nodeExePath);
 
-            // We can only log telemetry when we're running in VS.
-            // Since the required assemblies are not on disk if we're not running in VS, we have to reference them in a separate method
-            // this way the .NET framework only tries to load the assemblies when we actually need them.
-            if (startedFromVs)
-            {
-                this.LogTelemetry(tests.Count(), nodeVersion, this.runContext.IsBeingDebugged, testFramework);
-            }
-
             foreach (var test in tests)
             {
                 if (this.cancelRequested.WaitOne(0))
@@ -299,11 +291,6 @@ namespace Microsoft.NodejsTools.TestAdapter
         private void DetachDebugger(int vsProcessId)
         {
             VisualStudioApp.DetachDebugger(vsProcessId);
-        }
-
-        private void LogTelemetry(int testCount, Version nodeVersion, bool isDebugging, string testFramework)
-        {
-            VisualStudioApp.LogTelemetry(testCount, nodeVersion, isDebugging, testFramework);
         }
 
         private void AttachDebugger(int vsProcessId, int port, Version nodeVersion)

--- a/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
+++ b/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
@@ -129,9 +129,6 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes">
       <Version>15.0.17</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Telemetry">
-      <Version>15.7.942-master669188BE</Version>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>

--- a/Nodejs/Product/TestAdapterImpl/VisualStudioApp.cs
+++ b/Nodejs/Product/TestAdapterImpl/VisualStudioApp.cs
@@ -9,7 +9,6 @@ using EnvDTE;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Telemetry;
 using Process = System.Diagnostics.Process;
 
 namespace Microsoft.VisualStudioTools
@@ -29,18 +28,6 @@ namespace Microsoft.VisualStudioTools
                 }
             }
             return inst;
-        }
-
-        public static void LogTelemetry(int testCount, Version nodeVersion, bool isDebugging, string testFramework)
-        {
-            var userTask = new UserTaskEvent("VS/NodejsTools/UnitTestsExecuted", TelemetryResult.Success);
-            userTask.Properties["VS.NodejsTools.TestCount"] = testCount;
-            // This is safe, since changes to the ToString method are very unlikely, as the current output is widely documented.
-            userTask.Properties["VS.NodejsTools.NodeVersion"] = nodeVersion.ToString() ?? "0.0";
-            userTask.Properties["VS.NodejsTools.IsDebugging"] = isDebugging;
-            userTask.Properties["VS.NodejsTools.TestFramework"] = testFramework;
-
-            TelemetryService.DefaultSession?.PostEvent(userTask);
         }
 
         public static bool AttachToProcessNode2DebugAdapter(int vsProcessId, int port)


### PR DESCRIPTION
Telemetry doesn't work from the sattelite process that runs the tests,
we depend on the events we get from the test framework

Issue #

##### Bug


##### Fix


##### Testing
