### PR TITLE
Fixes accessibility issues

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -71,7 +71,7 @@
                                 Visibility="{Binding HomepagesVisibility}"
                                 Orientation="Horizontal">
                                 <TextBlock Margin="0" FontWeight="Bold" xml:space="preserve" Text="{x:Static resx:NpmInstallWindowResources.HomepageLabel}" />
-                                <ItemsControl ItemsSource="{Binding Path=Homepages, Mode=OneWay}">
+                                <ItemsControl ItemsSource="{Binding Path=Homepages, Mode=OneWay}" IsTabStop="False">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <vsui:HyperlinkButton

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -82,7 +82,6 @@
                                                     KeyboardNavigation.TabIndex="8"
                                                     Margin="0"
                                                     Padding="0" />
-
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -33,11 +33,11 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            
+
             <x:Array Type="ComboBoxItem" x:Key="LatestVersionComboItem">
                 <ComboBoxItem Content="{x:Static resx:NpmInstallWindowResources.LatestVersion }" />
             </x:Array>
-            
+
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.NodejsTools;component/SharedProject/Wpf/Controls.xaml" />
                 <ResourceDictionary>
@@ -74,13 +74,15 @@
                                 <ItemsControl ItemsSource="{Binding Path=Homepages, Mode=OneWay}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
-                                            <Button Style="{StaticResource NavigationButton}"
+                                            <vsui:HyperlinkButton
+                                                    Style="{StaticResource HyperlinkButton}"
                                                     Content="{Binding Mode=OneWay}"
                                                     Command="{x:Static npmUi:NpmPackageInstallViewModel.OpenHomepageCommand}"
                                                     CommandParameter="{Binding}"
                                                     KeyboardNavigation.TabIndex="8"
                                                     Margin="0"
-                                                    Padding="0"/>
+                                                    Padding="0" />
+
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
@@ -160,7 +162,7 @@
                                            FontWeight="Bold"
                                            Foreground="Red"
                                            Text="{x:Static resx:NpmInstallWindowResources.MissingLocallyMessage}" />
-                                
+
                                 <TextBlock Grid.Column="1"
                                            x:Name="LocalInstallOutOfDateMessage"
                                            Visibility="Collapsed"
@@ -432,7 +434,7 @@
                                 IsDefault="True"
                                 Content="{x:Static resx:NpmInstallWindowResources.InstallPackageButtonLabel}" />
 
-                        <Button Style="{StaticResource NavigationButton}" VerticalAlignment="Center" Margin="5 0 0 0" 
+                        <Button VerticalAlignment="Center" Margin="5 0 0 0" 
                                 Click="ResetOptionsButton_Click" KeyboardNavigation.TabIndex="14"
                                 Content="{x:Static resx:NpmInstallWindowResources.ResetOptionsButtonLabel}" />
                     </StackPanel>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NodejsTools.NpmUI
                 cmdr.CommandCompleted -= Cmdr_CommandCompleted;
             }
 
-            void Cmdr_CommandStarted(object sender, EventArgs e)
+            void Cmdr_CommandStarted(object sender, NpmCommandStartedEventArgs e)
             {
                 this.CommandStarted?.Invoke(this, e);
             }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -248,12 +248,15 @@ namespace Microsoft.NodejsTools.Project
             WriteNpmLogToOutputWindow(TrimLastNewline(args.LogText));
         }
 
-        private void NpmController_CommandStarted(object sender, EventArgs e)
+        private void NpmController_CommandStarted(object sender, NpmCommandStartedEventArgs e)
         {
             StopNpmIdleTimer();
             lock (this._commandCountLock)
             {
                 ++this._npmCommandsExecuting;
+
+                var message = string.Format(CultureInfo.CurrentCulture, Resources.NpmCommandStarted, e.CommandText);
+                ForceUpdateStatusBarWithNpmActivitySafe(message);
             }
         }
 

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -271,11 +271,11 @@
             this.overallPanel.Controls.Add(this._debuggerPortLabel, 0, 12);
             this.overallPanel.Controls.Add(this._debuggerPort, 1, 12);
             this.overallPanel.Controls.Add(this.testHeaderTableLayoutPanel, 0, 13);
-            this.overallPanel.Controls.Add(this._testRootLabel, 0, 14);
-            this.overallPanel.Controls.Add(this._testRoot, 1, 14);
-            this.overallPanel.Controls.Add(this._browseTestroot, 2, 14);
-            this.overallPanel.Controls.Add(this._testFrameworkLabel, 0, 15);
-            this.overallPanel.Controls.Add(this._frameworkSelector, 1, 15);
+            this.overallPanel.Controls.Add(this._testFrameworkLabel, 0, 14);
+            this.overallPanel.Controls.Add(this._frameworkSelector, 1, 14);
+            this.overallPanel.Controls.Add(this._testRootLabel, 0, 15);
+            this.overallPanel.Controls.Add(this._testRoot, 1, 15);
+            this.overallPanel.Controls.Add(this._browseTestroot, 2, 15);
             this.overallPanel.Location = new System.Drawing.Point(0, 0);
             this.overallPanel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
             this.overallPanel.Name = "overallPanel";
@@ -484,46 +484,15 @@
             this.testHeaderLabelLine.Size = new System.Drawing.Size(730, 1);
             this.testHeaderLabelLine.TabIndex = 1;
             // 
-            // _testRootLabel
-            // 
-            this._testRootLabel.AutoSize = true;
-            this._testRootLabel.Location = new System.Drawing.Point(3, 398);
-            this._testRootLabel.Margin = new System.Windows.Forms.Padding(3);
-            this._testRootLabel.Name = "_testRootLabel";
-            this._testRootLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
-            this._testRootLabel.Size = new System.Drawing.Size(89, 13);
-            this._testRootLabel.TabIndex = 23;
-            this._testRootLabel.Text = "_testRootLabel";
-            // 
-            // _testRoot
-            // 
-            this._testRoot.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._testRoot.Location = new System.Drawing.Point(181, 398);
-            this._testRoot.Name = "_testRoot";
-            this._testRoot.Size = new System.Drawing.Size(620, 20);
-            this._testRoot.TabIndex = 24;
-            // 
-            // _browseTestroot
-            // 
-            this._browseTestroot.AutoSize = true;
-            this._browseTestroot.Location = new System.Drawing.Point(807, 398);
-            this._browseTestroot.Name = "_browseTestroot";
-            this._browseTestroot.Size = new System.Drawing.Size(26, 23);
-            this._browseTestroot.TabIndex = 25;
-            this._browseTestroot.Text = "...";
-            this._browseTestroot.UseVisualStyleBackColor = true;
-            this._browseTestroot.Click += new System.EventHandler(this.BrowseTestRootClick);
-            // 
             // _testFrameworkLabel
             // 
             this._testFrameworkLabel.AutoSize = true;
-            this._testFrameworkLabel.Location = new System.Drawing.Point(3, 427);
+            this._testFrameworkLabel.Location = new System.Drawing.Point(3, 398);
             this._testFrameworkLabel.Margin = new System.Windows.Forms.Padding(3);
             this._testFrameworkLabel.Name = "_testFrameworkLabel";
             this._testFrameworkLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
             this._testFrameworkLabel.Size = new System.Drawing.Size(118, 13);
-            this._testFrameworkLabel.TabIndex = 26;
+            this._testFrameworkLabel.TabIndex = 23;
             this._testFrameworkLabel.Text = "_testFrameworkLabel";
             // 
             // _frameworkSelector
@@ -532,12 +501,43 @@
             this._frameworkSelector.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this._frameworkSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._frameworkSelector.FormattingEnabled = true;
-            this._frameworkSelector.Location = new System.Drawing.Point(181, 427);
+            this._frameworkSelector.Location = new System.Drawing.Point(181, 398);
             this._frameworkSelector.Name = "_frameworkSelector";
             this._frameworkSelector.Size = new System.Drawing.Size(196, 21);
             this._frameworkSelector.Sorted = true;
-            this._frameworkSelector.TabIndex = 28;
+            this._frameworkSelector.TabIndex = 24;
             this._frameworkSelector.SelectedIndexChanged += new System.EventHandler(this.Changed);
+            // 
+            // _testRootLabel
+            // 
+            this._testRootLabel.AutoSize = true;
+            this._testRootLabel.Location = new System.Drawing.Point(3, 425);
+            this._testRootLabel.Margin = new System.Windows.Forms.Padding(3);
+            this._testRootLabel.Name = "_testRootLabel";
+            this._testRootLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
+            this._testRootLabel.Size = new System.Drawing.Size(89, 13);
+            this._testRootLabel.TabIndex = 26;
+            this._testRootLabel.Text = "_testRootLabel";
+            // 
+            // _testRoot
+            // 
+            this._testRoot.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._testRoot.Location = new System.Drawing.Point(181, 425);
+            this._testRoot.Name = "_testRoot";
+            this._testRoot.Size = new System.Drawing.Size(620, 20);
+            this._testRoot.TabIndex = 27;
+            // 
+            // _browseTestroot
+            // 
+            this._browseTestroot.AutoSize = true;
+            this._browseTestroot.Location = new System.Drawing.Point(807, 425);
+            this._browseTestroot.Name = "_browseTestroot";
+            this._browseTestroot.Size = new System.Drawing.Size(26, 23);
+            this._browseTestroot.TabIndex = 28;
+            this._browseTestroot.Text = "...";
+            this._browseTestroot.UseVisualStyleBackColor = true;
+            this._browseTestroot.Click += new System.EventHandler(this.BrowseTestRootClick);
             // 
             // NodejsGeneralPropertyPageControl
             // 

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -67,14 +67,12 @@
             this._testFrameworkLabel = new System.Windows.Forms.Label();
             this._frameworkSelector = new System.Windows.Forms.ComboBox();
             this._tooltip = new System.Windows.Forms.ToolTip(this.components);
-            this._nodeExeErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             startActionTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             nodeHeaderTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             startActionTableLayoutPanel.SuspendLayout();
             nodeHeaderTableLayoutPanel.SuspendLayout();
             this.overallPanel.SuspendLayout();
             this.testHeaderTableLayoutPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).BeginInit();
             this.SuspendLayout();
             // 
             // startActionTableLayoutPanel
@@ -330,7 +328,7 @@
             this._workingDir.Name = "_workingDir";
             this._workingDir.Size = new System.Drawing.Size(620, 20);
             this._workingDir.TabIndex = 7;
-            this._workingDir.TextChanged += new System.EventHandler(this.WorkingDirChanged);
+            this._workingDir.LostFocus += new System.EventHandler(this.WorkingDirChanged);
             // 
             // _browseDirectory
             // 
@@ -359,7 +357,7 @@
             this._nodejsPort.Name = "_nodejsPort";
             this._nodejsPort.Size = new System.Drawing.Size(105, 20);
             this._nodejsPort.TabIndex = 12;
-            this._nodejsPort.TextChanged += new System.EventHandler(this.PortChanged);
+            this._nodejsPort.LostFocus += new System.EventHandler(this.PortChanged);
             // 
             // _envVars
             // 
@@ -419,7 +417,7 @@
             this._nodeExePath.Name = "_nodeExePath";
             this._nodeExePath.Size = new System.Drawing.Size(620, 20);
             this._nodeExePath.TabIndex = 17;
-            this._nodeExePath.TextChanged += new System.EventHandler(this.NodeExePathChanged);
+            this._nodeExePath.LostFocus += new System.EventHandler(this.NodeExePathChanged);
             // 
             // _browsePath
             // 
@@ -448,7 +446,7 @@
             this._debuggerPort.Name = "_debuggerPort";
             this._debuggerPort.Size = new System.Drawing.Size(105, 20);
             this._debuggerPort.TabIndex = 20;
-            this._debuggerPort.TextChanged += new System.EventHandler(this.PortChanged);
+            this._debuggerPort.LostFocus += new System.EventHandler(this.PortChanged);
             // 
             // testHeaderTableLayoutPanel
             // 
@@ -541,10 +539,6 @@
             this._frameworkSelector.TabIndex = 28;
             this._frameworkSelector.SelectedIndexChanged += new System.EventHandler(this.Changed);
             // 
-            // _nodeExeErrorProvider
-            // 
-            this._nodeExeErrorProvider.ContainerControl = this;
-            // 
             // NodejsGeneralPropertyPageControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -562,7 +556,6 @@
             this.overallPanel.PerformLayout();
             this.testHeaderTableLayoutPanel.ResumeLayout(false);
             this.testHeaderTableLayoutPanel.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._nodeExeErrorProvider)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -584,7 +577,6 @@
         private System.Windows.Forms.TextBox _envVars;
         private System.Windows.Forms.CheckBox _startBrowserCheckBox;
         private System.Windows.Forms.ToolTip _tooltip;
-        private System.Windows.Forms.ErrorProvider _nodeExeErrorProvider;
         private System.Windows.Forms.Label _nodeArgumentsLabel;
         private System.Windows.Forms.Label _scriptLabel;
         private System.Windows.Forms.Label _scriptArgsLabel;

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -225,7 +225,7 @@
             this._debuggerPortLabel.Name = "_debuggerPortLabel";
             this._debuggerPortLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
             this._debuggerPortLabel.Size = new System.Drawing.Size(113, 13);
-            this._debuggerPortLabel.TabIndex = 21;
+            this._debuggerPortLabel.TabIndex = 20;
             this._debuggerPortLabel.Text = "_debuggerPortLabel";
             // 
             // _envVarsLabel
@@ -445,7 +445,7 @@
             this._debuggerPort.Location = new System.Drawing.Point(181, 353);
             this._debuggerPort.Name = "_debuggerPort";
             this._debuggerPort.Size = new System.Drawing.Size(105, 20);
-            this._debuggerPort.TabIndex = 20;
+            this._debuggerPort.TabIndex = 21;
             this._debuggerPort.LostFocus += new System.EventHandler(this.PortChanged);
             // 
             // testHeaderTableLayoutPanel

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -86,11 +86,11 @@
             startActionTableLayoutPanel.Controls.Add(this.startActionHeaderLabelLine, 1, 0);
             startActionTableLayoutPanel.Controls.Add(this._startActionHeaderLabel, 0, 0);
             startActionTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
-            startActionTableLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            startActionTableLayoutPanel.Margin = new System.Windows.Forms.Padding(0, 0, 0, 6);
             startActionTableLayoutPanel.Name = "startActionTableLayoutPanel";
             startActionTableLayoutPanel.RowCount = 1;
             startActionTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            startActionTableLayoutPanel.Size = new System.Drawing.Size(843, 13);
+            startActionTableLayoutPanel.Size = new System.Drawing.Size(493, 13);
             startActionTableLayoutPanel.TabIndex = 0;
             // 
             // startActionHeaderLabelLine
@@ -100,7 +100,7 @@
             this.startActionHeaderLabelLine.BackColor = System.Drawing.SystemColors.ControlDark;
             this.startActionHeaderLabelLine.Location = new System.Drawing.Point(130, 6);
             this.startActionHeaderLabelLine.Name = "startActionHeaderLabelLine";
-            this.startActionHeaderLabelLine.Size = new System.Drawing.Size(710, 1);
+            this.startActionHeaderLabelLine.Size = new System.Drawing.Size(360, 1);
             this.startActionHeaderLabelLine.TabIndex = 1;
             // 
             // _startActionHeaderLabel
@@ -123,12 +123,12 @@
             nodeHeaderTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             nodeHeaderTableLayoutPanel.Controls.Add(this.nodeHeaderLabelLine, 1, 0);
             nodeHeaderTableLayoutPanel.Controls.Add(this._nodeHeaderLabel, 0, 0);
-            nodeHeaderTableLayoutPanel.Location = new System.Drawing.Point(0, 259);
-            nodeHeaderTableLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            nodeHeaderTableLayoutPanel.Location = new System.Drawing.Point(0, 274);
+            nodeHeaderTableLayoutPanel.Margin = new System.Windows.Forms.Padding(0, 9, 0, 6);
             nodeHeaderTableLayoutPanel.Name = "nodeHeaderTableLayoutPanel";
             nodeHeaderTableLayoutPanel.RowCount = 1;
             nodeHeaderTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            nodeHeaderTableLayoutPanel.Size = new System.Drawing.Size(843, 13);
+            nodeHeaderTableLayoutPanel.Size = new System.Drawing.Size(493, 13);
             nodeHeaderTableLayoutPanel.TabIndex = 0;
             // 
             // nodeHeaderLabelLine
@@ -138,7 +138,7 @@
             this.nodeHeaderLabelLine.BackColor = System.Drawing.SystemColors.ControlDark;
             this.nodeHeaderLabelLine.Location = new System.Drawing.Point(104, 6);
             this.nodeHeaderLabelLine.Name = "nodeHeaderLabelLine";
-            this.nodeHeaderLabelLine.Size = new System.Drawing.Size(736, 1);
+            this.nodeHeaderLabelLine.Size = new System.Drawing.Size(386, 1);
             this.nodeHeaderLabelLine.TabIndex = 16;
             // 
             // _nodeHeaderLabel
@@ -154,7 +154,7 @@
             // _nodeArgumentsLabel
             // 
             this._nodeArgumentsLabel.AutoSize = true;
-            this._nodeArgumentsLabel.Location = new System.Drawing.Point(3, 327);
+            this._nodeArgumentsLabel.Location = new System.Drawing.Point(3, 348);
             this._nodeArgumentsLabel.Margin = new System.Windows.Forms.Padding(3);
             this._nodeArgumentsLabel.Name = "_nodeArgumentsLabel";
             this._nodeArgumentsLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -165,7 +165,7 @@
             // _scriptLabel
             // 
             this._scriptLabel.AutoSize = true;
-            this._scriptLabel.Location = new System.Drawing.Point(3, 16);
+            this._scriptLabel.Location = new System.Drawing.Point(3, 22);
             this._scriptLabel.Margin = new System.Windows.Forms.Padding(3);
             this._scriptLabel.Name = "_scriptLabel";
             this._scriptLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -176,7 +176,7 @@
             // _scriptArgsLabel
             // 
             this._scriptArgsLabel.AutoSize = true;
-            this._scriptArgsLabel.Location = new System.Drawing.Point(3, 42);
+            this._scriptArgsLabel.Location = new System.Drawing.Point(3, 48);
             this._scriptArgsLabel.Margin = new System.Windows.Forms.Padding(3);
             this._scriptArgsLabel.Name = "_scriptArgsLabel";
             this._scriptArgsLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -187,7 +187,7 @@
             // _workingDirLabel
             // 
             this._workingDirLabel.AutoSize = true;
-            this._workingDirLabel.Location = new System.Drawing.Point(3, 68);
+            this._workingDirLabel.Location = new System.Drawing.Point(3, 74);
             this._workingDirLabel.Margin = new System.Windows.Forms.Padding(3);
             this._workingDirLabel.Name = "_workingDirLabel";
             this._workingDirLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -198,7 +198,7 @@
             // _launchUrlLabel
             // 
             this._launchUrlLabel.AutoSize = true;
-            this._launchUrlLabel.Location = new System.Drawing.Point(3, 97);
+            this._launchUrlLabel.Location = new System.Drawing.Point(3, 103);
             this._launchUrlLabel.Margin = new System.Windows.Forms.Padding(3);
             this._launchUrlLabel.Name = "_launchUrlLabel";
             this._launchUrlLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -209,7 +209,7 @@
             // _nodePortLabel
             // 
             this._nodePortLabel.AutoSize = true;
-            this._nodePortLabel.Location = new System.Drawing.Point(3, 123);
+            this._nodePortLabel.Location = new System.Drawing.Point(3, 129);
             this._nodePortLabel.Margin = new System.Windows.Forms.Padding(3);
             this._nodePortLabel.Name = "_nodePortLabel";
             this._nodePortLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -220,7 +220,7 @@
             // _debuggerPortLabel
             // 
             this._debuggerPortLabel.AutoSize = true;
-            this._debuggerPortLabel.Location = new System.Drawing.Point(3, 353);
+            this._debuggerPortLabel.Location = new System.Drawing.Point(3, 374);
             this._debuggerPortLabel.Margin = new System.Windows.Forms.Padding(3);
             this._debuggerPortLabel.Name = "_debuggerPortLabel";
             this._debuggerPortLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -231,7 +231,7 @@
             // _envVarsLabel
             // 
             this._envVarsLabel.AutoSize = true;
-            this._envVarsLabel.Location = new System.Drawing.Point(3, 149);
+            this._envVarsLabel.Location = new System.Drawing.Point(3, 155);
             this._envVarsLabel.Margin = new System.Windows.Forms.Padding(3);
             this._envVarsLabel.Name = "_envVarsLabel";
             this._envVarsLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -297,43 +297,37 @@
             this.overallPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.overallPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.overallPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.overallPanel.Size = new System.Drawing.Size(843, 500);
+            this.overallPanel.Size = new System.Drawing.Size(493, 481);
             this.overallPanel.TabIndex = 0;
             // 
             // _scriptFile
             // 
-            this._scriptFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptFile.Location = new System.Drawing.Point(181, 16);
+            this._scriptFile.Location = new System.Drawing.Point(181, 22);
             this._scriptFile.Name = "_scriptFile";
-            this._scriptFile.Size = new System.Drawing.Size(620, 20);
+            this._scriptFile.Size = new System.Drawing.Size(228, 20);
             this._scriptFile.TabIndex = 3;
             this._scriptFile.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _scriptArguments
             // 
-            this._scriptArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._scriptArguments.Location = new System.Drawing.Point(181, 42);
+            this._scriptArguments.Location = new System.Drawing.Point(181, 48);
             this._scriptArguments.Name = "_scriptArguments";
-            this._scriptArguments.Size = new System.Drawing.Size(620, 20);
+            this._scriptArguments.Size = new System.Drawing.Size(228, 20);
             this._scriptArguments.TabIndex = 5;
             this._scriptArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _workingDir
             // 
-            this._workingDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._workingDir.Location = new System.Drawing.Point(181, 68);
+            this._workingDir.Location = new System.Drawing.Point(181, 74);
             this._workingDir.Name = "_workingDir";
-            this._workingDir.Size = new System.Drawing.Size(620, 20);
+            this._workingDir.Size = new System.Drawing.Size(228, 20);
             this._workingDir.TabIndex = 7;
             this._workingDir.LostFocus += new System.EventHandler(this.WorkingDirChanged);
             // 
             // _browseDirectory
             // 
             this._browseDirectory.AutoSize = true;
-            this._browseDirectory.Location = new System.Drawing.Point(807, 68);
+            this._browseDirectory.Location = new System.Drawing.Point(415, 74);
             this._browseDirectory.Name = "_browseDirectory";
             this._browseDirectory.Size = new System.Drawing.Size(26, 23);
             this._browseDirectory.TabIndex = 8;
@@ -343,17 +337,15 @@
             // 
             // _launchUrl
             // 
-            this._launchUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._launchUrl.Location = new System.Drawing.Point(181, 97);
+            this._launchUrl.Location = new System.Drawing.Point(181, 103);
             this._launchUrl.Name = "_launchUrl";
-            this._launchUrl.Size = new System.Drawing.Size(620, 20);
+            this._launchUrl.Size = new System.Drawing.Size(228, 20);
             this._launchUrl.TabIndex = 10;
             this._launchUrl.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _nodejsPort
             // 
-            this._nodejsPort.Location = new System.Drawing.Point(181, 123);
+            this._nodejsPort.Location = new System.Drawing.Point(181, 129);
             this._nodejsPort.Name = "_nodejsPort";
             this._nodejsPort.Size = new System.Drawing.Size(105, 20);
             this._nodejsPort.TabIndex = 12;
@@ -361,13 +353,11 @@
             // 
             // _envVars
             // 
-            this._envVars.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._envVars.Location = new System.Drawing.Point(181, 149);
+            this._envVars.Location = new System.Drawing.Point(181, 155);
             this._envVars.Multiline = true;
             this._envVars.Name = "_envVars";
             this._envVars.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this._envVars.Size = new System.Drawing.Size(620, 84);
+            this._envVars.Size = new System.Drawing.Size(228, 84);
             this._envVars.TabIndex = 14;
             this._envVars.TextChanged += new System.EventHandler(this.Changed);
             // 
@@ -375,7 +365,7 @@
             // 
             this._startBrowserCheckBox.AutoSize = true;
             this.overallPanel.SetColumnSpan(this._startBrowserCheckBox, 3);
-            this._startBrowserCheckBox.Location = new System.Drawing.Point(3, 239);
+            this._startBrowserCheckBox.Location = new System.Drawing.Point(3, 245);
             this._startBrowserCheckBox.Name = "_startBrowserCheckBox";
             this._startBrowserCheckBox.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
             this._startBrowserCheckBox.Size = new System.Drawing.Size(149, 17);
@@ -387,7 +377,7 @@
             // _saveInProjectFileCheckBox
             // 
             this._saveInProjectFileCheckBox.AutoSize = true;
-            this._saveInProjectFileCheckBox.Location = new System.Drawing.Point(3, 275);
+            this._saveInProjectFileCheckBox.Location = new System.Drawing.Point(3, 296);
             this._saveInProjectFileCheckBox.Name = "_saveInProjectFileCheckBox";
             this._saveInProjectFileCheckBox.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
             this._saveInProjectFileCheckBox.Size = new System.Drawing.Size(172, 17);
@@ -399,7 +389,7 @@
             // _nodeExePathLabel
             // 
             this._nodeExePathLabel.AutoSize = true;
-            this._nodeExePathLabel.Location = new System.Drawing.Point(3, 298);
+            this._nodeExePathLabel.Location = new System.Drawing.Point(3, 319);
             this._nodeExePathLabel.Margin = new System.Windows.Forms.Padding(3);
             this._nodeExePathLabel.Name = "_nodeExePathLabel";
             this._nodeExePathLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -409,20 +399,18 @@
             // 
             // _nodeExePath
             // 
-            this._nodeExePath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this._nodeExePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this._nodeExePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystem;
-            this._nodeExePath.Location = new System.Drawing.Point(181, 298);
+            this._nodeExePath.Location = new System.Drawing.Point(181, 319);
             this._nodeExePath.Name = "_nodeExePath";
-            this._nodeExePath.Size = new System.Drawing.Size(620, 20);
+            this._nodeExePath.Size = new System.Drawing.Size(228, 20);
             this._nodeExePath.TabIndex = 17;
             this._nodeExePath.LostFocus += new System.EventHandler(this.NodeExePathChanged);
             // 
             // _browsePath
             // 
             this._browsePath.AutoSize = true;
-            this._browsePath.Location = new System.Drawing.Point(807, 298);
+            this._browsePath.Location = new System.Drawing.Point(415, 319);
             this._browsePath.Name = "_browsePath";
             this._browsePath.Size = new System.Drawing.Size(26, 23);
             this._browsePath.TabIndex = 18;
@@ -432,17 +420,15 @@
             // 
             // _nodeExeArguments
             // 
-            this._nodeExeArguments.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._nodeExeArguments.Location = new System.Drawing.Point(181, 327);
+            this._nodeExeArguments.Location = new System.Drawing.Point(181, 348);
             this._nodeExeArguments.Name = "_nodeExeArguments";
-            this._nodeExeArguments.Size = new System.Drawing.Size(620, 20);
+            this._nodeExeArguments.Size = new System.Drawing.Size(228, 20);
             this._nodeExeArguments.TabIndex = 19;
             this._nodeExeArguments.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _debuggerPort
             // 
-            this._debuggerPort.Location = new System.Drawing.Point(181, 353);
+            this._debuggerPort.Location = new System.Drawing.Point(181, 374);
             this._debuggerPort.Name = "_debuggerPort";
             this._debuggerPort.Size = new System.Drawing.Size(105, 20);
             this._debuggerPort.TabIndex = 21;
@@ -458,11 +444,12 @@
             this.testHeaderTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.testHeaderTableLayoutPanel.Controls.Add(this._TestHeaderLabel, 0, 0);
             this.testHeaderTableLayoutPanel.Controls.Add(this.testHeaderLabelLine, 1, 0);
-            this.testHeaderTableLayoutPanel.Location = new System.Drawing.Point(3, 379);
+            this.testHeaderTableLayoutPanel.Location = new System.Drawing.Point(0, 406);
+            this.testHeaderTableLayoutPanel.Margin = new System.Windows.Forms.Padding(0, 9, 0, 6);
             this.testHeaderTableLayoutPanel.Name = "testHeaderTableLayoutPanel";
             this.testHeaderTableLayoutPanel.RowCount = 1;
             this.testHeaderTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.testHeaderTableLayoutPanel.Size = new System.Drawing.Size(837, 13);
+            this.testHeaderTableLayoutPanel.Size = new System.Drawing.Size(493, 13);
             this.testHeaderTableLayoutPanel.TabIndex = 22;
             // 
             // _TestHeaderLabel
@@ -481,7 +468,7 @@
             this.testHeaderLabelLine.BackColor = System.Drawing.SystemColors.ControlDark;
             this.testHeaderLabelLine.Location = new System.Drawing.Point(104, 6);
             this.testHeaderLabelLine.Name = "testHeaderLabelLine";
-            this.testHeaderLabelLine.Size = new System.Drawing.Size(730, 1);
+            this.testHeaderLabelLine.Size = new System.Drawing.Size(386, 1);
             this.testHeaderLabelLine.TabIndex = 1;
             // 
             // _testFrameworkLabel
@@ -511,7 +498,7 @@
             // _testRootLabel
             // 
             this._testRootLabel.AutoSize = true;
-            this._testRootLabel.Location = new System.Drawing.Point(3, 425);
+            this._testRootLabel.Location = new System.Drawing.Point(3, 428);
             this._testRootLabel.Margin = new System.Windows.Forms.Padding(3);
             this._testRootLabel.Name = "_testRootLabel";
             this._testRootLabel.Padding = new System.Windows.Forms.Padding(10, 0, 0, 0);
@@ -521,17 +508,15 @@
             // 
             // _testRoot
             // 
-            this._testRoot.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._testRoot.Location = new System.Drawing.Point(181, 425);
+            this._testRoot.Location = new System.Drawing.Point(181, 428);
             this._testRoot.Name = "_testRoot";
-            this._testRoot.Size = new System.Drawing.Size(620, 20);
+            this._testRoot.Size = new System.Drawing.Size(228, 20);
             this._testRoot.TabIndex = 27;
             // 
             // _browseTestroot
             // 
             this._browseTestroot.AutoSize = true;
-            this._browseTestroot.Location = new System.Drawing.Point(807, 425);
+            this._browseTestroot.Location = new System.Drawing.Point(415, 428);
             this._browseTestroot.Name = "_browseTestroot";
             this._browseTestroot.Size = new System.Drawing.Size(26, 23);
             this._browseTestroot.TabIndex = 28;
@@ -541,13 +526,10 @@
             // 
             // NodejsGeneralPropertyPageControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.Controls.Add(this.overallPanel);
-            this.MinimumSize = new System.Drawing.Size(850, 550);
             this.Name = "NodejsGeneralPropertyPageControl";
-            this.Size = new System.Drawing.Size(850, 550);
+            this.Size = new System.Drawing.Size(493, 481);
             startActionTableLayoutPanel.ResumeLayout(false);
             startActionTableLayoutPanel.PerformLayout();
             nodeHeaderTableLayoutPanel.ResumeLayout(false);

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -25,9 +25,6 @@ namespace Microsoft.NodejsTools.Project
 
             LocalizeLabels();
             AddToolTips();
-
-            this._nodeExeErrorProvider.SetIconAlignment(this._nodeExePath, ErrorIconAlignment.MiddleLeft);
-            this._nodeExeErrorProvider.SetIconAlignment(this._workingDir, ErrorIconAlignment.MiddleLeft);
         }
 
         public NodejsGeneralPropertyPageControl(NodejsGeneralPropertyPage page) : this()
@@ -250,14 +247,11 @@ namespace Microsoft.NodejsTools.Project
 
         private void NodeExePathChanged(object sender, EventArgs e)
         {
-            if (string.IsNullOrEmpty(this._nodeExePath.Text) || this._nodeExePath.Text.Contains("$(") ||
-                File.Exists(Nodejs.GetAbsoluteNodeExePath(this._propPage.Project.ProjectHome, this._nodeExePath.Text)))
+            if (!string.IsNullOrEmpty(this._nodeExePath.Text)
+                && !this._nodeExePath.Text.Contains("$(")
+                && !File.Exists(Nodejs.GetAbsoluteNodeExePath(this._propPage.Project.ProjectHome, this._nodeExePath.Text)))
             {
-                this._nodeExeErrorProvider.SetError(this._nodeExePath, string.Empty);
-            }
-            else
-            {
-                this._nodeExeErrorProvider.SetError(this._nodeExePath, Resources.NodeExePathNotFound);
+                DisplayWarning(Resources.NodeExePathNotFound);
             }
             Changed(sender, e);
         }
@@ -308,23 +302,26 @@ namespace Microsoft.NodejsTools.Project
             if (!textSender.Text.Contains("$(") &&
                 textSender.Text.Any(ch => !char.IsDigit(ch)))
             {
-                this._nodeExeErrorProvider.SetError(textSender, Resources.InvalidPortNumber);
-            }
-            else
-            {
-                this._nodeExeErrorProvider.SetError(textSender, string.Empty);
+                DisplayWarning(Resources.InvalidPortNumber);
             }
             Changed(sender, e);
         }
 
+        private static void DisplayWarning(string text)
+        {
+            MessageBox.Show(text, Resources.WarningDialogCaption, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
         private void WorkingDirChanged(object sender, EventArgs e)
         {
-            var errorMessage = ValidateWorkingDir(this._workingDir.Text) ? "" : Resources.WorkingDirInvalidOrMissing;
-            this._nodeExeErrorProvider.SetError(this._workingDir, errorMessage);
+            if (!IsValidWorkingDir(this._workingDir.Text))
+            {
+                DisplayWarning(Resources.WorkingDirInvalidOrMissing);
+            }
 
             Changed(sender, e);
 
-            bool ValidateWorkingDir(string workingDir)
+            bool IsValidWorkingDir(string workingDir)
             {
                 if (workingDir.Contains("$("))
                 {

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.resx
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.resx
@@ -126,7 +126,4 @@
   <metadata name="_tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="_nodeExeErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>110, 17</value>
-  </metadata>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -1519,7 +1519,7 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to St&amp;art web browser on launch.
+        ///   Looks up a localized string similar to Sta&amp;rt web browser on launch.
         /// </summary>
         internal static string PropertiesStartBrowser {
             get {
@@ -1895,6 +1895,15 @@ namespace Microsoft.NodejsTools {
         internal static string UpgradedEnvironmentVariables {
             get {
                 return ResourceManager.GetString("UpgradedEnvironmentVariables", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Microsoft Visual Studio.
+        /// </summary>
+        internal static string WarningDialogCaption {
+            get {
+                return ResourceManager.GetString("WarningDialogCaption", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/Resources.Designer.cs
+++ b/Nodejs/Product/Nodejs/Resources.Designer.cs
@@ -813,6 +813,15 @@ namespace Microsoft.NodejsTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} started..
+        /// </summary>
+        internal static string NpmCommandStarted {
+            get {
+                return ResourceManager.GetString("NpmCommandStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} completed with errors - see Output window for details.
         /// </summary>
         internal static string NpmCompletedWithErrors {

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -752,4 +752,8 @@ The following error occurred trying to execute npm.cmd:
     <value>Microsoft Visual Studio</value>
     <comment>Caption displayed on the error dialog of the project properties.</comment>
   </data>
+  <data name="NpmCommandStarted" xml:space="preserve">
+    <value>{0} started.</value>
+    <comment>Parameter would be an npm command parameters.</comment>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/Resources.resx
+++ b/Nodejs/Product/Nodejs/Resources.resx
@@ -565,7 +565,7 @@ The following error occurred trying to execute npm.cmd:
     <value>Script ar&amp;guments:</value>
   </data>
   <data name="PropertiesStartBrowser" xml:space="preserve">
-    <value>St&amp;art web browser on launch</value>
+    <value>Sta&amp;rt web browser on launch</value>
   </data>
   <data name="PropertiesWorkingDir" xml:space="preserve">
     <value>Working director&amp;y:</value>
@@ -747,5 +747,9 @@ The following error occurred trying to execute npm.cmd:
   </data>
   <data name="NpmIsInstalling" xml:space="preserve">
     <value>Debugging could not be started because npm is installing packages. Please wait until npm finishes and try again.</value>
+  </data>
+  <data name="WarningDialogCaption" xml:space="preserve">
+    <value>Microsoft Visual Studio</value>
+    <comment>Caption displayed on the error dialog of the project properties.</comment>
   </data>
 </root>

--- a/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
+++ b/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
-                    xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf">
+                    xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
+                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0">
 
     <Style x:Key="FocusVisualStyle" TargetType="{x:Type Control}">
         <Setter Property="Control.Template">
@@ -246,10 +247,8 @@
         </Style.Triggers>
     </Style>
 
-    <Style x:Key="NavigationButton" TargetType="{x:Type Button}">
+    <Style x:Key="HyperlinkButton" TargetType="{x:Type vsui:HyperlinkButton}">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HyperlinkKey}}" />
-        <Setter Property="HorizontalContentAlignment" Value="Center" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Template">
             <Setter.Value>
@@ -257,59 +256,13 @@
                     <ContentPresenter TextElement.Foreground="{TemplateBinding Foreground}" RecognizesAccessKey="True" Height="Auto">
                         <ContentPresenter.Resources>
                             <Style TargetType="{x:Type TextBlock}">
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="TextDecorations">
-                                            <Setter.Value>
-                                                <TextDecorationCollection>
-                                                    <TextDecoration Location="Underline" />
-                                                </TextDecorationCollection>
-                                            </Setter.Value>
-                                        </Setter>
-                                    </Trigger>
-                                </Style.Triggers>
+                                <Setter Property="TextDecorations" Value="Underline" />
                             </Style>
                         </ContentPresenter.Resources>
                     </ContentPresenter>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="FocusVisualStyle">
-            <Setter.Value>
-                <Style TargetType="Control">
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate>
-                                <Rectangle Margin="0"
-                                           RenderOptions.EdgeMode="Aliased"
-                                           Stroke="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}"
-                                           StrokeThickness="1"
-                                           StrokeDashArray="1 1" />
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </Setter.Value>
-        </Setter>
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HyperlinkHoverKey}}" />
-            </Trigger>
-            <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.GrayTextKey}}" />
-            </Trigger>
-        </Style.Triggers>
-    </Style>
-    
-    <Style x:Key="NavigationButtonInList" BasedOn="{StaticResource NavigationButton}" TargetType="{x:Type Button}">
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding IsSelected,RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HighlightTextKey}}" />
-            </DataTrigger>
-            <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.GrayTextKey}}" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
 
     <Style x:Key="PopupExpander" TargetType="{x:Type Expander}" BasedOn="{StaticResource {x:Type Control}}">

--- a/Nodejs/Product/Npm/INpmLogSource.cs
+++ b/Nodejs/Product/Npm/INpmLogSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 
@@ -6,7 +6,7 @@ namespace Microsoft.NodejsTools.Npm
 {
     public interface INpmLogSource
     {
-        event EventHandler CommandStarted;
+        event EventHandler<NpmCommandStartedEventArgs> CommandStarted;
         event EventHandler<NpmLogEventArgs> OutputLogged;
         event EventHandler<NpmLogEventArgs> ErrorLogged;
         event EventHandler<NpmExceptionEventArgs> ExceptionLogged;

--- a/Nodejs/Product/Npm/Npm.csproj
+++ b/Nodejs/Product/Npm/Npm.csproj
@@ -51,6 +51,7 @@
     <Compile Include="IPackageJsonScript.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="NpmArgumentBuilder.cs" />
+    <Compile Include="NpmCommandStartedEventArgs.cs" />
     <Compile Include="NpmHelpers.cs" />
     <Compile Include="SemverVersionComparer.cs" />
     <Compile Include="SPI\AbstractNpmSearchComparer.cs" />

--- a/Nodejs/Product/Npm/NpmCommandStartedEventArgs.cs
+++ b/Nodejs/Product/Npm/NpmCommandStartedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NodejsTools.Npm
+{
+    public class NpmCommandStartedEventArgs : EventArgs
+    {
+        public NpmCommandStartedEventArgs(string arguments)
+        {
+            this.Arguments = arguments;
+        }
+
+        public string Arguments { get; }
+
+        public string CommandText
+        {
+            get { return string.IsNullOrEmpty(this.Arguments) ? "npm" : string.Format(CultureInfo.InvariantCulture, "npm {0}", this.Arguments); }
+        }
+    }
+}

--- a/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
+++ b/Nodejs/Product/Npm/SPI/AbstractNpmLogSource.cs
@@ -6,15 +6,11 @@ namespace Microsoft.NodejsTools.Npm.SPI
 {
     internal abstract class AbstractNpmLogSource : INpmLogSource
     {
-        public event EventHandler CommandStarted;
+        public event EventHandler<NpmCommandStartedEventArgs> CommandStarted;
 
-        protected void OnCommandStarted()
+        protected void OnCommandStarted(string arguments)
         {
-            var handlers = CommandStarted;
-            if (null != handlers)
-            {
-                handlers(this, EventArgs.Empty);
-            }
+            CommandStarted?.Invoke(this, new NpmCommandStartedEventArgs(arguments));
         }
 
         protected void FireNpmLogEvent(string logText, EventHandler<NpmLogEventArgs> handlers)

--- a/Nodejs/Product/Npm/SPI/NpmCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommand.cs
@@ -74,7 +74,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
 
         public virtual async Task<bool> ExecuteAsync()
         {
-            this.OnCommandStarted();
+            this.OnCommandStarted(this.Arguments);
 
             var redirector = this.showConsole ? null : new NpmCommandRedirector(this);
             var cancelled = false;

--- a/Nodejs/Product/Npm/SPI/NpmCommander.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommander.cs
@@ -78,9 +78,9 @@ namespace Microsoft.NodejsTools.Npm.SPI
             }
         }
 
-        private void command_CommandStarted(object sender, EventArgs e)
+        private void command_CommandStarted(object sender, NpmCommandStartedEventArgs e)
         {
-            OnCommandStarted();
+            OnCommandStarted(e.Arguments);
         }
 
         private void command_ExceptionLogged(object sender, NpmExceptionEventArgs e)

--- a/Nodejs/Product/Npm/SPI/NpmController.cs
+++ b/Nodejs/Product/Npm/SPI/NpmController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;
@@ -171,9 +171,9 @@ namespace Microsoft.NodejsTools.Npm.SPI
             return new NpmCommander(this);
         }
 
-        public void LogCommandStarted(object sender, EventArgs args)
+        public void LogCommandStarted(object sender, NpmCommandStartedEventArgs args)
         {
-            OnCommandStarted();
+            OnCommandStarted(args.Arguments);
         }
 
         public void LogOutput(object sender, NpmLogEventArgs e)


### PR DESCRIPTION
This PR fixes a bunch of accessibility issues:
- Narrator/NVDA is not reading the alert message, while user is giving any invalid input​ on Project > Properties > General
- The short cut key provided for "start web browser on search" and "Apply Node.js setting" check box is same(Alt+A),which is confusing for the users. On Project > Properties > General
- When user clicks on 'Install Package' screen reader should notify the installing action and also progress of installation
- NVDA/Narrator  should not read link as button ​
- 'Reset options' appears as link but NVDA/Narrator reading as button ​