### PR TITLE
embedding types instead of using internal dll

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Diagnostics\HierarchyItem.cs" />
     <Compile Include="Diagnostics\NodeJsToolsEventSource.cs" />
     <Compile Include="Repl\InteractiveWindowContentType.cs" />
+    <Compile Include="SharedProject\IVsFeatureFlags.cs" />
     <Compile Include="SharedProject\SystemUtilities.cs" />
     <Compile Include="SharedProject\UiaAutomationNativeMethods.cs" />
     <Compile Include="SharedProject\Wpf\NotificationTextBox.cs" />
@@ -1183,9 +1184,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
       <Version>12.0.30111</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime">
-      <Version>14.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime">
       <Version>14.3.26929</Version>

--- a/Nodejs/Product/Nodejs/SharedProject/IVsFeatureFlags.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/IVsFeatureFlags.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Internal.VisualStudio.Shell.Interop
+{
+    [ComImport]
+    [Guid("78A67F33-22CF-426C-8C90-B6E18FD35E0F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [TypeIdentifier]
+    public interface SVsFeatureFlags { }
+
+    [ComImport]
+    [Guid("AD44B8B9-B646-4B18-8847-150695AEC480")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [TypeIdentifier]
+    public interface IVsFeatureFlags
+    {
+        bool IsFeatureEnabled(string name, bool defaultValue);
+    }
+}


### PR DESCRIPTION
The Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime assembly has been moved to internal feeds, so this is to let us read values from feature flags in VS.

Following example from PTVS: https://github.com/microsoft/PTVS/blob/master/Python/Product/PythonTools/PythonTools/Editor/IVsFeatureFlags.cs