### PR TITLE
Block debug during npm install

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.cs
+++ b/Nodejs/Product/Nodejs/Nodejs.cs
@@ -179,6 +179,16 @@ namespace Microsoft.NodejsTools
             );
         }
 
+        public static void ShowNpmIsInstalling()
+        {
+            MessageBox.Show(
+                SR.GetString(SR.NpmIsInstalling),
+                SR.ProductName,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+        }
+
         public static void ShowNodejsPathNotFound(string path)
         {
             MessageBox.Show(

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NodejsTools.Project
             if(NpmInstallCommand.IsInstalling)
             {
                 Nodejs.ShowNpmIsInstalling();
-                return VSConstants.E_ABORT;
+                return VSConstants.S_OK;
             }
 
             if (nodePath == null)

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -16,6 +16,7 @@ using System.Web;
 using System.Windows.Forms;
 using Microsoft.NodejsTools.Debugger;
 using Microsoft.NodejsTools.Debugger.DebugEngine;
+using Microsoft.NodejsTools.Npm.SPI;
 using Microsoft.NodejsTools.Options;
 using Microsoft.NodejsTools.Telemetry;
 using Microsoft.NodejsTools.TypeScript;
@@ -54,6 +55,12 @@ namespace Microsoft.NodejsTools.Project
         public int LaunchFile(string file, bool debug)
         {
             var nodePath = GetNodePath();
+
+            if(NpmInstallCommand.IsInstalling)
+            {
+                Nodejs.ShowNpmIsInstalling();
+                return VSConstants.E_ABORT;
+            }
 
             if (nodePath == null)
             {

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -56,9 +56,11 @@ namespace Microsoft.NodejsTools.Project
         {
             var nodePath = GetNodePath();
 
-            if(NpmInstallCommand.IsInstalling)
+            if(this._project.IsInstallingMissingModules)
             {
                 Nodejs.ShowNpmIsInstalling();
+                this._project.NpmOutputPane?.Show();
+
                 return VSConstants.S_OK;
             }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -37,6 +37,8 @@ namespace Microsoft.NodejsTools.Project
         private Timer _idleNodeModulesTimer;
 #pragma warning restore 0414
 
+        public bool IsInstallingMissingModules { get; private set; } = false;
+
         public NodejsProjectNode(NodejsProjectPackage package) : base(package, null)
         {
             var projectNodePropsType = typeof(NodejsProjectNodeProperties);
@@ -553,9 +555,11 @@ namespace Microsoft.NodejsTools.Project
 
         Task INodePackageModulesCommands.InstallMissingModulesAsync()
         {
-            //Fire off the command to update the missing modules
-            //  through NPM
-            return this.ModulesNode.InstallMissingModules();
+            this.IsInstallingMissingModules = true;
+
+            //Fire off the command to update the missing modules through NPM
+            return this.ModulesNode.InstallMissingModules()
+                .ContinueWith(task => this.IsInstallingMissingModules = false, TaskScheduler.Default);
         }
 
         internal event EventHandler OnDispose;

--- a/Nodejs/Product/Nodejs/Project/ProjectResources.cs
+++ b/Nodejs/Product/Nodejs/Project/ProjectResources.cs
@@ -13,6 +13,7 @@ namespace Microsoft.NodejsTools.Project
 
         internal const string NodeExeDoesntExist = "NodeExeDoesntExist";
         internal const string NodejsNotInstalled = "NodejsNotInstalled";
+        internal const string NpmIsInstalling = "NpmIsInstalling";
 
         internal const string TestFramework = "TestFramework";
 

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -869,7 +869,7 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Debugging could not be started because NPM is installing packages. Please wait untill NPM finishes and try again..
+        ///   Looks up a localized string similar to Debugging could not be started because npm is installing packages. Please wait untill npm finishes and try again..
         /// </summary>
         internal static string NpmIsInstalling {
             get {

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -869,6 +869,15 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Debugging could not be started because NPM is installing packages. Please wait untill NPM finishes and try again..
+        /// </summary>
+        internal static string NpmIsInstalling {
+            get {
+                return ResourceManager.GetString("NpmIsInstalling", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package Installations.
         /// </summary>
         internal static string NpmNodePackageInstallation {

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -869,7 +869,7 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Debugging could not be started because npm is installing packages. Please wait untill npm finishes and try again..
+        ///   Looks up a localized string similar to Debugging could not be started because npm is installing packages. Please wait until npm finishes and try again..
         /// </summary>
         internal static string NpmIsInstalling {
             get {

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -760,6 +760,6 @@ Error retrieving websocket debug proxy information from web.config.</value>
     <value>Specifies the directory where the unit tests are located.</value>
   </data>
   <data name="NpmIsInstalling" xml:space="preserve">
-    <value>Debugging could not be started because NPM is installing packages. Please wait untill NPM finishes and try again.</value>
+    <value>Debugging could not be started because npm is installing packages. Please wait untill npm finishes and try again.</value>
   </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -759,4 +759,7 @@ Error retrieving websocket debug proxy information from web.config.</value>
   <data name="TestRootToolTip" xml:space="preserve">
     <value>Specifies the directory where the unit tests are located.</value>
   </data>
+  <data name="NpmIsInstalling" xml:space="preserve">
+    <value>Debugging could not be started because NPM is installing packages. Please wait untill NPM finishes and try again.</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -760,6 +760,6 @@ Error retrieving websocket debug proxy information from web.config.</value>
     <value>Specifies the directory where the unit tests are located.</value>
   </data>
   <data name="NpmIsInstalling" xml:space="preserve">
-    <value>Debugging could not be started because npm is installing packages. Please wait untill npm finishes and try again.</value>
+    <value>Debugging could not be started because npm is installing packages. Please wait until npm finishes and try again.</value>
   </data>
 </root>

--- a/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
+++ b/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    public abstract class AbstractNpmLogSource : INpmLogSource
+    internal abstract class AbstractNpmLogSource : INpmLogSource
     {
         public event EventHandler CommandStarted;
 

--- a/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
+++ b/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
@@ -1,10 +1,10 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    internal abstract class AbstractNpmLogSource : INpmLogSource
+    public abstract class AbstractNpmLogSource : INpmLogSource
     {
         public event EventHandler CommandStarted;
 

--- a/Nodejs/Product/Npm/SPI/NpmCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    public abstract class NpmCommand : AbstractNpmLogSource
+    internal abstract class NpmCommand : AbstractNpmLogSource
     {
         private string pathToNpm;
 

--- a/Nodejs/Product/Npm/SPI/NpmCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommand.cs
@@ -81,7 +81,8 @@ namespace Microsoft.NodejsTools.Npm.SPI
 
             try
             {
-                this.GetPathToNpm();
+                // Call this method first to throw a NpmNotFoundException before writing anything to the output.
+                var pathToNpm = this.GetPathToNpm();
 
                 redirector?.WriteLine(
                     string.Format(CultureInfo.InvariantCulture, "===={0}====\r\n\r\n",
@@ -89,7 +90,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
 
                 await NpmHelpers.ExecuteNpmCommandAsync(
                     redirector,
-                    this.GetPathToNpm(),
+                    pathToNpm,
                     this.FullPathToRootPackageDirectory,
                     new[] { this.Arguments },
                     this.showConsole,
@@ -103,11 +104,6 @@ namespace Microsoft.NodejsTools.Npm.SPI
             catch (OperationCanceledException)
             {
                 cancelled = true;
-            }
-            catch (Exception)
-            {
-                // Catch exception to run the finally block during an unhandled exception.
-                throw;
             }
             finally
             {

--- a/Nodejs/Product/Npm/SPI/NpmCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    internal abstract class NpmCommand : AbstractNpmLogSource
+    public abstract class NpmCommand : AbstractNpmLogSource
     {
         private string pathToNpm;
 

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -4,8 +4,6 @@ namespace Microsoft.NodejsTools.Npm.SPI
 {
     public class NpmInstallCommand : NpmCommand
     {
-        public static bool IsInstalling { get; private set; } = false;
-
         public NpmInstallCommand(
             string fullPathToRootPackageDirectory,
             string pathToNpm = null,
@@ -13,9 +11,6 @@ namespace Microsoft.NodejsTools.Npm.SPI
             : base(fullPathToRootPackageDirectory, showConsole: false, pathToNpm: pathToNpm)
         {
             this.Arguments = "install";
-
-            this.CommandStarted += (sender, eventArgs) => { IsInstalling = true; };
-            this.CommandCompleted += (sender, eventArgs) => { IsInstalling = false; };
         }
 
         public NpmInstallCommand(

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -4,7 +4,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
 {
     internal class NpmInstallCommand : NpmCommand
     {
-        internal NpmInstallCommand(
+        public NpmInstallCommand(
             string fullPathToRootPackageDirectory,
             string pathToNpm = null,
             bool useFallbackIfNpmNotFound = true)

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -2,9 +2,9 @@
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    public class NpmInstallCommand : NpmCommand
+    internal class NpmInstallCommand : NpmCommand
     {
-        public NpmInstallCommand(
+        internal NpmInstallCommand(
             string fullPathToRootPackageDirectory,
             string pathToNpm = null,
             bool useFallbackIfNpmNotFound = true)

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
             this.Arguments = "install";
 
             this.CommandStarted += (sender, eventArgs) => { IsInstalling = true; };
-            this.CommandStarted += (sender, eventArgs) => { IsInstalling = false; };
+            this.CommandCompleted += (sender, eventArgs) => { IsInstalling = false; };
         }
 
         public NpmInstallCommand(

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -2,8 +2,10 @@
 
 namespace Microsoft.NodejsTools.Npm.SPI
 {
-    internal class NpmInstallCommand : NpmCommand
+    public class NpmInstallCommand : NpmCommand
     {
+        public static bool IsInstalling { get; private set; } = false;
+
         public NpmInstallCommand(
             string fullPathToRootPackageDirectory,
             string pathToNpm = null,
@@ -11,6 +13,9 @@ namespace Microsoft.NodejsTools.Npm.SPI
             : base(fullPathToRootPackageDirectory, showConsole: false, pathToNpm: pathToNpm)
         {
             this.Arguments = "install";
+
+            this.CommandStarted += (sender, eventArgs) => { IsInstalling = true; };
+            this.CommandStarted += (sender, eventArgs) => { IsInstalling = false; };
         }
 
         public NpmInstallCommand(


### PR DESCRIPTION
When starting debug during npm install. Visual studio display the message:

Attribute 'program' does not exists (<JavaScript_file>).

This PR aborts starting debug during the initial npm install and display an error message to the user. Note that it doesn't block any subsequent installs.