### PR TITLE
Fix VS crash in test file discovery upon file change notifications

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -522,6 +522,11 @@ namespace Microsoft.NodejsTools.Project
             if (TypeScriptHelpers.IsTypeScriptFile(startupFile))
             {
                 startupFile = TypeScriptHelpers.GetTypeScriptBackedJavaScriptFile(this._project, startupFile);
+                if (startupFile == null)
+                {
+                    // Expected to find a JS file
+                    throw new ArgumentException();
+                }
             }
             return startupFile;
         }

--- a/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             if (TypeScriptHelpers.IsTypeScriptFile(pathToFile))
             {
                 var jsFile = TypeScriptHelpers.GetTypeScriptBackedJavaScriptFile(project, pathToFile);
-                if (!File.Exists(jsFile))
+                if (jsFile == null || !File.Exists(jsFile))
                 {
                     //Ignore the file for now.  On the next build event the typescript compiler will generate the file
                     //  at that point this function gets invoked again on the .ts file and we'll see the newly created .js file

--- a/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
+++ b/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
@@ -89,12 +89,9 @@ namespace Microsoft.NodejsTools.TypeScript
                 {
                     ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out outDir));
                 }
-                catch (System.Runtime.InteropServices.COMException e)
+                catch (System.Runtime.InteropServices.COMException e) when (e.ErrorCode == ERR_XML_ATTRIBUTE_NOT_FOUND)
                 {
-                    if (e.ErrorCode == ERR_XML_ATTRIBUTE_NOT_FOUND)
-                    {
-                        return null;
-                    }
+                    return null;
                 }
             }
             else

--- a/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
+++ b/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
@@ -82,7 +82,20 @@ namespace Microsoft.NodejsTools.TypeScript
 
             if (project is IVsBuildPropertyStorage props)
             {
-                ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out outDir));
+                // GetProperty can return this error code if the property doesn't exist
+                const int ERR_XML_ATTRIBUTE_NOT_FOUND = unchecked((int)0x8004C738);
+
+                try
+                {
+                    ErrorHandler.ThrowOnFailure(props.GetPropertyValue(NodeProjectProperty.TypeScriptOutDir, null, (uint)_PersistStorageType.PST_PROJECT_FILE, out outDir));
+                }
+                catch (System.Runtime.InteropServices.COMException e)
+                {
+                    if (e.ErrorCode == ERR_XML_ATTRIBUTE_NOT_FOUND)
+                    {
+                        return null;
+                    }
+                }
             }
             else
             {
@@ -90,6 +103,11 @@ namespace Microsoft.NodejsTools.TypeScript
             }
 
             var projHome = GetProjectHome(project);
+
+            if (projHome == null)
+            {
+                return null;
+            }
 
             return GetTypeScriptBackedJavaScriptFile(projHome, outDir, pathToFile);
         }
@@ -113,13 +131,17 @@ namespace Microsoft.NodejsTools.TypeScript
             {
                 return null;
             }
-            var projHome = props.Item("ProjectHome");
-            if (projHome == null)
+
+            try
             {
+                var projHome = props.Item("ProjectHome");
+                return projHome == null ? null : projHome.Value as string;
+            }
+            catch (ArgumentException)
+            {
+                // EnvDTE.Properties.Item may throw ArgumentException if the property is not found
                 return null;
             }
-
-            return projHome.Value as string;
         }
 #endif
     }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/731590 (more details in bug)

`GetTestProjectFromFile` can return projects that are not NTVS projects. Later we try to get the `ProjectHome` property from that project, which throws because that property isn't necessarily defined on every project. Per contract `EnvDTE.Properties.Item` throws `ArgumentException` if the property isn't found. 

The exception _can_ propagate and cause VS to crash, depending on context. In most cases it seems to be swallowed further up the stack, but it really should be handled at the originating site.

A similar thing will happen when getting the `TypeScriptOutDir` property. Some project types (e.g. ASP.NET with .NET Framework) will throw a `COMException` when the property isn't found. This should also be handled.

To handle these exceptions, the most sensible thing to do in this context would be to ignore the notification since the project clearly isn't supported. There is probably a smarter solution here that would prevent the notifications from getting fired in the first place, but I'm not familiar enough with the design to think of it.