### PR TITLE
Add property for Azure Cloud Services packaging

### DIFF
--- a/Nodejs/Product/TargetsVsix/Microsoft.NodejsTools.targets
+++ b/Nodejs/Product/TargetsVsix/Microsoft.NodejsTools.targets
@@ -105,6 +105,13 @@
     <AssignTargetPath Files="@(_TempBuiltProjectOutputGroup)" RootFolder="$(MSBuildProjectDirectory)">
       <Output TaskParameter="AssignedFiles" ItemName="BuiltProjectOutputGroupOutput" />
     </AssignTargetPath>
+
+    <!-- Add FinalOutputPath property to support Azure Cloud Service role packaging -->
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="@(BuiltProjectOutputGroupOutput)">
+        <FinalOutputPath>%(FullPath)</FinalOutputPath>
+      </BuiltProjectOutputGroupOutput>
+    </ItemGroup>    
   </Target>
 
   <Target

--- a/Nodejs/Product/TargetsVsix/Microsoft.NodejsToolsV2.targets
+++ b/Nodejs/Product/TargetsVsix/Microsoft.NodejsToolsV2.targets
@@ -108,6 +108,13 @@
     <AssignTargetPath Files="@(_TempBuiltProjectOutputGroup)" RootFolder="$(MSBuildProjectDirectory)">
       <Output TaskParameter="AssignedFiles" ItemName="BuiltProjectOutputGroupOutput" />
     </AssignTargetPath>
+
+    <!-- Add FinalOutputPath property to support Azure Cloud Service role packaging -->
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="@(BuiltProjectOutputGroupOutput)">
+        <FinalOutputPath>%(FullPath)</FinalOutputPath>
+      </BuiltProjectOutputGroupOutput>
+    </ItemGroup> 
   </Target>
 
   <Target


### PR DESCRIPTION
##### Bug
When well-formed Azure Cloud Services worker roles are packaged, the operation fails because `node.cmd` is not copied to the right location before running the `CSPack` task.

![image](https://user-images.githubusercontent.com/9092011/94324961-210aa100-ff51-11ea-8929-1728bf6b2d55.png)


##### Fix
Add the full path to each output item as the `FinalOutputPath` property so the Azure targets can copy them appropriately.

##### Testing
Validated by making the change in my local targets files.