### PR TITLE
Make VSHPROPID_IsNonSearchable return true for project files

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -174,6 +174,16 @@ namespace Microsoft.VisualStudioTools.Project
         public override bool IsShowingAllFiles => this.isShowingAllFiles;
 
         /// <summary>
+        /// Returns true if the item should be included in search results
+        /// </summary>
+        /// 
+        // Starting with 16.0 Preview 2, it is important for the
+        // project to report as not searchable. Otherwise, find in
+        // files will return results in project file, and IsItemDirty
+        // and SaveItem won't work properly.
+        public override bool IsSearchable => false;
+
+        /// <summary>
         /// Since we appended the language images to the base image list in the constructor,
         /// this should be the offset in the ImageList of the langauge project icon.
         /// </summary>


### PR DESCRIPTION
This fix is copied from https://github.com/Microsoft/PTVS/pull/4910 and fixes the exact same issue.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/756502 among others (described in comment and linked PTVS issue).