### PR TITLE
Launching v3 debugger under a feature flag

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1139,6 +1139,9 @@
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.5.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime">
+      <Version>14.0.25023-setup</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel">
       <Version>16.0.1</Version>
     </PackageReference>

--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1140,7 +1140,7 @@
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime">
-      <Version>14.0.25023-setup</Version>
+      <Version>14.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel">
       <Version>16.0.1</Version>

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudioTools.Project;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NodejsTools.Project
@@ -35,6 +36,7 @@ namespace Microsoft.NodejsTools.Project
         private int? _testServerPort;
 
         internal static readonly Guid WebKitDebuggerV2Guid = Guid.Parse("30d423cc-6d0b-4713-b92d-6b2a374c3d89");
+        internal static readonly Guid JsCdpDebuggerV3Guid = Guid.Parse("394120B6-2FF9-4D0D-8953-913EF5CD0BCD");
 
         public NodejsProjectLauncher(NodejsProjectNode project)
         {
@@ -215,6 +217,12 @@ namespace Microsoft.NodejsTools.Project
             return builder.ToString();
         }
 
+        internal static bool ShouldUseV3CdpDebugger()
+        {
+            var featureFlagsService = (IVsFeatureFlags)ServiceProvider.GlobalProvider.GetService(typeof(SVsFeatureFlags));
+            return featureFlagsService != null && featureFlagsService.IsFeatureEnabled("JavaScript.Debugger.V3CdpDebugAdapter", false);
+        }
+
         private int TestServerPort
         {
             get
@@ -280,7 +288,7 @@ namespace Microsoft.NodejsTools.Project
             var debugTargets = new[] {
                 new VsDebugTargetInfo4() {
                     dlo = (uint)DEBUG_LAUNCH_OPERATION.DLO_CreateProcess,
-                    guidLaunchDebugEngine = WebKitDebuggerV2Guid,
+                    guidLaunchDebugEngine = ShouldUseV3CdpDebugger() ? JsCdpDebuggerV3Guid : WebKitDebuggerV2Guid,
                     bstrExe = file,
                     bstrOptions = jsonContent
                 }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -35,8 +35,7 @@ namespace Microsoft.NodejsTools.Project
         private readonly NodejsProjectNode _project;
         private int? _testServerPort;
 
-        internal static readonly Guid WebKitDebuggerV2Guid = Guid.Parse("30d423cc-6d0b-4713-b92d-6b2a374c3d89");
-        internal static readonly Guid JsCdpDebuggerV3Guid = Guid.Parse("394120B6-2FF9-4D0D-8953-913EF5CD0BCD");
+        private static Guid debuggerGuid = Guid.Empty;
 
         public NodejsProjectLauncher(NodejsProjectNode project)
         {
@@ -217,10 +216,17 @@ namespace Microsoft.NodejsTools.Project
             return builder.ToString();
         }
 
-        internal static bool ShouldUseV3CdpDebugger()
+        internal static Guid GetDebuggerGuid()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            
+            Guid WebKitDebuggerV2Guid = Guid.Parse("30d423cc-6d0b-4713-b92d-6b2a374c3d89");
+            Guid JsCdpDebuggerV3Guid = Guid.Parse("394120B6-2FF9-4D0D-8953-913EF5CD0BCD");
+            
             var featureFlagsService = (IVsFeatureFlags)ServiceProvider.GlobalProvider.GetService(typeof(SVsFeatureFlags));
-            return featureFlagsService != null && featureFlagsService.IsFeatureEnabled("JavaScript.Debugger.V3CdpDebugAdapter", false);
+            return (featureFlagsService != null && featureFlagsService.IsFeatureEnabled("JavaScript.Debugger.V3CdpDebugAdapter", false)) ?
+                                JsCdpDebuggerV3Guid :
+                                WebKitDebuggerV2Guid;
         }
 
         private int TestServerPort
@@ -288,7 +294,7 @@ namespace Microsoft.NodejsTools.Project
             var debugTargets = new[] {
                 new VsDebugTargetInfo4() {
                     dlo = (uint)DEBUG_LAUNCH_OPERATION.DLO_CreateProcess,
-                    guidLaunchDebugEngine = ShouldUseV3CdpDebugger() ? JsCdpDebuggerV3Guid : WebKitDebuggerV2Guid,
+                    guidLaunchDebugEngine = GetDebuggerGuid(),
                     bstrExe = file,
                     bstrOptions = jsonContent
                 }

--- a/Nodejs/Product/Nodejs/Workspace/JsFileDebugLaunchTargetProvider.cs
+++ b/Nodejs/Product/Nodejs/Workspace/JsFileDebugLaunchTargetProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NodejsTools.Workspace
             var jsonContent = GetJsonConfigurationForInspectProtocol(target, cwd, nodeExe, debugLaunchContext);
 
             vsDebugTargetInfo.dlo = DEBUG_LAUNCH_OPERATION.DLO_CreateProcess;
-            vsDebugTargetInfo.clsidCustom = NodejsProjectLauncher.WebKitDebuggerV2Guid;
+            vsDebugTargetInfo.clsidCustom = NodejsProjectLauncher.ShouldUseV3CdpDebugger() ? NodejsProjectLauncher.JsCdpDebuggerV3Guid : NodejsProjectLauncher.WebKitDebuggerV2Guid;
             vsDebugTargetInfo.bstrOptions = jsonContent;
             vsDebugTargetInfo.grfLaunch = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
         }

--- a/Nodejs/Product/Nodejs/Workspace/JsFileDebugLaunchTargetProvider.cs
+++ b/Nodejs/Product/Nodejs/Workspace/JsFileDebugLaunchTargetProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NodejsTools.Workspace
             var jsonContent = GetJsonConfigurationForInspectProtocol(target, cwd, nodeExe, debugLaunchContext);
 
             vsDebugTargetInfo.dlo = DEBUG_LAUNCH_OPERATION.DLO_CreateProcess;
-            vsDebugTargetInfo.clsidCustom = NodejsProjectLauncher.ShouldUseV3CdpDebugger() ? NodejsProjectLauncher.JsCdpDebuggerV3Guid : NodejsProjectLauncher.WebKitDebuggerV2Guid;
+            vsDebugTargetInfo.clsidCustom = NodejsProjectLauncher.GetDebuggerGuid();
             vsDebugTargetInfo.bstrOptions = jsonContent;
             vsDebugTargetInfo.grfLaunch = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
         }

--- a/Nodejs/Product/Nodejs/Workspace/NodeJsDebugLaunchTargetProvider.cs
+++ b/Nodejs/Product/Nodejs/Workspace/NodeJsDebugLaunchTargetProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.NodejsTools.Workspace
             var jsonContent = GetJsonConfigurationForInspectProtocol(target, cwd, nodeExe, debugLaunchContext);
 
             vsDebugTargetInfo.dlo = (uint)DEBUG_LAUNCH_OPERATION.DLO_CreateProcess;
-            vsDebugTargetInfo.guidLaunchDebugEngine = NodejsProjectLauncher.WebKitDebuggerV2Guid;
+            vsDebugTargetInfo.guidLaunchDebugEngine = NodejsProjectLauncher.ShouldUseV3CdpDebugger() ? NodejsProjectLauncher.JsCdpDebuggerV3Guid : NodejsProjectLauncher.WebKitDebuggerV2Guid;
             vsDebugTargetInfo.bstrOptions = jsonContent;
             vsDebugTargetInfo.LaunchFlags = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
         }

--- a/Nodejs/Product/Nodejs/Workspace/NodeJsDebugLaunchTargetProvider.cs
+++ b/Nodejs/Product/Nodejs/Workspace/NodeJsDebugLaunchTargetProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.NodejsTools.Workspace
             var jsonContent = GetJsonConfigurationForInspectProtocol(target, cwd, nodeExe, debugLaunchContext);
 
             vsDebugTargetInfo.dlo = (uint)DEBUG_LAUNCH_OPERATION.DLO_CreateProcess;
-            vsDebugTargetInfo.guidLaunchDebugEngine = NodejsProjectLauncher.ShouldUseV3CdpDebugger() ? NodejsProjectLauncher.JsCdpDebuggerV3Guid : NodejsProjectLauncher.WebKitDebuggerV2Guid;
+            vsDebugTargetInfo.guidLaunchDebugEngine = NodejsProjectLauncher.GetDebuggerGuid();
             vsDebugTargetInfo.bstrOptions = jsonContent;
             vsDebugTargetInfo.LaunchFlags = (uint)__VSDBGLAUNCHFLAGS.DBGLAUNCH_StopDebuggingOnEnd;
         }

--- a/nuget.config
+++ b/nuget.config
@@ -6,5 +6,6 @@
     <add key="roslyn myget" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
     <add key="Interactive Window" value="https://dotnet.myget.org/f/interactive-window/api/v3/index.json" />
     <add key="VSSDK Preview" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We've have a new debug adapter that can be used to debug Node projects (see [here](https://github.com/microsoft/vscode-js-debug)). This PR is to enable launching that debug adapter under a feature flag.