### PR TITLE
Fix a deadlock when updating test files and directories

### DIFF
--- a/Nodejs/Product/TestAdapterImpl/TestFilesUpdateWatcher.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestFilesUpdateWatcher.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
@@ -86,11 +87,17 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
         {
-            for (var i = 0; i < cChanges; i++)
+            return ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                this.FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(rgpszFile[i], ConvertVSFILECHANGEFLAGS(rggrfChange[i])));
-            }
-            return VSConstants.S_OK;
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                for (var i = 0; i < cChanges; i++)
+                {
+                    this.FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(rgpszFile[i], ConvertVSFILECHANGEFLAGS(rggrfChange[i])));
+                }
+
+                return VSConstants.S_OK;
+            });
         }
 
         public int DirectoryChanged(string directory)
@@ -115,11 +122,17 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         public int DirectoryChangedEx2(string directory, uint numberOfFilesChanged, string[] filesChanged, uint[] flags)
         {
-            for (var i = 0; i < numberOfFilesChanged; i++)
+            return ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                this.FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(filesChanged[i], ConvertVSFILECHANGEFLAGS(flags[i])));
-            }
-            return VSConstants.S_OK;
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                for (var i = 0; i < numberOfFilesChanged; i++)
+                {
+                    this.FileChangedEvent?.Invoke(this, new TestFileChangedEventArgs(filesChanged[i], ConvertVSFILECHANGEFLAGS(flags[i])));
+                }
+
+                return VSConstants.S_OK;
+            });
         }
 
         private static WatcherChangeTypes ConvertVSFILECHANGEFLAGS(uint flag)


### PR DESCRIPTION
This is a deadlock between the main thread (which is blocked on JTF.Run) and a background thread handling a file change notification (which is trying to get back to the main thread via RPC to get a service).

The change will switch to the main thread as soon as FilesChanged and DirectoryChangedEx2 had been called.