### PR TITLE
using separate tools option and feature flag for Node

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -229,7 +229,7 @@ namespace Microsoft.NodejsTools.Project
             var userRegistryRoot = VSRegistry.RegistryRoot(__VsLocalRegistryType.RegType_UserSettings, writable: false);
             try
             {
-                object userDebuggerOption = userRegistryRoot.OpenSubKey("Debugger")?.GetValue("EnableJavaScriptMultitargetDebugging");
+                object userDebuggerOption = userRegistryRoot.OpenSubKey("Debugger")?.GetValue("EnableJavaScriptMultitargetNodeDebug");
                 if (userDebuggerOption is int optionVal)
                 {
                     return optionVal != 0;
@@ -238,7 +238,7 @@ namespace Microsoft.NodejsTools.Project
             catch (Exception) { } // do nothing. proceed to trying the feature flag below.
 
             var featureFlagsService = (IVsFeatureFlags)ServiceProvider.GlobalProvider.GetService(typeof(SVsFeatureFlags));
-            return featureFlagsService is IVsFeatureFlags && featureFlagsService.IsFeatureEnabled("JavaScript.Debugger.V3CdpDebugAdapter", false);
+            return featureFlagsService is IVsFeatureFlags && featureFlagsService.IsFeatureEnabled("JavaScript.Debugger.V3CdpNodeDebugAdapter", false);
         }
 
         private int TestServerPort


### PR DESCRIPTION
We are now using a separate feature flag and tools option for node so that we can turn it on separately from browser debugging. This change is to use the new values
