### PR TITLE
Move System.ValueTuple package to 4.3.0

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1270,7 +1270,7 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
See customer reports at:

 - https://developercommunity.visualstudio.com/content/problem/290861/cannot-open-nodejs-project-in-vs2017-158-preview-4.html
 - https://developercommunity.visualstudio.com/content/problem/317159/cannot-create-new-nodejs-project.html

The root cause is that System.ValueTuple moved to the core .NET libraries in .NET 4.7 (see https://github.com/dotnet/announcements/issues/25), and .NET 4.7 is already present on Windows 10, and if certain workloads/components were installed along with VS. This masks the fact that the System.ValueTuple assembly (4.0.2.0) we were referencing in NuGet package 4.4.0, cannot be found (as the type is already present when the framework is loaded anyway). On non-Win10 machines that don't have .NET 4.7 installed, this problem can occur.

With this revert to NuGet package 4.3.0, we are now referencing the System.ValueTuple assembly version 4.0.1.0, which is already included in Visual Studio in the PrivateAssemblies folder (so should always be found).

Current workarounds (before this fix ships) are to either:

 - Install the .NET Framework 4.7 on the machine.
 - Place a copy of System.ValueTuple.dll asssembly version 4.0.2.0 into the Node.js Tools extension folder (`"%VSINSTALLDIR%\Common7\IDE\Extensions\Microsoft\NodeJsTools\NodeJsTools`).

To get a copy of the dll version mentioned above, you could NuGet restore the System.ValueTuple version 4.4.0, and you'll find it in a path similar to `%USERPROFILE%\.nuget\packages\system.valuetuple\4.4.0\lib\net461`.