### PR TITLE
Fix Jasmine specFilter deprecation

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -113,7 +113,7 @@ function find_tests(testFileList, discoverResultFile, projectFolder) {
         return;
     }
     var jasmineInstance = initializeJasmine(Jasmine, projectFolder);
-    jasmineInstance.env.specFilter = _ => false;
+    setSpecFilter(jasmineInstance, _ => false);
 
     var testList = [];
     testFileList.split(";").forEach((testFile) => {
@@ -222,9 +222,7 @@ function run_tests(testCases, callback) {
     try {
         var jasmineInstance = initializeJasmine(Jasmine, projectFolder);
         jasmineInstance.configureDefaultReporter({ showColors: false });
-        jasmineInstance.env.specFilter = (spec) => {
-            return testNameList.hasOwnProperty(spec.getSpecName(spec));
-        };
+        setSpecFilter(jasmineInstance, spec => testNameList.hasOwnProperty(spec.getSpecName(spec)));
         jasmineInstance.addReporter(createCustomReporter(callback));
         jasmineInstance.execute(testFileList);
     }
@@ -232,4 +230,13 @@ function run_tests(testCases, callback) {
         logError("Execute test error:", ex);
     }
 }
+
+function setSpecFilter(jasmineInstance, specFilter) {
+    if (jasmineInstance.env.configure) {
+        jasmineInstance.env.configure({ specFilter });
+    } else {
+        jasmineInstance.env.specFilter = specFilter;
+    }
+}
+
 exports.run_tests = run_tests;


### PR DESCRIPTION
Jasmine's `specFilter` property have been deprecated from the `env` class and instead moved to the `configuration` interface.

This changes fixes the deprecation warning shown in Visual Studio. It also maintains backwards compatibility for older Jasmine versions.

Details: https://github.com/jasmine/jasmine/blob/0d6db64eb1346bd2d15c845fd02b435d76390815/src/core/Env.js#L163

![image](https://user-images.githubusercontent.com/13305542/53995718-cbf70800-40ea-11e9-8934-647bc674d31f.png)
