### PR TITLE
Fix mocha test adapter failing to set extended timeout in debugging

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/mocha/mocha.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/mocha/mocha.js
@@ -3,6 +3,7 @@
 var EOL = require('os').EOL;
 var fs = require('fs');
 var path = require('path');
+var inspector = require('inspector');
 // Choose 'tap' rather than 'min' or 'xunit'. The reason is that
 // 'min' produces undisplayable text to stdout and stderr under piped/redirect, 
 // and 'xunit' does not print the stack trace from the test.
@@ -205,7 +206,7 @@ function getMochaOptions(projectFolder) {
     }
 
     // set timeout to 10 minutes, because the default of 2 sec is too short for debugging scenarios
-    if (typeof v8debug === 'object') {
+    if (inspector.url()) {
         mochaOptions['timeout'] = 600000;
     }
 


### PR DESCRIPTION
There's a bug: mocha tests time out in 2 seconds even under debugger. It can be reproduced by stepping through a mocha test for longer than two seconds.

I found that the mocha test adapter contains a check for the `v8debug` object to detect debugging scenarios. That interface seems to have been deprecated and/or EOL'd. At least it's not available in v12.14.1. The Inspector API, on the other hand, has been available since version 8, and thus it should be a safe replacement.

Here's my environment where I found and successfully patched the bug:
- Microsoft Visual Studio Community 2019 Version 16.6.0
- Node.js Tools 1.5.20317.1 Commit Hash:3e70368beb9630c811076c051f4c9a59b45d7c10
- node --version v12.14.1