### PR TITLE
Handle beginning of list in span list search

### DIFF
--- a/Nodejs/Product/Nodejs/Repl/ReplOutputClassifier.cs
+++ b/Nodejs/Product/Nodejs/Repl/ReplOutputClassifier.cs
@@ -48,6 +48,9 @@ namespace Microsoft.NodejsTools.Repl
             if (startIndex < 0)
             {
                 startIndex = ~startIndex - 1;
+                if (startIndex < 0) {
+                    startIndex = 0;
+                }
             }
 
             var spanEnd = span.End.Position;


### PR DESCRIPTION
Fixes #2138 

The `-1` here looks intentional, as this method tries to find spans that overlap with the one passed in - so it needs to also look at the element _before_ the start index of the passed in span.

Fix turned out to be identical to https://github.com/Microsoft/PTVS/pull/286/files