### PR TITLE
Change tsconfig item types back to content

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/TypeScriptExpressApp.njsproj
@@ -31,7 +31,7 @@
     <None Include="app.ts" />
     <None Include="routes\index.ts" />
     <None Include="routes\user.ts" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/TypeScriptWebApp.njsproj
@@ -36,7 +36,7 @@
     <Content Include="README.md" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
   </ItemGroup>
 
   <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsToolsV2.targets" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/NodejsConsoleApp.njsproj
@@ -33,7 +33,7 @@
     <None Include="app.ts" />
     <Content Include="package.json" />
     <Content Include="README.md" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
   </ItemGroup>
 
   <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsToolsV2.targets" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/ExpressApp.njsproj
@@ -31,7 +31,7 @@
     <None Include="app.ts" />
     <None Include="routes\index.ts" />
     <None Include="routes\user.ts" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
     <Content Include="package.json" />
     <Content Include="public\stylesheets\main.css" />
     <Content Include="README.md" />

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/TypeScriptVuejsApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/TypeScriptVuejsApp.njsproj
@@ -36,7 +36,7 @@
     <Content Include="public\index.html" />
     <Content Include="src\App.vue" />
     <Content Include="src\components\Home.vue" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
     <Content Include="package.json" />
     <Content Include="README.md" />
   </ItemGroup>

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/NodejsWebApp.njsproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <None Include="server.ts" />
-    <None Include="tsconfig.json" />
+    <Content Include="tsconfig.json" />
     <Content Include="package.json" />
     <Content Include="README.md" />
   </ItemGroup>


### PR DESCRIPTION
Issue #2154 

##### Bug
1. Create new TypeScript Express App
2. Add TypeScript file
3. Click Project dropdown and see that there are two projects; a configured project and an external project.
   - The external project should not be there.

##### Fix
Change the item type of the tsconfig.json files in the templates to `Content` instead of `None`.

##### Testing
Making the change locally after creating a template fixes the issue.