### PR TITLE
2055: TestAdapter: Test discovery fails on test projects that contain a large number of test files

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             // Create a temp file with the list of test files.
             var testFilesString = string.Join(";", testFiles);
             var testFilesListFile = Path.GetTempFileName();
-            File.AppendAllText(testFilesListFile, testFilesString, System.Text.Encoding.UTF8);
+            File.WriteAllText(testFilesListFile, testFilesString, System.Text.Encoding.UTF8);
 
             try
             {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -35,9 +35,15 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
         {
             var testInfo = string.Empty;
             var discoverResultFile = Path.GetTempFileName();
+
+            // Create a temp file with the list of test files.
+            var testFilesString = string.Join(";", testFiles);
+            var testFilesListFile = Path.GetTempFileName();
+            File.AppendAllText(testFilesListFile, testFilesString, System.Text.Encoding.UTF8);
+
             try
             {
-                var stdout = EvaluateJavaScript(nodeExe, string.Join(";", testFiles), discoverResultFile, logger, projectRoot);
+                var stdout = EvaluateJavaScript(nodeExe, testFilesListFile, discoverResultFile, logger, projectRoot);
                 if (!string.IsNullOrWhiteSpace(stdout))
                 {
                     var stdoutLines = stdout.Split(new[] { Environment.NewLine },
@@ -74,6 +80,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 try
                 {
                     File.Delete(discoverResultFile);
+                    File.Delete(testFilesListFile);
                 }
                 catch (Exception)
                 {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
@@ -1,3 +1,4 @@
+var fs = require("fs");
 var framework;
 try {
     framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
@@ -6,7 +7,19 @@ try {
     process.exit(1);
 }
 try {
-    framework.find_tests(process.argv[3], process.argv[4], process.argv[5]);
+    var testFilesListInputFile = process.argv[3];
+    if (!fs.existsSync(testFilesListInputFile)) {
+        throw new Error("testFilesListInputFile '" + testFilesListInputFile + "' does not exist.");
+    }
+
+    var testFilesList = fs.readFileSync(testFilesListInputFile, "utf-8");
+
+    // strip the BOM in case of UTF-8
+    if (testFilesList.charCodeAt(0) === 0xFEFF) {
+        testFilesList = testFilesList.slice(1);
+    }
+
+    framework.find_tests(testFilesList, process.argv[4], process.argv[5]);
 } catch (exception) {
     console.log("NTVS_ERROR:TestFramework (" + process.argv[2] + ") threw an exception processing (" + process.argv[3] + "), " + exception);
     process.exit(1);


### PR DESCRIPTION
Issue #
 #2055 
##### Bug
Test discovery fails for unit test projects with 100+ test files because the command line to execute node.js test discovery from C# exceeds the windows command line length limit of 8191 characters.

##### Fix
Updated the communication between the TestFramework class in C# and find_tests.js to provide the file path for a temp file that contains the list of test files in which to discover tests.  find_tests.js then reads the contents of the provided file to get the list of test files.  This prevents exceeding the command line length maximum for projects with a large number of test files.

##### Testing
Validated that test discovery works on large projects where it failed previously