### PR TITLE
Refactored ProcessOutput.Run to not use cmd.exe

### DIFF
--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -138,14 +138,12 @@ namespace Microsoft.VisualStudioTools.Project
                 throw new ArgumentException("Filename required", nameof(filename));
             }
 
-            var psi = new ProcessStartInfo("cmd.exe")
+            var psi = new ProcessStartInfo(filename)
             {
-                Arguments = string.Format(@"/S /C pushd {0} & {1} {2}",
-                    QuoteSingleArgument(workingDirectory),
-                    QuoteSingleArgument(filename),
-                    GetArguments(arguments, quoteArgs)),
+                Arguments = GetArguments(arguments, quoteArgs),
                 CreateNoWindow = !visible,
-                UseShellExecute = false
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory
             };
 
             if (!visible || (redirector != null))


### PR DESCRIPTION
Removes running `cmd.exe` from `ProcessOutput.Run`.

There is two other places where `cmd.exe` is runned but I believe we want to do that. Also the full path is qualified.

- https://github.com/Microsoft/nodejstools/blob/a87694461411af88c655641f6ca72af8455aeb37/Nodejs/Product/Nodejs/SharedProject/CommonFolderNode.cs#L98
- https://github.com/Microsoft/nodejstools/blob/a87694461411af88c655641f6ca72af8455aeb37/Nodejs/Product/Nodejs/SharedProject/HierarchyNode.cs#L1581