### PR TITLE
SpaRoot msbuild property support

### DIFF
--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -141,7 +141,14 @@ namespace Microsoft.NodejsTools.TestAdapter
                                 nodeExePath = Nodejs.GetPathToNodeExecutableFromEnvironment();
                             }
 
-                            this.DiscoverTests(testItems, frameworkDiscoverer, discoverySink, logger, nodeExePath, proj.FullPath);
+                            var spaRoot = proj.GetProperty("SpaRoot")?.EvaluatedValue;
+                            var workDir = Path.GetDirectoryName(proj.FullPath);
+                            if (!String.IsNullOrEmpty(spaRoot))
+                            {
+                                workDir = Path.Combine(workDir, spaRoot);
+                            }
+                            this.DiscoverTests(testItems, frameworkDiscoverer, discoverySink, logger, nodeExePath,
+                                proj.FullPath, workDir);
                         }
                     }
                 }
@@ -159,7 +166,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             }
         }
 
-        private void DiscoverTests(Dictionary<string, HashSet<string>> testItems, FrameworkDiscoverer frameworkDiscoverer, ITestCaseDiscoverySink discoverySink, IMessageLogger logger, string nodeExePath, string projectFullPath)
+        private void DiscoverTests(Dictionary<string, HashSet<string>> testItems, FrameworkDiscoverer frameworkDiscoverer, ITestCaseDiscoverySink discoverySink, IMessageLogger logger, string nodeExePath, string projectFullPath, string workDir)
         {
             foreach (var testFx in testItems.Keys)
             {
@@ -172,7 +179,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
                 var fileList = testItems[testFx];
 
-                var discoverWorker = new TestDiscovererWorker(projectFullPath, NodejsConstants.ExecutorUri, nodeExePath);
+                var discoverWorker = new TestDiscovererWorker(projectFullPath, NodejsConstants.ExecutorUri, nodeExePath, workDir);
                 discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink);
             }
         }

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -20,6 +20,14 @@ namespace Microsoft.NodejsTools.TestAdapter
         private readonly Uri testExecutorUri;
         private readonly string nodeExePath;
 
+        public TestDiscovererWorker(string testSource, Uri testExecutorUri, string nodeExePath, string workDir)
+        {
+            this.testSource = testSource;
+            this.workingDir = workDir;
+            this.testExecutorUri = testExecutorUri;
+            this.nodeExePath = nodeExePath;
+        }
+
         public TestDiscovererWorker(string testSource, Uri testExecutorUri, string nodeExePath)
         {
             this.testSource = testSource;


### PR DESCRIPTION
Test discovery not working for the default react template - dotnet new react.
Test adapter assumes that node_modules folder will be in root of a project, but in case of the react template it in ClientApp folder defined by SpaRoot property.
This patch adds code for handling SpaRoot property and overriding work directory based on it.
