### PR TITLE
Updated VsSDK Preview Nuget feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,6 @@
     <add key="dotnet myget" value="https://dotnet.myget.org/f/dotnet-core/api/v3/index.json" />
     <add key="roslyn myget" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
     <add key="Interactive Window" value="https://dotnet.myget.org/f/interactive-window/api/v3/index.json" />
-    <add key="VSSDK Preview" value="https://vside.myget.org/F/vssdk/api/v3/index.json" />
+    <add key="VSSDK Preview" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Update the VSSDK preview nuget feed as the previous path has been deprecated.