### PR TITLE
Add EventSource and telemetry for OnItemAdded

### DIFF
--- a/Nodejs/Product/Nodejs/Diagnostics/HierarchyItem.cs
+++ b/Nodejs/Product/Nodejs/Diagnostics/HierarchyItem.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.NodejsTools.Diagnostics
+{
+    internal class HierarchyItem
+    {
+        public uint ItemId { get; set; }
+        public string Name { get; set; }
+        public int ParentId { get; set; }
+    }
+}

--- a/Nodejs/Product/Nodejs/Diagnostics/NodeJsToolsEventSource.cs
+++ b/Nodejs/Product/Nodejs/Diagnostics/NodeJsToolsEventSource.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.NodejsTools.Diagnostics
 {
@@ -41,10 +41,16 @@ namespace Microsoft.NodejsTools.Diagnostics
             this.WriteEvent(2, message);
         }
 
-        [Event(3, Message = "Hierarchy event failed. \"{0}\". Result: {1}. Sink.OnItemAdded({2}, {3}, {4})", Keywords = Keywords.HierarchyEvent, Level = EventLevel.Error)]
-        internal void HierarchyEventException(string message, int result, uint parentHierarchyId, uint prevId, uint childHierarchyId)
+        [Event(3, Message = "Hierarchy event failed. \"{0}\". Result: {1}. Sink.OnItemAdded({2}, {3}, {4}).\r\nHierarchy\r\nItemId\tName\tParentId\r\n{5}", Keywords = Keywords.HierarchyEvent, Level = EventLevel.Error)]
+        internal void HierarchyEventException(string message, int result, uint parentHierarchyId, uint prevId, uint childHierarchyId, IEnumerable<HierarchyItem> hierarchyItems)
         {
-            this.WriteEvent(3, message, result, parentHierarchyId, prevId, childHierarchyId);
+            var builder = new StringBuilder();
+            foreach (var item in hierarchyItems)
+            {
+                builder.AppendLine($"{item.ItemId}\t{this.GetSuppressedMessage(item.Name)}\t{item.ParentId}");
+            }
+
+            this.WriteEvent(3, message, result, parentHierarchyId, prevId, childHierarchyId, builder.ToString());
         }
 
         private string GetSuppressedMessage(string msg)

--- a/Nodejs/Product/Nodejs/Diagnostics/NodeJsToolsEventSource.cs
+++ b/Nodejs/Product/Nodejs/Diagnostics/NodeJsToolsEventSource.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NodejsTools.Diagnostics
+{
+    internal sealed class NodejsToolsEventSource : EventSource
+    {
+        public static NodejsToolsEventSource Instance = new NodejsToolsEventSource();
+
+        public static class Keywords
+        {
+            public const EventKeywords LogPossiblePII = (EventKeywords)0x0001;
+            public const EventKeywords HierarchyEvent = (EventKeywords)0x0002;
+            public const EventKeywords Errors = (EventKeywords)0x0080; // Matches the TypeScriptLanguageService event keywords
+        }
+
+        public const string SuppressedMsg = "<PII suppressed>";
+        public const string NullMsg = "<null>";
+
+        [Event(1, Message = "Hierarchy event started. OnItemAdded requested for ParentNode.HierarhcyId: {0}, ParentNode.ItemName: \"{1}\", ChildNode.HierarchyId: {2}, ChildNode.ItemName: \"{3}\", PreviousVisibleNode.HierarchyId: {4}, PreviousVisibleNode.ItemName: \"{5}\", isDiskNode: {6}", Keywords = Keywords.HierarchyEvent)]
+        internal void HierarchyEventStart(uint parentNodeHierarchyId, string parentNodeName, uint childNodeHierarchyId, string childNodeName, uint? previousVisibleNodeHierarchyId, string previousVisibleNodeName, bool isDiskNode)
+        {
+            this.WriteEvent(
+                1,
+                parentNodeHierarchyId,
+                this.GetSuppressedMessage(parentNodeName),
+                childNodeHierarchyId,
+                this.GetSuppressedMessage(childNodeName),
+                previousVisibleNodeHierarchyId.HasValue ? previousVisibleNodeHierarchyId.Value.ToString() : NullMsg,
+                this.GetSuppressedMessage(previousVisibleNodeName),
+                isDiskNode);
+        }
+
+        [Event(2, Message = "Hierarchy event stopped. {0}", Keywords = Keywords.HierarchyEvent)]
+        internal void HierarchyEventStop(string message)
+        {
+            this.WriteEvent(2, message);
+        }
+
+        [Event(3, Message = "Hierarchy event failed. \"{0}\". Result: {1}. Sink.OnItemAdded({2}, {3}, {4})", Keywords = Keywords.HierarchyEvent, Level = EventLevel.Error)]
+        internal void HierarchyEventException(string message, int result, uint parentHierarchyId, uint prevId, uint childHierarchyId)
+        {
+            this.WriteEvent(3, message, result, parentHierarchyId, prevId, childHierarchyId);
+        }
+
+        private string GetSuppressedMessage(string msg)
+        {
+            return string.IsNullOrWhiteSpace(msg) || this.IsEnabled(EventLevel.LogAlways, Keywords.LogPossiblePII)
+                ? msg ?? NullMsg
+                : SuppressedMsg;
+        }
+    }
+}

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Commands\ImportWizardCommand.cs" />
     <Compile Include="Commands\OpenReplWindowCommand.cs" />
     <Compile Include="Debugger\DebugEngine\AD7EvalErrorProperty.cs" />
+    <Compile Include="Diagnostics\HierarchyItem.cs" />
     <Compile Include="Diagnostics\NodeJsToolsEventSource.cs" />
     <Compile Include="Repl\InteractiveWindowContentType.cs" />
     <Compile Include="SharedProject\SystemUtilities.cs" />

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Commands\ImportWizardCommand.cs" />
     <Compile Include="Commands\OpenReplWindowCommand.cs" />
     <Compile Include="Debugger\DebugEngine\AD7EvalErrorProperty.cs" />
+    <Compile Include="Diagnostics\NodeJsToolsEventSource.cs" />
     <Compile Include="Repl\InteractiveWindowContentType.cs" />
     <Compile Include="SharedProject\SystemUtilities.cs" />
     <Compile Include="TypeScriptHelpers\TsConfigJson.cs" />


### PR DESCRIPTION
This should add etl traces to the OnItemAdded method.

In case of en exception all of the items on the Hierarchy should be listed with their respective parents.