### PR TITLE
Removed process.exit for process.exitCode on Mocha test adapter

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/mocha/mocha.js
@@ -111,7 +111,7 @@ var run_tests = function (testCases, callback) {
     mocha.addFile(testCases[0].testFile);
 
     var runner = mocha.run(function (code) {
-        process.exit(code);
+        process.exitCode = code ? code : 0;
     });
 
     // See events available at https://github.com/mochajs/mocha/blob/8cae7a34f0b6eafeb16567beb8852b827cc5956b/lib/runner.js#L47-L57

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -7,7 +7,7 @@ var rl = readline.createInterface({
     output: process.stdout
 });
 
-rl.on('line', (line) => {
+rl.on('line', function (line) {
     rl.close();
 
     // strip the BOM in case of UTF-8


### PR DESCRIPTION
Fixes an issue when the process.stdout has not finished reporting the test result and the node process is killed.

With this the node process will wait until the I/O has finished all operations to be closed.