### PR TITLE
Update AssemblyResolver probe path for dev16

### DIFF
--- a/Nodejs/Product/TestAdapter/AssemblyResolver.cs
+++ b/Nodejs/Product/TestAdapter/AssemblyResolver.cs
@@ -20,7 +20,8 @@ namespace Microsoft.NodejsTools.TestAdapter
             this.probePaths = new[] {
                 Path.Combine(ideFolder, "PrivateAssemblies"),
                 Path.Combine(ideFolder, "PublicAssemblies"),
-                Path.Combine(installPath, "MSBuild","15.0","Bin"), // TODO: Update this to version 16.0 when the folder exists.
+                Path.Combine(installPath, "MSBuild","Current","Bin"),
+                Path.Combine(installPath, "MSBuild","15.0","Bin"),
                 Path.Combine(ideFolder, "CommonExtensions","Microsoft","TestWindow"),
                 Path.Combine(ideFolder, "CommonExtensions","Microsoft","WebClient","Project System") };
 


### PR DESCRIPTION
Fixes #2113 

Manually verified that discovery of Tape tests works in dev15 (regular testing process) and dev16 (swapping out DLL).