### PR TITLE
Fixed project properties that are not marked as dirty when edited

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.Designer.cs
@@ -322,6 +322,7 @@
             this._workingDir.Name = "_workingDir";
             this._workingDir.Size = new System.Drawing.Size(228, 20);
             this._workingDir.TabIndex = 7;
+            this._workingDir.TextChanged += new System.EventHandler(this.Changed);
             this._workingDir.LostFocus += new System.EventHandler(this.WorkingDirChanged);
             // 
             // _browseDirectory
@@ -349,6 +350,7 @@
             this._nodejsPort.Name = "_nodejsPort";
             this._nodejsPort.Size = new System.Drawing.Size(105, 20);
             this._nodejsPort.TabIndex = 12;
+            this._nodejsPort.TextChanged += new System.EventHandler(this.Changed);
             this._nodejsPort.LostFocus += new System.EventHandler(this.PortChanged);
             // 
             // _envVars
@@ -405,6 +407,7 @@
             this._nodeExePath.Name = "_nodeExePath";
             this._nodeExePath.Size = new System.Drawing.Size(228, 20);
             this._nodeExePath.TabIndex = 17;
+            this._nodeExePath.TextChanged += new System.EventHandler(this.Changed);
             this._nodeExePath.LostFocus += new System.EventHandler(this.NodeExePathChanged);
             // 
             // _browsePath
@@ -432,6 +435,7 @@
             this._debuggerPort.Name = "_debuggerPort";
             this._debuggerPort.Size = new System.Drawing.Size(105, 20);
             this._debuggerPort.TabIndex = 21;
+            this._debuggerPort.TextChanged += new System.EventHandler(this.Changed);
             this._debuggerPort.LostFocus += new System.EventHandler(this.PortChanged);
             // 
             // testHeaderTableLayoutPanel
@@ -512,6 +516,7 @@
             this._testRoot.Name = "_testRoot";
             this._testRoot.Size = new System.Drawing.Size(228, 20);
             this._testRoot.TabIndex = 27;
+            this._testRoot.TextChanged += new System.EventHandler(this.Changed);
             // 
             // _browseTestroot
             // 


### PR DESCRIPTION
Fixed an issue with some project properties that don't get saved all the time when modified.