### PR TITLE
Set Assembly attributes in targets file

### DIFF
--- a/Build/fileVersion.targets
+++ b/Build/fileVersion.targets
@@ -37,6 +37,12 @@
       <AssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute"> 
         <_Parameter1>$(BuildVersionExtended)</_Parameter1> 
       </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyProductAttribute">
+         <_Parameter1>Microsoft&#174; VisualStudio&#174;</_Parameter1> 
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyTitle">
+         <_Parameter1>$(AssemblyName).dll</_Parameter1> 
+      </AssemblyAttribute>
     </ItemGroup>
 
     <WriteCodeFragment AssemblyAttributes="@(AssemblyAttribute)"

--- a/Nodejs/Product/Nodejs/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/Nodejs/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Reflection;
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.Shell;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/Npm/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/Npm/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Npm")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/PressAnyKey/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/PressAnyKey/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Press any key to continue helper")]
 [assembly: AssemblyDescription("Provides press any key to continue support for Node.js programs.")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/ProjectWizard/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/ProjectWizard/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Wizards")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/TestAdapter/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/TestAdapter/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Test Explorer Integration Shims")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/TestAdapterImpl/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/TestAdapterImpl/Properties/AssemblyInfo.cs
@@ -1,11 +1,10 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Test Explorer Integration")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 

--- a/Nodejs/Product/WebRole/Properties/AssemblyInfo.cs
+++ b/Nodejs/Product/WebRole/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Node.js Tools for Visual Studio - Azure Support")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 


### PR DESCRIPTION
This way they'll be consistent through out the build, including in
.NET Core/Standard assemblies.