### PR TITLE
Do not disable the Install npm package menu option

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsTools.vsct
+++ b/Nodejs/Product/Nodejs/NodejsTools.vsct
@@ -180,7 +180,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidNpmInstallModules</CommandName>
-          <ButtonText>&amp;Install Missing npm Packages</ButtonText>
+          <ButtonText>&amp;Install npm Packages</ButtonText>
         </Strings>
       </Button>
 
@@ -210,7 +210,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidNpmInstallSingleMissingModule</CommandName>
-          <ButtonText>&amp;Install Missing npm Package(s)</ButtonText>
+          <ButtonText>&amp;Install npm Package(s)</ButtonText>
         </Strings>
       </Button>
 

--- a/Nodejs/Product/Nodejs/Project/DependencyNode.cs
+++ b/Nodejs/Product/Nodejs/Project/DependencyNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -155,7 +155,7 @@ namespace Microsoft.NodejsTools.Project
                             }
                             else
                             {
-                                if (null != this.Package && this.Package.IsMissing)
+                                if (null != this.Package)
                                 {
                                     result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
                                 }

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -412,14 +412,7 @@ namespace Microsoft.NodejsTools.Project
                         }
                         else
                         {
-                            if (this.HasMissingModules)
-                            {
-                                result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
-                            }
-                            else
-                            {
-                                result = QueryStatusResult.SUPPORTED;
-                            }
+                            result = QueryStatusResult.ENABLED | QueryStatusResult.SUPPORTED;
                         }
                         return VSConstants.S_OK;
 


### PR DESCRIPTION
This PR is in relation to this issue:
https://github.com/microsoft/nodejstools/issues/2129

We disable the 'Install Missing npm package' in the VS right-click menu when the package is present. The only way to update to a newer version of the package inside VS for the customers is to use the 'Update npm package' menu option. 

However this option does not work if the user first updates the package.json file with the new package version and then tries the menu option (more details in the comment on the issue). This is just due to the fact how npm update behaves. 

Due to this, we shouldn't disable the 'Install Missing npm package' option to allow users to use this option in such cases. This PR also changes the menu option text to 'Install npm package' instead to reflect that this just runs the 'npm install' command. 
