### PR TITLE
Code defensively when casting IVsBuildPropertyStorage

### DIFF
--- a/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.NodejsTools.TypeScript;
@@ -173,6 +174,8 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             if(!(project is IVsBuildPropertyStorage propStore))
             {
+                Debug.Fail($"Why is {nameof(project)} not of type {nameof(IVsBuildPropertyStorage)}?");
+
                 return false;
             }
 

--- a/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
+++ b/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
@@ -61,8 +61,16 @@ namespace Microsoft.NodejsTools.TypeScript
         internal static string GetTypeScriptBackedJavaScriptFile(IVsProject project, string pathToFile)
         {
             //Need to deal with the format being relative and explicit
-            var props = (IVsBuildPropertyStorage)project;
-            ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out var outDir));
+            string outDir = null;
+
+            if (project is IVsBuildPropertyStorage props)
+            {
+                ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out outDir));
+            }
+            else
+            {
+                Debug.Fail($"Why is {nameof(project)} not of type {nameof(IVsBuildPropertyStorage)}?");
+            }
 
             var projHome = GetProjectHome(project);
 


### PR DESCRIPTION
This code fixes an unhandled exception when trying to cast to IVsBuildPropertyStorage.