### PR TITLE
Added NotificationTextBox

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -200,6 +200,8 @@
     <Compile Include="Diagnostics\NodeJsToolsEventSource.cs" />
     <Compile Include="Repl\InteractiveWindowContentType.cs" />
     <Compile Include="SharedProject\SystemUtilities.cs" />
+    <Compile Include="SharedProject\UiaAutomationNativeMethods.cs" />
+    <Compile Include="SharedProject\Wpf\NotificationTextBox.cs" />
     <Compile Include="TypeScriptHelpers\TsConfigJson.cs" />
     <Compile Include="TypeScriptHelpers\TsConfigJsonFactory.cs" />
     <Compile Include="TypeScriptHelpers\TypeScriptCompile.cs" />
@@ -573,6 +575,7 @@
     <EmbeddedResource Include="NpmUI\NpmInstallWindowResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>NpmInstallWindowResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
@@ -214,6 +214,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to One result found.
+        /// </summary>
+        public static string OneResultFoundMessage {
+            get {
+                return ResourceManager.GetString("OneResultFoundMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Options.
         /// </summary>
         public static string OptionsLabel {
@@ -246,6 +255,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         public static string ResetOptionsButtonLabel {
             get {
                 return ResourceManager.GetString("ResetOptionsButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} results found.
+        /// </summary>
+        public static string ResultsFoundMessage {
+            get {
+                return ResourceManager.GetString("ResultsFoundMessage", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
@@ -192,4 +192,11 @@
   <data name="LatestVersion" xml:space="preserve">
     <value>(latest)</value>
   </data>
+  <data name="OneResultFoundMessage" xml:space="preserve">
+    <value>One result found</value>
+  </data>
+  <data name="ResultsFoundMessage" xml:space="preserve">
+    <value>{0} results found</value>
+    <comment>Parameter is a number representing the amount of results.</comment>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -53,12 +53,14 @@ namespace Microsoft.NodejsTools.NpmUI
         private readonly Timer filterTimer;
         private readonly Dispatcher dispatcher;
         private readonly NpmWorker npmWorker;
+        private readonly Action<int> searchResultCallback;
 
         private bool disposed = false;
 
         public NpmPackageInstallViewModel(
             NpmWorker npmWorker,
-            Dispatcher dispatcher
+            Dispatcher dispatcher,
+            Action<int> searchResultCallback
         )
         {
             this.dispatcher = dispatcher;
@@ -67,6 +69,7 @@ namespace Microsoft.NodejsTools.NpmUI
             this.npmWorker.CommandStarted += this.NpmWorker_CommandStarted;
             this.npmWorker.CommandCompleted += this.NpmWorker_CommandCompleted;
             this.filterTimer = new Timer(this.FilterTimer_Elapsed, null, Timeout.Infinite, Timeout.Infinite);
+            this.searchResultCallback = searchResultCallback;
         }
 
         private void NpmWorker_CommandStarted(object sender, EventArgs e)
@@ -243,6 +246,11 @@ namespace Microsoft.NodejsTools.NpmUI
                 if (filterText != GetTrimmedTextSafe(this.filterText))
                 {
                     return;
+                }
+
+                if (!string.IsNullOrWhiteSpace(filterText))
+                {
+                    this.searchResultCallback(filtered.Count());
                 }
 
                 var originalSelectedPackage = this.SelectedPackage;

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -53,14 +53,14 @@ namespace Microsoft.NodejsTools.NpmUI
         private readonly Timer filterTimer;
         private readonly Dispatcher dispatcher;
         private readonly NpmWorker npmWorker;
-        private readonly Action<int> searchResultCallback;
 
         private bool disposed = false;
 
+        public event EventHandler<int> OnSearchResultEnded;
+
         public NpmPackageInstallViewModel(
             NpmWorker npmWorker,
-            Dispatcher dispatcher,
-            Action<int> searchResultCallback
+            Dispatcher dispatcher
         )
         {
             this.dispatcher = dispatcher;
@@ -69,7 +69,6 @@ namespace Microsoft.NodejsTools.NpmUI
             this.npmWorker.CommandStarted += this.NpmWorker_CommandStarted;
             this.npmWorker.CommandCompleted += this.NpmWorker_CommandCompleted;
             this.filterTimer = new Timer(this.FilterTimer_Elapsed, null, Timeout.Infinite, Timeout.Infinite);
-            this.searchResultCallback = searchResultCallback;
         }
 
         private void NpmWorker_CommandStarted(object sender, EventArgs e)
@@ -250,7 +249,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
                 if (!string.IsNullOrWhiteSpace(filterText))
                 {
-                    this.searchResultCallback(filtered.Count());
+                    this.OnSearchResultEnded(this, filtered.Count());
                 }
 
                 var originalSelectedPackage = this.SelectedPackage;

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -4,11 +4,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:npmUi="clr-namespace:Microsoft.NodejsTools.NpmUI"
-    xmlns:ui="clr-namespace:Microsoft.VisualStudioTools"
     xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
     xmlns:wpf="clr-namespace:Microsoft.VisualStudioTools.Wpf"
-    xmlns:sys="clr-namespace:System;assembly=mscorlib"
     xmlns:resx="clr-namespace:Microsoft.NodejsTools.NpmUI"
+    xmlns:ntvs="clr-namespace:Microsoft.NodejsTools.SharedProject.Wpf"
     Title="{x:Static resx:NpmInstallWindowResources.WindowTitle}"
     Height="500"
     MinHeight="500"
@@ -262,7 +261,8 @@
                 <ColumnDefinition Width="7*" MinWidth="100"/>
             </Grid.ColumnDefinitions>
             <Grid Grid.Row="0" Grid.Column="0">
-                <TextBox x:Name="FilterTextBox"
+                <ntvs:NotificationTextBox x:Name="FilterTextBox"
+                         Style="{StaticResource TextBoxStyle}"
                          IsVisibleChanged="FilterTextBox_IsVisibleChanged"
                          Height="24"
                          Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}"

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
@@ -19,20 +19,10 @@ namespace Microsoft.NodejsTools.NpmUI
 
         internal NpmPackageInstallWindow(INpmController controller, NpmWorker npmWorker, DependencyType dependencyType = DependencyType.Standard)
         {
-            this.DataContext = this.viewModel = new NpmPackageInstallViewModel(
-                npmWorker,
-                this.Dispatcher,
-                (count) =>
-                {
-                    var notification = count == 0 ? NpmInstallWindowResources.NoResultsFoundMessage
-                        : count == 1 ? NpmInstallWindowResources.OneResultFoundMessage
-                        : string.Format(NpmInstallWindowResources.ResultsFoundMessage, count);
-
-                    this.FilterTextBox.RaiseNotificationEvent(notification, NpmResultGuid);
-                });
-
+            this.DataContext = this.viewModel = new NpmPackageInstallViewModel(npmWorker, this.Dispatcher);
 
             this.viewModel.NpmController = controller;
+            this.viewModel.OnSearchResultEnded += this.RaiseNotification_OnSearchResultEnded;
             InitializeComponent();
             this.DependencyComboBox.SelectedIndex = (int)dependencyType;
         }
@@ -44,6 +34,15 @@ namespace Microsoft.NodejsTools.NpmUI
             // The catalog refresh operation spawns many long-lived Gen 2 objects,
             // so the garbage collector will take a while to get to them otherwise.
             GC.Collect();
+        }
+
+        private void RaiseNotification_OnSearchResultEnded(object sender, int e)
+        {
+            var notification = e == 0 ? NpmInstallWindowResources.NoResultsFoundMessage
+                        : e == 1 ? NpmInstallWindowResources.OneResultFoundMessage
+                        : string.Format(NpmInstallWindowResources.ResultsFoundMessage, e);
+
+            this.FilterTextBox.RaiseNotificationEvent(notification, NpmResultGuid);
         }
 
         private void Close_Executed(object sender, ExecutedRoutedEventArgs e)

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Windows;
@@ -15,10 +15,23 @@ namespace Microsoft.NodejsTools.NpmUI
     public sealed partial class NpmPackageInstallWindow : DialogWindow, IDisposable
     {
         private readonly NpmPackageInstallViewModel viewModel;
+        private const string NpmResultGuid = "2A7B6678-DFC9-40AA-BF2C-AD08B40A3031";
 
         internal NpmPackageInstallWindow(INpmController controller, NpmWorker npmWorker, DependencyType dependencyType = DependencyType.Standard)
         {
-            this.DataContext = this.viewModel = new NpmPackageInstallViewModel(npmWorker, this.Dispatcher);
+            this.DataContext = this.viewModel = new NpmPackageInstallViewModel(
+                npmWorker,
+                this.Dispatcher,
+                (count) =>
+                {
+                    var notification = count == 0 ? NpmInstallWindowResources.NoResultsFoundMessage
+                        : count == 1 ? NpmInstallWindowResources.OneResultFoundMessage
+                        : string.Format(NpmInstallWindowResources.ResultsFoundMessage, count);
+
+                    this.FilterTextBox.RaiseNotificationEvent(notification, NpmResultGuid);
+                });
+
+
             this.viewModel.NpmController = controller;
             InitializeComponent();
             this.DependencyComboBox.SelectedIndex = (int)dependencyType;

--- a/Nodejs/Product/Nodejs/SharedProject/UiaAutomationNativeMethods.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/UiaAutomationNativeMethods.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Windows.Automation.Provider;
+
+namespace Microsoft.NodejsTools.SharedProject
+{
+    internal class UiaAutomationNativeMethods
+    {
+        public enum AutomationNotificationKind
+        {
+            ItemAdded = 0,
+            ItemRemoved = 1,
+            ActionCompleted = 2,
+            ActionAborted = 3,
+            Other = 4
+        }
+
+        public enum AutomationNotificationProcessing
+        {
+            ImportantAll = 0,
+            ImportantMostRecent = 1,
+            All = 2,
+            MostRecent = 3,
+            CurrentThenMostRecent = 4
+        }
+
+        [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
+        public static extern int UiaRaiseNotificationEvent(
+            IRawElementProviderSimple provider,
+            AutomationNotificationKind notificationKind,
+            AutomationNotificationProcessing notificationProcessing,
+            string notificationText,
+            string notificationGuid);
+
+        [DllImport("UIAutomationCore.dll")]
+        public static extern bool UiaClientsAreListening();
+    }
+}

--- a/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
+++ b/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
@@ -340,7 +340,7 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type Control}}">
+    <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type Control}}">
         <Setter Property="CaretBrush" Value="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Template">

--- a/Nodejs/Product/Nodejs/SharedProject/Wpf/NotificationTextBox.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/Wpf/NotificationTextBox.cs
@@ -12,22 +12,6 @@ namespace Microsoft.NodejsTools.SharedProject.Wpf
         // This control's AutomationPeer is the object that actually raises the UIA Notification event.
         private NotificationTextBoxAutomationPeer notificationTextBoxAutomationPeer;
 
-        // Assume the UIA Notification event is available until we learn otherwise.
-        // If we learn that the UIA Notification event is not available, no instance
-        // of the NotificationTextBox should attempt to raise it.
-        private static bool notificationEventAvailable = true;
-        public bool NotificationEventAvailable
-        {
-            get
-            {
-                return notificationEventAvailable;
-            }
-            set
-            {
-                notificationEventAvailable = value;
-            }
-        }
-
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             this.notificationTextBoxAutomationPeer = new NotificationTextBoxAutomationPeer(this);
@@ -47,7 +31,12 @@ namespace Microsoft.NodejsTools.SharedProject.Wpf
 
     internal class NotificationTextBoxAutomationPeer : TextBoxAutomationPeer
     {
-        private NotificationTextBox notificationTextBox;
+        private readonly NotificationTextBox notificationTextBox;
+
+        // Assume the UIA Notification event is available until we learn otherwise.
+        // If we learn that the UIA Notification event is not available, no instance
+        // of the NotificationTextBox should attempt to raise it.
+        public bool NotificationEventAvailable { get; set; } = true;
 
         // The UIA Notification event requires the IRawElementProviderSimple
         // associated with this AutomationPeer.
@@ -62,7 +51,7 @@ namespace Microsoft.NodejsTools.SharedProject.Wpf
         {
             // If we already know that the UIA Notification event is not available, do not
             // attempt to raise it.
-            if (this.notificationTextBox.NotificationEventAvailable)
+            if (this.NotificationEventAvailable)
             {
                 // If no UIA clients are listening for events, don't bother raising one.
                 if (UiaAutomationNativeMethods.UiaClientsAreListening())
@@ -93,7 +82,7 @@ namespace Microsoft.NodejsTools.SharedProject.Wpf
                         {
                             // The UIA Notification event is not not available, so don't attempt
                             // to raise it again.
-                            this.notificationTextBox.NotificationEventAvailable = false;
+                            this.NotificationEventAvailable = false;
                         }
                     }
                 }

--- a/Nodejs/Product/Nodejs/SharedProject/Wpf/NotificationTextBox.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/Wpf/NotificationTextBox.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+
+namespace Microsoft.NodejsTools.SharedProject.Wpf
+{
+    internal class NotificationTextBox : TextBox
+    {
+        // This control's AutomationPeer is the object that actually raises the UIA Notification event.
+        private NotificationTextBoxAutomationPeer notificationTextBoxAutomationPeer;
+
+        // Assume the UIA Notification event is available until we learn otherwise.
+        // If we learn that the UIA Notification event is not available, no instance
+        // of the NotificationTextBox should attempt to raise it.
+        private static bool notificationEventAvailable = true;
+        public bool NotificationEventAvailable
+        {
+            get
+            {
+                return notificationEventAvailable;
+            }
+            set
+            {
+                notificationEventAvailable = value;
+            }
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            this.notificationTextBoxAutomationPeer = new NotificationTextBoxAutomationPeer(this);
+
+            return this.notificationTextBoxAutomationPeer;
+        }
+
+        public void RaiseNotificationEvent(string notificationText, string notificationGuid)
+        {
+            // Only attempt to raise the event if we already have an AutomationPeer.
+            if (this.notificationTextBoxAutomationPeer != null)
+            {
+                this.notificationTextBoxAutomationPeer.RaiseNotificationEvent(notificationText, notificationGuid);
+            }
+        }
+    }
+
+    internal class NotificationTextBoxAutomationPeer : TextBoxAutomationPeer
+    {
+        private NotificationTextBox notificationTextBox;
+
+        // The UIA Notification event requires the IRawElementProviderSimple
+        // associated with this AutomationPeer.
+        private IRawElementProviderSimple rawElementProviderSimple;
+
+        public NotificationTextBoxAutomationPeer(NotificationTextBox owner) : base(owner)
+        {
+            this.notificationTextBox = owner;
+        }
+
+        public void RaiseNotificationEvent(string notificationText, string notificationGuid)
+        {
+            // If we already know that the UIA Notification event is not available, do not
+            // attempt to raise it.
+            if (this.notificationTextBox.NotificationEventAvailable)
+            {
+                // If no UIA clients are listening for events, don't bother raising one.
+                if (UiaAutomationNativeMethods.UiaClientsAreListening())
+                {
+                    // Get the IRawElementProviderSimple for this AutomationPeer if we don't
+                    // have it already.
+                    if (this.rawElementProviderSimple == null)
+                    {
+                        var automationPeer = FromElement(this.notificationTextBox);
+                        if (automationPeer != null)
+                        {
+                            this.rawElementProviderSimple = this.ProviderFromPeer(automationPeer);
+                        }
+                    }
+
+                    if (this.rawElementProviderSimple != null)
+                    {
+                        try
+                        {
+                            UiaAutomationNativeMethods.UiaRaiseNotificationEvent(
+                                this.rawElementProviderSimple,
+                                UiaAutomationNativeMethods.AutomationNotificationKind.ActionCompleted,
+                                UiaAutomationNativeMethods.AutomationNotificationProcessing.All,
+                                notificationText,
+                                notificationGuid);
+                        }
+                        catch (EntryPointNotFoundException)
+                        {
+                            // The UIA Notification event is not not available, so don't attempt
+                            // to raise it again.
+                            this.notificationTextBox.NotificationEventAvailable = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the capability for screen readers to read that an npm search has finished and the amount of results found.

There's a drawback I'm still figuring out. When VS is unable to query npm, it keeps searching infinitely. A screen reader wont tell a user that a search as started only that a search has finished.