### PR TITLE
Fix reporting for tape.js

### DIFF
--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -161,7 +161,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             if (this.runContext.IsBeingDebugged && startedFromVs)
             {
                 this.DetachDebugger(vsProcessId);
-                // Ensure that --debug - brk or--inspect - brk is the first argument
+                // Ensure that --debug-brk or --inspect-brk is the first argument
                 nodeArgs.Insert(0, GetDebugArgs(nodeVersion, out port));
             }
 

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -19,6 +19,12 @@ namespace Microsoft.NodejsTools.TestAdapter
 {
     internal sealed partial class TestExecutorWorker
     {
+        private class TestCaseResult
+        {
+            public TestCase TestCase;
+            public TestResult TestResult;
+        }
+
         private static readonly Version Node8Version = new Version(8, 0);
 
         //get from NodeRemoteDebugPortSupplier::PortSupplierId
@@ -29,9 +35,8 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         private readonly IFrameworkHandle frameworkHandle;
         private readonly IRunContext runContext;
-        private List<TestCase> currentTests;
+        private List<TestCaseResult> currentTests;
         private ProcessOutput nodeProcess;
-        private TestResult currentResult;
         private ResultObject currentResultObject;
 
         public TestExecutorWorker(IRunContext runContext, IFrameworkHandle frameworkHandle)
@@ -44,7 +49,7 @@ namespace Microsoft.NodejsTools.TestAdapter
         {
             //let us just kill the node process there, rather do it late, because VS engine process 
             //could exit right after this call and our node process will be left running.
-            KillNodeProcess();
+            this.KillNodeProcess();
             this.cancelRequested.Set();
         }
 
@@ -81,16 +86,16 @@ namespace Microsoft.NodejsTools.TestAdapter
             ValidateArg.NotNull(tests, nameof(tests));
 
             // .ts file path -> project settings
-            var fileToTests = new Dictionary<string, List<TestCase>>();
+            var fileToTests = new Dictionary<string, List<TestCaseResult>>();
 
             // put tests into dictionary where key is their source file
             foreach (var test in tests)
             {
                 if (!fileToTests.ContainsKey(test.CodeFilePath))
                 {
-                    fileToTests[test.CodeFilePath] = new List<TestCase>();
+                    fileToTests[test.CodeFilePath] = new List<TestCaseResult>();
                 }
-                fileToTests[test.CodeFilePath].Add(test);
+                fileToTests[test.CodeFilePath].Add(new TestCaseResult() { TestCase = test });
             }
 
             // where key is the file and value is a list of tests
@@ -99,15 +104,14 @@ namespace Microsoft.NodejsTools.TestAdapter
                 this.currentTests = testcaseList;
 
                 // Run all test cases in a given file
-                RunTestCases(testcaseList);
+                this.RunTestCases(testcaseList);
             }
         }
 
-        private void RunTestCases(IEnumerable<TestCase> tests)
+        private void RunTestCases(IEnumerable<TestCaseResult> tests)
         {
             // May be null, but this is handled by RunTestCase if it matters.
-            // No VS instance just means no debugging, but everything else is
-            // okay.
+            // No VS instance just means no debugging, but everything else is okay.
             if (!tests.Any())
             {
                 return;
@@ -120,7 +124,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             var testObjects = new List<TestCaseObject>();
 
             // All tests being run are for the same test file, so just use the first test listed to get the working dir
-            var firstTest = tests.First();
+            var firstTest = tests.First().TestCase;
             var testFramework = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.TestFramework, defaultValue: "ExportRunner");
             var workingDir = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.WorkingDir, defaultValue: Path.GetDirectoryName(firstTest.CodeFilePath));
             var nodeExePath = firstTest.GetPropertyValue<string>(JavaScriptTestCaseProperties.NodeExePath, defaultValue: null);
@@ -142,7 +146,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                     break;
                 }
 
-                var args = GetInterpreterArgs(test, workingDir, projectRootDir);
+                var args = GetInterpreterArgs(test.TestCase, workingDir, projectRootDir);
 
                 // Fetch the run_tests argument for starting node.exe if not specified yet
                 if (nodeArgs.Count == 0)
@@ -157,7 +161,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             if (this.runContext.IsBeingDebugged && startedFromVs)
             {
                 this.DetachDebugger(vsProcessId);
-                // Ensure that --debug-brk or --inspect-brk is the first argument
+                // Ensure that --debug - brk or--inspect - brk is the first argument
                 nodeArgs.Insert(0, GetDebugArgs(nodeVersion, out port));
             }
 
@@ -195,7 +199,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             // Automatically fail tests that haven't been run by this point (failures in before() hooks)
             foreach (var notRunTest in this.currentTests)
             {
-                var result = new TestResult(notRunTest)
+                var result = new TestResult(notRunTest.TestCase)
                 {
                     Outcome = TestOutcome.Failed
                 };
@@ -206,7 +210,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                     result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, this.currentResultObject.stderr));
                 }
                 this.frameworkHandle.RecordResult(result);
-                this.frameworkHandle.RecordEnd(notRunTest, TestOutcome.Failed);
+                this.frameworkHandle.RecordEnd(notRunTest.TestCase, TestOutcome.Failed);
             }
         }
 
@@ -216,30 +220,27 @@ namespace Microsoft.NodejsTools.TestAdapter
             {
                 var testEvent = JsonConvert.DeserializeObject<TestEvent>(line);
                 // Extract test from list of tests
-                var tests = this.currentTests.Where(n => n.DisplayName == testEvent.title);
-                if (tests.Any())
+                var test = this.currentTests
+                               .Where(n => n.TestCase.DisplayName == testEvent.title)
+                               .FirstOrDefault();
+
+                if (test != null)
                 {
                     switch (testEvent.type)
                     {
                         case "test start":
+                            test.TestResult = new TestResult(test.TestCase)
                             {
-                                this.currentResult = new TestResult(tests.First())
-                                {
-                                    StartTime = DateTimeOffset.Now
-                                };
-                                this.frameworkHandle.RecordStart(tests.First());
-                            }
+                                StartTime = DateTimeOffset.Now
+                            };
+                            this.frameworkHandle.RecordStart(test.TestCase);
                             break;
                         case "result":
-                            {
-                                RecordEnd(tests.First(), testEvent.result);
-                            }
+                            RecordEnd(test, testEvent.result);
                             break;
                         case "pending":
-                            {
-                                this.currentResult = new TestResult(tests.First());
-                                RecordEnd(tests.First(), testEvent.result);
-                            }
+                            test.TestResult = new TestResult(test.TestCase);
+                            RecordEnd(test, testEvent.result);
                             break;
                     }
                 }
@@ -254,29 +255,29 @@ namespace Microsoft.NodejsTools.TestAdapter
                 // Often lines emitted while running tests are not test results, and thus will fail to parse above
             }
 
-            void RecordEnd(TestCase test, ResultObject resultObject)
+            void RecordEnd(TestCaseResult test, ResultObject resultObject)
             {
                 var standardOutputLines = resultObject.stdout.Split('\n');
                 var standardErrorLines = resultObject.stderr.Split('\n');
 
                 if (resultObject.pending == true)
                 {
-                    this.currentResult.Outcome = TestOutcome.Skipped;
+                    test.TestResult.Outcome = TestOutcome.Skipped;
                 }
                 else
                 {
-                    this.currentResult.EndTime = DateTimeOffset.Now;
-                    this.currentResult.Duration = this.currentResult.EndTime - this.currentResult.StartTime;
-                    this.currentResult.Outcome = resultObject.passed ? TestOutcome.Passed : TestOutcome.Failed;
+                    test.TestResult.EndTime = DateTimeOffset.Now;
+                    test.TestResult.Duration = test.TestResult.EndTime - test.TestResult.StartTime;
+                    test.TestResult.Outcome = resultObject.passed ? TestOutcome.Passed : TestOutcome.Failed;
                 }
 
                 var errorMessage = string.Join(Environment.NewLine, standardErrorLines);
 
-                this.currentResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, string.Join(Environment.NewLine, standardOutputLines)));
-                this.currentResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, errorMessage));
-                this.currentResult.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, errorMessage));
-                this.frameworkHandle.RecordResult(this.currentResult);
-                this.frameworkHandle.RecordEnd(test, this.currentResult.Outcome);
+                test.TestResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, string.Join(Environment.NewLine, standardOutputLines)));
+                test.TestResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, errorMessage));
+                test.TestResult.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, errorMessage));
+                this.frameworkHandle.RecordResult(test.TestResult);
+                this.frameworkHandle.RecordEnd(test.TestCase, test.TestResult.Outcome);
                 this.currentTests.Remove(test);
             }
         }
@@ -320,14 +321,14 @@ namespace Microsoft.NodejsTools.TestAdapter
             {
                 this.frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
                 this.frameworkHandle.SendMessage(TestMessageLevel.Error, ex.ToString());
-                KillNodeProcess();
+                this.KillNodeProcess();
             }
 #else
             }
             catch (COMException)
             {
-                frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
-                KillNodeProcess();
+                this.frameworkHandle.SendMessage(TestMessageLevel.Error, "Error occurred connecting to debuggee.");
+                this.KillNodeProcess();
             }
 #endif
         }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
@@ -84,7 +84,7 @@ function run_tests(testInfo, callback) {
                 var msg = "Operator: " + evt.operator + ". Expected: " + evt.expected + ". Actual: " + evt.actual + ". evt: " + JSON.stringify(evt) + "\n";
                 if (evt.ok) {
                     result.stdOut += msg;
-                    result.passed = true;
+                    result.passed = result.passed === undefined ? true : result.passed;
                 } else {
                     result.stdErr += msg + (evt.error.stack || evt.error.message) + "\n";
                     result.passed = false;
@@ -120,7 +120,7 @@ function run_tests(testInfo, callback) {
         for (var i = 0; i < testState.length; i++) {
             if (testState[i]) {
                 var result = testState[i];
-                if (result.passed == undefined) { result.passed = false; }
+                if (!result.passed) { result.passed = false; }
                 callback({
                     'type': 'result',
                     'title': result.title,

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
@@ -2,12 +2,6 @@
 var EOL = require('os').EOL;
 var fs = require('fs');
 var path = require('path');
-var result = {
-    'title': '',
-    'passed': false,
-    'stdOut': '',
-    'stdErr': ''
-};
 
 function append_stdout(string, encoding, fd) {
     result.stdOut += string;
@@ -57,19 +51,25 @@ function run_tests(testInfo, callback) {
         return;
     }
 
+    // Since the test events don't come in order we store all of them in this array
+    // in the 'onFinish' event we loop through them and process anything remaining.
+    var testState = [];
     var harness = tape.getHarness({ objectMode: true });
-    var capture = false; // Only capture between 'test' and 'end' events to avoid skipped test events.
+
     harness.createStream({ objectMode: true }).on('data', function (evt) {
         switch (evt.type) {
             case 'test':
-                capture = true;
-                // Test is starting. Reset the result object. Send a "test start" event.
-                result = {
+
+                var result = {
                     'title': evt.name,
-                    'passed': true,
+                    'passed': undefined,
                     'stdOut': '',
                     'stdErr': ''
                 };
+
+                testState[evt.id] = result;
+
+                // Test is starting. Reset the result object. Send a "test start" event.
                 callback({
                     'type': 'test start',
                     'title': result.title,
@@ -77,25 +77,29 @@ function run_tests(testInfo, callback) {
                 });
                 break;
             case 'assert':
-                if (!capture) break;
+                var result = testState[evt.test];
+                if (!result) { break; }
+
                 // Correlate the success/failure asserts for this test. There may be multiple per test
-                var msg = "Operator: " + evt.operator + ". Expected: " + evt.expected + ". Actual: " + evt.actual + "\n";
+                var msg = "Operator: " + evt.operator + ". Expected: " + evt.expected + ". Actual: " + evt.actual + ". evt: " + JSON.stringify(evt) + "\n";
                 if (evt.ok) {
                     result.stdOut += msg;
+                    result.passed = true;
                 } else {
                     result.stdErr += msg + (evt.error.stack || evt.error.message) + "\n";
                     result.passed = false;
                 }
                 break;
             case 'end':
-                if (!capture) break;
+                var result = testState[evt.test];
+                if (!result) { break; }
                 // Test is done. Send a "result" event.
                 callback({
                     'type': 'result',
                     'title': result.title,
                     'result': result
                 });
-                capture = false;
+                testState[evt.test] = undefined;
                 break;
             default:
                 break;
@@ -112,14 +116,17 @@ function run_tests(testInfo, callback) {
     });
 
     harness.onFinish(function () {
-        if (capture) {
-            // Something didn't finish. Finish it now.
-            result.passed = false;
-            callback({
-                'type': 'result',
-                'title': result.title,
-                'result': result
-            });
+        // loop through items in testState
+        for (var i = 0; i < testState.length; i++) {
+            if (testState[i]) {
+                var result = testState[i];
+                if (result.passed == undefined) { result.passed = false; }
+                callback({
+                    'type': 'result',
+                    'title': result.title,
+                    'result': result
+                });
+            }
         }
         process.exit(0);
     });


### PR DESCRIPTION
Since tape doesn't report results in order for the first and last test
we have to keep a list of tests and handle them as their results become
available.
