### PR TITLE
Rollback change on GetAbsoluteFilePath

### DIFF
--- a/Common/Product/SharedProject/CommonUtils.cs
+++ b/Common/Product/SharedProject/CommonUtils.cs
@@ -197,7 +197,9 @@ namespace Microsoft.VisualStudioTools
                 }
             }
 
-            return Path.Combine(segments.ToArray());
+            // Cannot use Path.Combine because the result will not return an absolute path.
+            // This happens because the root has missing the trailing slash.
+            return string.Join(Path.DirectorySeparatorChar.ToString(), segments);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the project creation by using string.Join instead of Path.Combine.