### PR TITLE
Ensure SVsBuildManagerAccessor is initialized

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -5687,6 +5687,9 @@ If the files in the existing folder have the same names as files in the folder y
             this.ID = VSConstants.VSITEMID_ROOT;
             this.tracker = new TrackDocumentsHelper(this);
 
+            // Ensure the SVsBuildManagerAccessor is initialized, so there is an IVsUpdateSolutionEvents4 for
+            // solution update events (through Microsoft.VisualStudio.CommonIDE.BuildManager.BuildManagerAccessor).
+            // This ensures that the first build after project creation succeeds.
             var accessor = (IVsBuildManagerAccessor)this.Site.GetService(typeof(SVsBuildManagerAccessor));
             Utilities.CheckNotNull(accessor);
         }

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -2617,7 +2617,6 @@ namespace Microsoft.VisualStudioTools.Project
             var result = MSBuildResult.Failed;
             const bool designTime = true;
 
-            var accessor = this.Site.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
             BuildSubmission submission = null;
 
             try
@@ -2640,9 +2639,9 @@ namespace Microsoft.VisualStudioTools.Project
 
                     var requestData = new BuildRequestData(this.currentConfig, targetsToBuild, this.BuildProject.ProjectCollection.HostServices, BuildRequestDataFlags.ReplaceExistingProjectInstance);
                     submission = BuildManager.DefaultBuildManager.PendBuildRequest(requestData);
-                    if (accessor != null)
+                    if (this.buildManagerAccessor != null)
                     {
-                        ErrorHandler.ThrowOnFailure(accessor.RegisterLogger(submission.SubmissionId, this.BuildLogger));
+                        ErrorHandler.ThrowOnFailure(buildManagerAccessor.RegisterLogger(submission.SubmissionId, this.BuildLogger));
                     }
 
                     var buildResult = submission.Execute();

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -680,8 +680,8 @@ namespace Microsoft.VisualStudioTools.Project
         protected ProjectNode(IServiceProvider serviceProvider)
         {
             this.extensibilityEventsDispatcher = new ExtensibilityEventsDispatcher(this);
-            this.Initialize();
             this.site = serviceProvider;
+            this.Initialize();
             this.taskProvider = new TaskProvider(this.site);
         }
 
@@ -5686,6 +5686,9 @@ If the files in the existing folder have the same names as files in the folder y
         {
             this.ID = VSConstants.VSITEMID_ROOT;
             this.tracker = new TrackDocumentsHelper(this);
+
+            var accessor = (IVsBuildManagerAccessor)this.Site.GetService(typeof(SVsBuildManagerAccessor));
+            Utilities.CheckNotNull(accessor);
         }
 
         /// <summary>

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -2669,9 +2669,6 @@ namespace Microsoft.VisualStudioTools.Project
         {
             const bool designTime = false;
 
-            var accessor = (IVsBuildManagerAccessor)this.Site.GetService(typeof(SVsBuildManagerAccessor));
-            Utilities.CheckNotNull(accessor);
-
             if (!TryBeginBuild(designTime, false))
             {
                 if (uiThreadCallback != null)
@@ -2701,7 +2698,7 @@ namespace Microsoft.VisualStudioTools.Project
             {
                 if (this.BuildLogger != null)
                 {
-                    ErrorHandler.ThrowOnFailure(accessor.RegisterLogger(submission.SubmissionId, this.BuildLogger));
+                    ErrorHandler.ThrowOnFailure(this.buildManagerAccessor.RegisterLogger(submission.SubmissionId, this.BuildLogger));
                 }
 
                 submission.ExecuteAsync(sub =>
@@ -6025,11 +6022,6 @@ If the files in the existing folder have the same names as files in the folder y
         /// </remarks>
         private bool TryBeginBuild(bool designTime, bool requiresUIThread = false)
         {
-            if (this.Site != null && this.buildManagerAccessor == null)
-            {
-                this.buildManagerAccessor = this.Site.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
-            }
-
             var releaseUIThread = false;
 
             try
@@ -6094,11 +6086,6 @@ If the files in the existing folder have the same names as files in the folder y
         /// </remarks>
         private void EndBuild(BuildSubmission submission, bool designTime, bool requiresUIThread = false)
         {
-            if (this.Site != null && this.buildManagerAccessor == null)
-            {
-                this.buildManagerAccessor = this.Site.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
-            }
-
             if (this.buildManagerAccessor != null)
             {
                 // It's very important that we try executing all three end-build steps, even if errors occur partway through.


### PR DESCRIPTION
This ensures the SVsBuildManagerAccessor is initialized when the project is created, and the project can be build on the first try.