### PR TITLE
Suppress ObjectDisposedException on BoldStartupItem to avoid crash…

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -399,7 +399,13 @@ namespace Microsoft.VisualStudioTools.Project
 
         private void BoldStartupItem()
         {
-            var startupPath = GetStartupFile();
+            string startupPath = null;
+            try
+            {
+                startupPath = GetStartupFile();
+            }
+            catch (ObjectDisposedException) { } // Supress the exception as VS crashes when closing a solution.
+
             if (!string.IsNullOrEmpty(startupPath))
             {
                 var startup = FindNodeByFullPath(startupPath);

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -1834,12 +1834,8 @@ namespace Microsoft.VisualStudioTools.Project
             this.Site.GetUIThread().MustBeCalledFromUIThread();
 
             var property = GetMsBuildProperty(propertyName, resetCache);
-            if (property == null)
-            {
-                return null;
-            }
 
-            return property.EvaluatedValue;
+            return property?.EvaluatedValue;
         }
 
         /// <summary>


### PR DESCRIPTION
Suppress ObjectDisposedException on BoldStartupItem to avoid VS crashing when closing a solution.