### PR TITLE
Added FailFast to OnItemAdded

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -6476,6 +6476,8 @@ If the files in the existing folder have the same names as files in the folder y
 
             if (string.IsNullOrWhiteSpace(parent.GetItemName()))
             {
+                // We suspect that `npm install` is launching a Hierarchy change that throws and exception causing VS to crash (it's not common but happens every now and then).
+                // FailFast will allow us to capture better information when this error happens.
                 Environment.FailFast("Parent name should not be null or whitespace.");
             }
 

--- a/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/ProjectNode.cs
@@ -6473,6 +6473,12 @@ If the files in the existing folder have the same names as files in the folder y
 
             var prev = previousVisible ?? child.PreviousVisibleSibling;
             var prevId = (prev != null) ? prev.HierarchyId : VSConstants.VSITEMID_NIL;
+
+            if (string.IsNullOrWhiteSpace(parent.GetItemName()))
+            {
+                Environment.FailFast("Parent name should not be null or whitespace.");
+            }
+
             foreach (IVsHierarchyEvents sink in this.hierarchyEventSinks)
             {
                 var result = sink.OnItemAdded(parent.HierarchyId, prevId, child.HierarchyId);


### PR DESCRIPTION
Added a FailFast to get better dumps whenever a "parent" node is null or whitespace. The condition should never be true. Nevertheless, it's been added to get information of a crash happening when updating the Hierarchy nodes.