### PR TITLE
Changed how unit tests shows on the Test Explorer

### DIFF
--- a/Nodejs/Product/TestAdapter/SerializationHelpers.cs
+++ b/Nodejs/Product/TestAdapter/SerializationHelpers.cs
@@ -27,7 +27,7 @@ internal sealed class ResultObject
 internal sealed class TestEvent
 {
     public string type { get; set; }
-    public string title { get; set; }
+    public string fullyQualifiedName { get; set; }
     public ResultObject result { get; set; }
 }
 
@@ -36,22 +36,22 @@ internal sealed class TestCaseObject
     public TestCaseObject()
     {
         this.framework = string.Empty;
-        this.testName = string.Empty;
+        this.fullyQualifiedName = string.Empty;
         this.testFile = string.Empty;
         this.workingFolder = string.Empty;
         this.projectFolder = string.Empty;
     }
 
-    public TestCaseObject(string framework, string testName, string testFile, string workingFolder, string projectFolder)
+    public TestCaseObject(string framework, string fullyQualifiedName, string testFile, string workingFolder, string projectFolder)
     {
         this.framework = framework;
-        this.testName = testName;
+        this.fullyQualifiedName = fullyQualifiedName;
         this.testFile = testFile;
         this.workingFolder = workingFolder;
         this.projectFolder = projectFolder;
     }
     public string framework { get; set; }
-    public string testName { get; set; }
+    public string fullyQualifiedName { get; set; }
     public string testFile { get; set; }
     public string workingFolder { get; set; }
     public string projectFolder { get; set; }

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -159,7 +159,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                     nodeArgs.Add(args.RunTestsScriptFile);
                 }
 
-                testObjects.Add(new TestCaseObject(framework: args.TestFramework, testName: args.TestName, testFile: args.TestFile, workingFolder: args.WorkingDirectory, projectFolder: args.ProjectRootDir));
+                testObjects.Add(new TestCaseObject(framework: args.TestFramework, fullyQualifiedName: args.fullyQualifiedName, testFile: args.TestFile, workingFolder: args.WorkingDirectory, projectFolder: args.ProjectRootDir));
             }
 
             var port = 0;
@@ -224,7 +224,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 var testEvent = JsonConvert.DeserializeObject<TestEvent>(line);
                 // Extract test from list of tests
                 var test = this.currentTests
-                               .Where(n => n.TestCase.DisplayName == testEvent.title)
+                               .Where(n => n.TestCase.FullyQualifiedName == testEvent.fullyQualifiedName)
                                .FirstOrDefault();
 
                 if (test != null)
@@ -353,7 +353,7 @@ namespace Microsoft.NodejsTools.TestAdapter
         {
             var testFile = test.GetPropertyValue(JavaScriptTestCaseProperties.TestFile, defaultValue: test.CodeFilePath);
             var testFramework = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFramework, defaultValue: null);
-            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.DisplayName, testFile, workingDir, projectRootDir);
+            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.FullyQualifiedName, testFile, workingDir, projectRootDir);
         }
 
         private static string GetDebugArgs(Version nodeVersion, out int port)

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -247,7 +247,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                             break;
                     }
                 }
-                else if (testEvent.type == "suite end")
+                else if (testEvent.type == "end")
                 {
                     this.currentResultObject = testEvent.result;
                     this.testsCompleted.Set();

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -64,8 +64,11 @@ function visitNodes(nodes, suites, tests) {
     for (let node of nodes) {
         switch (node.type) {
             case "describe":
-                suites.push(node.name);
+                const parent = suites.length > 0 ? `${suites[suites.length - 1]} ` : '';
+                suites.push(`${parent}${node.name}`);
+
                 visitNodes(node.children, suites, tests);
+
                 suites.pop();
                 break;
             case "it":
@@ -73,7 +76,7 @@ function visitNodes(nodes, suites, tests) {
                     column: node.start.column,
                     filepath: node.file,
                     line: node.start.line,
-                    suite: suites.length === 0 ? null : suites.join(" "),
+                    suite: suites.length === 0 ? null : suites[suites.length - 1],
                     name: node.name
                 });
                 break;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -19,14 +19,7 @@ const find_tests = function (testFileList, discoverResultFile, projectFolder) {
         try {
             const parseResult = jestEditorSupport.parse(testFile);
 
-            for (let test of parseResult.itBlocks) {
-                testList.push({
-                    column: test.start.column,
-                    file: test.file,
-                    line: test.start.line,
-                    test: test.name
-                });
-            }
+            visitNodes(parseResult.root.children, [], testList);
         }
         catch (e) {
             // We would like continue discover other files, so swallow, log and continue;
@@ -39,29 +32,54 @@ const find_tests = function (testFileList, discoverResultFile, projectFolder) {
     fs.closeSync(fd);
 };
 
-const run_tests = function (testCases, post) {
-    const jest = detectPackage(testCases[0].projectFolder, 'jest');
+const run_tests = function (context, post) {
+    const jest = detectPackage(context.testCases[0].projectFolder, 'jest');
     if (!jest) {
         return;
     }
 
     // Start all test cases, as jest is unable to filter out independently
-    for (const testCase of testCases) {
+    for (const testCase of context.testCases) {
         post({
             type: 'test start',
-            title: testCase.testName
+            fullyQualifiedName: testCase.fullyQualifiedName
         });
     }
 
     const config = {
         json: true,
-        reporters: [[__dirname + '/jestReporter.js', { post: post }]],
-        testMatch: [testCases[0].testFile]
+        reporters: [[__dirname + '/jestReporter.js', { context, post }]],
+        testMatch: [context.testCases[0].testFile]
     };
 
-    jest.runCLI(config, [testCases[0].projectFolder])
+    jest.runCLI(config, [context.testCases[0].projectFolder])
         .catch((error) => logError(error));
 };
+
+function visitNodes(nodes, suites, tests) {
+    if (!nodes || nodes.length === 0) {
+        return;
+    }
+
+    for (let node of nodes) {
+        switch (node.type) {
+            case "describe":
+                suites.push(node.name);
+                visitNodes(node.children, suites, tests);
+                suites.pop();
+                break;
+            case "it":
+                tests.push({
+                    column: node.start.column,
+                    filepath: node.file,
+                    line: node.start.line,
+                    suite: suites.length === 0 ? null : suites.join(" "),
+                    name: node.name
+                });
+                break;
+        }
+    }
+}
 
 function detectPackage(projectFolder, packageName) {
     try {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -32,7 +32,7 @@ const find_tests = function (testFileList, discoverResultFile, projectFolder) {
     fs.closeSync(fd);
 };
 
-const run_tests = function (context, post) {
+const run_tests = function (context) {
     const jest = detectPackage(context.testCases[0].projectFolder, 'jest');
     if (!jest) {
         return;
@@ -40,7 +40,7 @@ const run_tests = function (context, post) {
 
     // Start all test cases, as jest is unable to filter out independently
     for (const testCase of context.testCases) {
-        post({
+        context.post({
             type: 'test start',
             fullyQualifiedName: testCase.fullyQualifiedName
         });
@@ -48,7 +48,7 @@ const run_tests = function (context, post) {
 
     const config = {
         json: true,
-        reporters: [[__dirname + '/jestReporter.js', { context, post }]],
+        reporters: [[__dirname + '/jestReporter.js', { context }]],
         testMatch: [context.testCases[0].testFile]
     };
 

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jestReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jestReporter.js
@@ -15,16 +15,15 @@ class jestReporter {
                 fullyQualifiedName: this._options.context.getFullyQualifiedName(assertionResult.fullName)
             };
 
-            this._options.post({
+            this._options.context.post({
                 type: result.pending ? 'pending' : 'result',
                 fullyQualifiedName: result.fullyQualifiedName,
-                result: result
+                result
             });
         }
 
-        this._options.post({
-            type: 'suite end',
-            result: {}
+        this._options.context.post({
+            type: 'end'
         });
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jestReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jestReporter.js
@@ -1,4 +1,5 @@
-﻿class jestReporter {
+﻿//@ts-check
+class jestReporter {
     constructor(globalConfig, options) {
         this._globalConfig = globalConfig;
         this._options = options;
@@ -11,12 +12,12 @@
                 pending: assertionResult.status === 'pending',
                 stderr: assertionResult.failureMessages.join('\n'),
                 stdout: "",
-                title: assertionResult.title
+                fullyQualifiedName: this._options.context.getFullyQualifiedName(assertionResult.fullName)
             };
 
             this._options.post({
                 type: result.pending ? 'pending' : 'result',
-                title: assertionResult.title,
+                fullyQualifiedName: result.fullyQualifiedName,
                 result: result
             });
         }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
         {
             get
             {
-                // If no suite is defined, it on the "global" space.
+                // If no suite is defined, it's on the "global" space.
                 var suite = string.IsNullOrWhiteSpace(this.Suite) ? "global" : this.Suite;
 
                 // Only three levels are allowed on vstest.

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 {
     public sealed class NodejsTestInfo
     {
-        public NodejsTestInfo(string testPath, string testName, string testFramework, int line, int column, string projectRootDir)
+        public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir)
         {
             Debug.Assert(testPath.EndsWith(".js", StringComparison.OrdinalIgnoreCase) || testPath.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase));
 
@@ -20,9 +20,20 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             this.TestFramework = testFramework;
             this.SourceLine = line;
             this.SourceColumn = column;
+            this.Suite = suite;
         }
 
-        public string FullyQualifiedName => $"{this.TestFile}::{this.TestName}::{this.TestFramework}";
+        public string FullyQualifiedName
+        {
+            get
+            {
+                // If no suite is defined, it on the "global" space.
+                var suite = string.IsNullOrWhiteSpace(this.Suite) ? "global" : this.Suite;
+
+                // Only three levels are allowed on vstest.
+                return $"{this.TestFile}::{suite}::{this.TestName}";
+            }
+        }
 
         /// <summary>
         /// Project root relative path to the test file.
@@ -41,5 +52,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
         public int SourceLine { get; }
 
         public int SourceColumn { get; }
+
+        public string Suite { get; }
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -96,21 +96,21 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 {
                     var line = discoveredTest.Line + 1;
                     var column = discoveredTest.Column + 1;
-                    var test = new NodejsTestInfo(discoveredTest.File, discoveredTest.Test, this.Name, line, column, projectRoot);
+                    var test = new NodejsTestInfo(discoveredTest.Filepath, discoveredTest.Suite, discoveredTest.Name, this.Name, line, column, projectRoot);
                     testCases.Add(test);
                 }
             }
             return testCases;
         }
 
-        public ArgumentsToRunTests GetArgumentsToRunTests(string testName, string testFile, string workingDirectory, string projectRootDir)
+        public ArgumentsToRunTests GetArgumentsToRunTests(string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir)
         {
             workingDirectory = workingDirectory.TrimEnd('\\');
             projectRootDir = projectRootDir.TrimEnd('\\');
             return new ArgumentsToRunTests(
                 this.runTestsScriptFile,
                 this.Name,
-                testName,
+                fullyQualifiedName,
                 testFile,
                 workingDirectory,
                 projectRootDir);
@@ -167,9 +167,9 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
         {
             // fields are set using serializer
 #pragma warning disable CS0649
-            public string Test;
+            public string Name;
             public string Suite;
-            public string File;
+            public string Filepath;
             public int Line;
             public int Column;
 #pragma warning restore CS0649
@@ -206,11 +206,11 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 
         public sealed class ArgumentsToRunTests
         {
-            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string testName, string testFile, string workingDirectory, string projectRootDir)
+            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir)
             {
                 this.RunTestsScriptFile = WrapWithQuotes(runTestsScriptFile);
                 this.TestFramework = testFramework;
-                this.TestName = WrapTestNameWithQuotes(testName);
+                this.fullyQualifiedName = WrapTestNameWithQuotes(fullyQualifiedName);
                 this.TestFile = WrapWithQuotes(testFile);
                 this.WorkingDirectory = WrapWithQuotes(workingDirectory);
                 this.ProjectRootDir = WrapWithQuotes(projectRootDir);
@@ -218,7 +218,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 
             public readonly string RunTestsScriptFile;
             public readonly string TestFramework;
-            public readonly string TestName;
+            public readonly string fullyQualifiedName;
             public readonly string TestFile;
             public readonly string WorkingDirectory;
             public readonly string ProjectRootDir;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -47,6 +47,7 @@ function createContext(line) {
     }
 
     function getFullyQualifiedName(testCases, fullTitle) {
+        // TODO: Don't do linear search, instead use a property or cache the fullTitle, fullyQualifiedName.
         for (let testCase of testCases) {
             if (testCase.fullTitle === fullTitle) {
                 return testCase.fullyQualifiedName;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -38,6 +38,7 @@ function createContext(line) {
     function setFullTitle(testCases) {
         // FullyQualifiedName looks like `<filepath>::<suite><subSuite>::<testName>`.
         // <suite> will be `global` for all tests on the "global" scope.
+        // The result would be something like `<suite> <subSuite> <testName>`. Removes `global` as well.
         const cleanRegex = /.*?::(global::)?/;
 
         for (let testCase of testCases) {
@@ -54,19 +55,19 @@ function createContext(line) {
     }
 
     function post(event) {
-        unhookOutputs();
-
         if (event) {
             if (event.result) {
-                // Set only stdout and stderr if they are empty.
+                // Some test frameworks report the result on the stdout/stderr so the event will be empty. Set only stdout and stderr if that's the case.
                 event.result.stdout = event.result.stdout || newOutputs.stdout;
                 event.result.stderr = event.result.stderr || newOutputs.stderr;
             }
 
+            // We need to unhook the outputs as we want to post the event to the test explorer.
+            // Then hook again to continue capturing the stdout
+            unhookOutputs();
             console.log(JSON.stringify(event));
+            hookOutputs();
         }
-
-        hookOutputs();
     }
 
     function clearOutputs() {


### PR DESCRIPTION
Changes how the tests are displayed on the Test Explorer. Now the tree will look like:
```
<folder\fileName>
    <Test Group and Subgroup> or <global scope>
        <Test name>
```

For example, the mocha test:
```js
// file: mocha\UnitTest1.js

var assert = require('assert');

it('Test A', function () {
    assert.ok(true, "This shouldn't fail");
});

describe('Test Suite 1', function () {
    it('Test A', function () {
        assert.ok(true, "This shouldn't fail");
    });

    describe('Sub Suite 1', function () {
        it('Test A', function () {
            assert.ok(true, "This shouldn't fail");
        });
    });
});
```
Will show on the test explorer:
![image](https://user-images.githubusercontent.com/13305542/63552297-2a267480-c4ec-11e9-83c2-71274bd4fb9c.png)

This is standarized for all of the test frameworks supported.

Also fixes an issue when running tests with suites.