### PR TITLE
Add angular test adapter

### DIFF
--- a/Nodejs/Product/Nodejs/NodejsConstants.cs
+++ b/Nodejs/Product/Nodejs/NodejsConstants.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NodejsTools
         public const string NodejsProjectExtension = ".njsproj";
         public const string CSharpProjectExtension = ".csproj";
         public const string VisualBasicProjectExtension = ".vbproj";
-        public const string AngularProjectExtension = ".esproj";
+        public const string JavaScriptProjectExtension = ".esproj";
 
         public const string JavaScript = "JavaScript";
         public const string CSS = "CSS";

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -7,6 +7,10 @@ using System.Linq;
 
 namespace Microsoft.NodejsTools.TestFrameworks
 {
+    // TODO: Remove Angular form the test framworks.
+    // The Angular property appears on the file and project settings, nonetheless, this is configured differently
+    // than the rest of the frameworks due to the config file. We need to remove the Angular text as it not 
+    // supported like that.
     internal static class TestFrameworkDirectories
     {
         public const string ExportRunnerFrameworkName = "ExportRunner";

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -7,10 +7,6 @@ using System.Linq;
 
 namespace Microsoft.NodejsTools.TestFrameworks
 {
-    // TODO: Remove Angular form the test framworks.
-    // The Angular property appears on the file and project settings, nonetheless, this is configured differently
-    // than the rest of the frameworks due to the config file. We need to remove the Angular text as it not 
-    // supported like that.
     internal static class TestFrameworkDirectories
     {
         public const string ExportRunnerFrameworkName = "ExportRunner";
@@ -25,7 +21,8 @@ namespace Microsoft.NodejsTools.TestFrameworks
                 throw new InvalidOperationException($"Unable to find test framework folder. Tried: \"{testFrameworkRoot}\"");
             }
 
-            return Directory.EnumerateDirectories(testFrameworkRoot).Select(Path.GetFileName).ToArray();
+            // Enumarte all directories to appear on the properties bar. Angular is removed as it is configured by config file instead.
+            return Directory.EnumerateDirectories(testFrameworkRoot).Select(Path.GetFileName).Where(x => x != "Angular").ToArray();
         }
 
         public static string[] GetFrameworkDirectories(string testFrameworkRoot = null)

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -9,6 +9,7 @@ namespace Microsoft.NodejsTools.TestFrameworks
 {
     internal static class TestFrameworkDirectories
     {
+        public const string AngularFrameworkName = "Angular";
         public const string ExportRunnerFrameworkName = "ExportRunner";
         private const string TestFrameworksFolderName = "TestFrameworks";
         private const string TestAdapterFolderName = "TestAdapter";
@@ -22,7 +23,10 @@ namespace Microsoft.NodejsTools.TestFrameworks
             }
 
             // Enumerate all directories to appear on the properties bar. Angular is removed as it is configured by config file instead.
-            return Directory.EnumerateDirectories(testFrameworkRoot).Select(Path.GetFileName).Where(x => x != "Angular").ToArray();
+            return Directory.EnumerateDirectories(testFrameworkRoot)
+                .Select(Path.GetFileName)
+                .Where(x => !string.Equals(x, TestFrameworkDirectories.AngularFrameworkName, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
         }
 
         public static string[] GetFrameworkDirectories(string testFrameworkRoot = null)

--- a/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
+++ b/Nodejs/Product/Nodejs/TestFrameworks/TestFrameworkDirectories.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NodejsTools.TestFrameworks
                 throw new InvalidOperationException($"Unable to find test framework folder. Tried: \"{testFrameworkRoot}\"");
             }
 
-            // Enumarte all directories to appear on the properties bar. Angular is removed as it is configured by config file instead.
+            // Enumerate all directories to appear on the properties bar. Angular is removed as it is configured by config file instead.
             return Directory.EnumerateDirectories(testFrameworkRoot).Select(Path.GetFileName).Where(x => x != "Angular").ToArray();
         }
 

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.NodejsTools.TestAdapter.TestFrameworks;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -13,7 +13,7 @@ using MSBuild = Microsoft.Build.Evaluation;
 namespace Microsoft.NodejsTools.TestAdapter
 {
     // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
-    [FileExtension(NodejsConstants.NodejsProjectExtension), FileExtension(NodejsConstants.CSharpProjectExtension), FileExtension(NodejsConstants.VisualBasicProjectExtension), FileExtension(NodejsConstants.AngularProjectExtension)]
+    [FileExtension(NodejsConstants.NodejsProjectExtension), FileExtension(NodejsConstants.CSharpProjectExtension), FileExtension(NodejsConstants.VisualBasicProjectExtension), FileExtension(NodejsConstants.JavaScriptProjectExtension)]
     [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
     public partial class ProjectTestDiscoverer : ITestDiscoverer
     {
@@ -60,13 +60,11 @@ namespace Microsoft.NodejsTools.TestAdapter
                     }
 
                     FrameworkDiscoverer frameworkDiscoverer = null;
-                    var testItems = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-
                     foreach (var proj in buildEngine.LoadedProjects)
                     {
                         var projectHome = Path.GetFullPath(Path.Combine(proj.DirectoryPath, "."));
 
-                        testItems = TestFrameworkFactory.GetTestItems(projectHome, proj);
+                        var testItems = TestFrameworkFactory.GetTestItems(projectHome, proj);
 
                         if (testItems.Any())
                         {

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ProjectTestDiscoverer.cs" />
     <Compile Include="TestDiscovererWorker.cs" />
     <Compile Include="TestExecutorWorker.cs" />
+    <Compile Include="TestFrameworkFactory.cs" />
     <Compile Include="TestFrameworks\FrameworkDiscoverer.cs" />
     <Compile Include="JavaScriptTestCaseProperties.cs" />
     <Compile Include="TestFrameworks\NodejsTestInfo.cs" />
@@ -94,6 +95,18 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="TestFrameworks\Angular\Angular.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFrameworks\Angular\jasmineReporter.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFrameworks\Angular\karmaConfig.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFrameworks\Angular\vsKarmaReporter.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestFrameworks\ExportRunner\exportrunner.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         public void DiscoverTests(string testFolderPath, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {
-            var fileList = Directory.GetFiles(testFolderPath, "*.js", SearchOption.AllDirectories);
+            var fileList = Directory.EnumerateFiles(testFolderPath, "*.js", SearchOption.AllDirectories).Where(x => !x.Contains(NodejsConstants.NodeModulesFolder));
             this.DiscoverTests(fileList, testFx, logger, discoverySink);
         }
 

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -185,7 +185,12 @@ namespace Microsoft.NodejsTools.TestAdapter
                     nodeArgs.Add(args.RunTestsScriptFile);
                 }
 
-                testObjects.Add(new TestCaseObject(framework: args.TestFramework, fullyQualifiedName: args.fullyQualifiedName, testFile: args.TestFile, workingFolder: args.WorkingDirectory, projectFolder: args.ProjectRootDir));
+                testObjects.Add(new TestCaseObject(
+                    framework: args.TestFramework,
+                    fullyQualifiedName: args.fullyQualifiedName,
+                    testFile: args.TestFile,
+                    workingFolder: args.WorkingDirectory,
+                    projectFolder: args.ProjectRootDir));
             }
 
             var port = 0;

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -92,8 +92,10 @@ namespace Microsoft.NodejsTools.TestAdapter
             this.cancelRequested.Reset();
 
             var testFramework = tests.First().GetPropertyValue(JavaScriptTestCaseProperties.TestFramework, defaultValue: TestFrameworkDirectories.ExportRunnerFrameworkName);
-            if (testFramework == "Angular")
+            if (string.Equals(testFramework, TestFrameworkDirectories.AngularFrameworkName, StringComparison.OrdinalIgnoreCase))
             {
+                // Every angular run initializes karma, browser, caching, etc, 
+                // so is preferable to let the test adapter handle any optimization.
                 RunAllTests(tests);
             }
             else

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -109,6 +109,8 @@ namespace Microsoft.NodejsTools.TestAdapter
             {
                 this.currentTests = testCaseList;
 
+                // TODO: Don't run each test file. Instead run all of the test at once.
+                // This generates a problem for Angular as it creates all instances again for the servers.
                 // Run all test cases in a given file
                 this.RunTestCases(testCaseList);
             }
@@ -131,9 +133,12 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             // All tests being run are for the same test file, so just use the first test listed to get the working dir
             var firstTest = tests.First().TestCase;
+            // TODO: Get the test framework using the configuration file logic.
             var testFramework = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.TestFramework, defaultValue: TestFrameworkDirectories.ExportRunnerFrameworkName);
+            // TODO: Is this necessary if using a configuration file?.
             var workingDir = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.WorkingDir, defaultValue: Path.GetDirectoryName(firstTest.CodeFilePath));
             var nodeExePath = firstTest.GetPropertyValue<string>(JavaScriptTestCaseProperties.NodeExePath, defaultValue: null);
+            // TODO: Is this necessary if using a configuration file?.
             var projectRootDir = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.ProjectRootDir, defaultValue: Path.GetDirectoryName(firstTest.CodeFilePath));
 
             if (string.IsNullOrEmpty(nodeExePath) || !File.Exists(nodeExePath))

--- a/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 }
                 else if (!configItems.Any()) // Legacy behavior. If we have found a test configuration file is safe to ignore the rest of the files.
                 {
-                    // TODO: Deprecate. Is configured by projecft file or is configured per file.
+                    // TODO: Deprecate. Is configured by project file or is configured per file.
                     var testFrameworkAndFilePath = GetTestFrameworkAndFilePath(project, projectItem, projectRoot);
                     if (testFrameworkAndFilePath.HasValue)
                     {

--- a/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
 using Microsoft.NodejsTools.TestAdapter.TestFrameworks;
+using Microsoft.NodejsTools.TestFrameworks;
 using Microsoft.NodejsTools.TypeScript;
 using Microsoft.VisualStudioTools;
 
@@ -20,17 +21,14 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             foreach (var projectItem in projectItems)
             {
-                string testFrameworkName = null;
                 // TODO: Consider it can also be inside a <root>/.config/ folder and will configure the <root> folder.
-                if (projectItem.EvaluatedInclude.Contains("angular.json"))
-                {
-                    testFrameworkName = "angular";
-                }
                 // TODO: Add configuration files for jest, mocha , jasmine. Consider that some frameworks can be configured using package.json
                 // Also some frameworks have more than one filename to define a configuration.
                 // Tape is the only framework we support that doesn't have a configuration file. Decide what to do about that.
-                if (testFrameworkName != null)
+                if (projectItem.EvaluatedInclude.Contains("angular.json"))
                 {
+                    var testFrameworkName = TestFrameworkDirectories.AngularFrameworkName;
+
                     if (!configItems.ContainsKey(testFrameworkName))
                     {
                         configItems.Add(testFrameworkName, new HashSet<string>(StringComparer.OrdinalIgnoreCase));

--- a/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
@@ -21,16 +21,14 @@ namespace Microsoft.NodejsTools.TestAdapter
             foreach (var projectItem in projectItems)
             {
                 string testFrameworkName = null;
-                // TODO: Should it validate karma.conf.js? 
-                // consider it can also be inside a <root>/.config/ folder and will configure the <root> folder.
+                // TODO: Consider it can also be inside a <root>/.config/ folder and will configure the <root> folder.
                 if (projectItem.EvaluatedInclude.Contains("angular.json"))
                 {
                     testFrameworkName = "angular";
                 }
-                // TODO: Add configuration files for jest, mocha , jasmine. Consider some frameworks can be configured using package.json
+                // TODO: Add configuration files for jest, mocha , jasmine. Consider that some frameworks can be configured using package.json
                 // Also some frameworks have more than one filename to define a configuration.
                 // Tape is the only framework we support that doesn't have a configuration file. Decide what to do about that.
-
                 if (testFrameworkName != null)
                 {
                     if (!configItems.ContainsKey(testFrameworkName))

--- a/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworkFactory.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Evaluation;
+using Microsoft.NodejsTools.TestAdapter.TestFrameworks;
+using Microsoft.NodejsTools.TypeScript;
+using Microsoft.VisualStudioTools;
+
+namespace Microsoft.NodejsTools.TestAdapter
+{
+    public static class TestFrameworkFactory
+    {
+        public static Dictionary<string, HashSet<string>> GetTestItems(string projectRoot, Project project)
+        {
+            var configItems = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            var testItems = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+            var projectItems = project.Items.Where(x => x.ItemType != "NodeModulesContent");
+
+            foreach (var projectItem in projectItems)
+            {
+                string testFrameworkName = null;
+                // TODO: Should it validate karma.conf.js? 
+                // consider it can also be inside a <root>/.config/ folder and will configure the <root> folder.
+                if (projectItem.EvaluatedInclude.Contains("angular.json"))
+                {
+                    testFrameworkName = "angular";
+                }
+                // TODO: Add configuration files for jest, mocha , jasmine. Consider some frameworks can be configured using package.json
+                // Also some frameworks have more than one filename to define a configuration.
+                // Tape is the only framework we support that doesn't have a configuration file. Decide what to do about that.
+
+                if (testFrameworkName != null)
+                {
+                    if (!configItems.ContainsKey(testFrameworkName))
+                    {
+                        configItems.Add(testFrameworkName, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                    }
+
+                    configItems[testFrameworkName].Add(CommonUtils.GetAbsoluteFilePath(projectRoot, projectItem.EvaluatedInclude));
+                }
+                else if (!configItems.Any()) // Legacy behavior. If we have found a test configuration file is safe to ignore the rest of the files.
+                {
+                    // TODO: Deprecate. Is configured by projecft file or is configured per file.
+                    var testFrameworkAndFilePath = GetTestFrameworkAndFilePath(project, projectItem, projectRoot);
+                    if (testFrameworkAndFilePath.HasValue)
+                    {
+                        var (testFramework, fileAbsolutePath) = testFrameworkAndFilePath.Value;
+                        if (!testItems.ContainsKey(testFramework))
+                        {
+                            testItems.Add(testFramework, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                        }
+
+                        testItems[testFramework].Add(fileAbsolutePath);
+                    }
+                }
+            }
+
+            return configItems.Any() ? configItems : testItems;
+        }
+
+        private static (string, string)? GetTestFrameworkAndFilePath(Project project, ProjectItem projectItem, string projectRoot)
+        {
+            var testRoot = project.GetProperty(NodeProjectProperty.TestRoot)?.EvaluatedValue;
+            var testFrameworkName = project.GetProperty(NodeProjectProperty.TestFramework)?.EvaluatedValue;
+
+            string fileAbsolutePath;
+            if (!string.IsNullOrEmpty(testRoot) && !string.IsNullOrEmpty(testFrameworkName)) // If the test root and framework have been configured on the project.
+            {
+                var testRootPath = Path.GetFullPath(Path.Combine(project.DirectoryPath, testRoot));
+
+                try
+                {
+                    fileAbsolutePath = CommonUtils.GetAbsoluteFilePath(projectRoot, projectItem.EvaluatedInclude);
+                }
+                catch (ArgumentException)
+                {
+                    // .Net core projects include invalid paths, ignore them and continue checking the items.
+                    return null;
+                }
+
+                if (!fileAbsolutePath.StartsWith(testRootPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+            }
+            else // If the file has been configured individually.
+            {
+                testFrameworkName = projectItem.GetMetadataValue("TestFramework");
+                if (!TestFramework.IsValidTestFramework(testFrameworkName))
+                {
+                    return null;
+                }
+                fileAbsolutePath = CommonUtils.GetAbsoluteFilePath(projectRoot, projectItem.EvaluatedInclude);
+            }
+
+            // Check if file is a typecript file. If so, get the javascript file. The javascript file needs to be in the same path and name.
+            // It doesn't work with bundlers or minimizers. Also, project needs to be build in order to have the js file created.
+            var typeScriptTest = TypeScriptHelpers.IsTypeScriptFile(fileAbsolutePath);
+            if (typeScriptTest)
+            {
+                fileAbsolutePath = TypeScriptHelpers.GetTypeScriptBackedJavaScriptFile(project, fileAbsolutePath);
+            }
+            else if (!StringComparer.OrdinalIgnoreCase.Equals(Path.GetExtension(fileAbsolutePath), ".js"))
+            {
+                return null;
+            }
+
+            return (testFrameworkName, fileAbsolutePath);
+        }
+    }
+}

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -1,0 +1,97 @@
+﻿// @ts-check
+"use strict";
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require("child_process");
+
+process.env.VSTESTADAPTERPATH = __dirname;
+
+const karmaConfigName = "karma.conf.js";
+const vsKarmaConfigPath = path.resolve(__dirname, "./karmaConfig.js");
+
+const find_tests = function (configFiles, discoverResultFile, projectFolder) {
+    return new Promise(async resolve => {
+        const angular = detectPackage(projectFolder, '@angular/cli');
+        if (!angular) {
+            return;
+        }
+        for (let configFile of configFiles.split(';')) {
+            const projectPath = path.dirname(configFile);
+            const karmaConfigPath = path.resolve(projectPath, `./${karmaConfigName}`);
+
+            // process.chdir(configPath);
+            if (!fs.existsSync(karmaConfigPath)) {
+                logError(`Failed to find "${karmaConfigName}" file. The "${karmaConfigName}" file must exists in the same path as the "angular.json" file.`);
+                continue;
+            }
+
+            // Set the environment variable to share it across processes.
+            process.env.PROJECTPATH = projectPath;
+
+            // TODO: Handle npx or some other way to run ng not using the node_modules path.
+            const ngTest = spawn(
+                'E:/NodeJS/node-v13.11.0-win-x64/node.exe',
+                [
+                    path.resolve(projectPath, "./node_modules/@angular/cli/bin/ng"),
+                    'test',
+                    `--karmaConfig="${vsKarmaConfigPath}"`
+                ],
+                {
+                    cwd: projectPath,
+                    shell: true,
+                });
+
+            // TODO: Handle multiple projects. aka. multiple spawns running.
+            // const ngTest = spawn(
+            //     'npx',
+            //     ['ng', 'test', `--karmaConfig="${vsKarmaConfigPath}"`],
+            //     {
+            //         cwd: projectPath,
+            //         shell: true,
+            //     });
+
+            let data = "";
+            ngTest.stdout.on('data', (chunk) => {
+                data += chunk
+            });
+
+            ngTest.stdout.on('end', () => {
+                const fd = fs.openSync(discoverResultFile, 'w');
+                fs.writeSync(fd, data);
+                fs.closeSync(fd);
+
+                resolve();
+            });
+        };
+    });
+
+}
+
+const run_tests = function (context) {
+    throw new Error('Not implemented');
+}
+
+function detectPackage(projectFolder, packageName) {
+    try {
+        const packagePath = path.join(projectFolder, 'node_modules', packageName);
+        const pkg = require(packagePath);
+
+        return pkg;
+    } catch (ex) {
+        logError(
+            `Failed to find "${packageName}" package. "${packageName}" must be installed in the project locally.` + os.EOL +
+            `Install "${packageName}" locally using the npm manager via solution explorer` + os.EOL +
+            `or with ".npm install ${packageName} --save-dev" via the Node.js interactive window.`);
+        return null;
+    }
+}
+
+function logError() {
+    var errorArgs = Array.from(arguments);
+    errorArgs.unshift("NTVS_ERROR:");
+    console.error.apply(console, errorArgs);
+}
+
+module.exports.find_tests = find_tests;
+module.exports.run_tests = run_tests;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -30,9 +30,8 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
             process.env.TESTCASES = JSON.stringify([{ fullTitle: "NTVS_Discovery_ThisStringShouldExcludeAllTestCases" }]);
             process.env.ISDISCOVERY = 'true';
 
-            // TODO: Handle npx or some other way to run ng not using the node_modules path.
             const ngTest = spawn(
-                'E:/NodeJS/node-v13.11.0-win-x64/node.exe',
+                process.argv0, // Node executable path
                 [
                     path.resolve(projectPath, "./node_modules/@angular/cli/bin/ng"),
                     'test',
@@ -43,15 +42,6 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
                     shell: true,
                     stdio: ['pipe', 'ipc', 'pipe']
                 });
-
-            // TODO: Handle multiple projects. aka. multiple spawns running.
-            // const ngTest = spawn(
-            //     'npx',
-            //     ['ng', 'test', `--karmaConfig="${vsKarmaConfigPath}"`],
-            //     {
-            //         cwd: projectPath,
-            //         shell: true,
-            //     });
 
             const testsDiscovered = [];
 
@@ -73,7 +63,8 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
 const run_tests = function (context) {
     const projectFolder = context.testCases[0].projectFolder;
 
-    // TODO: Send the configuration path along with the test cases.
+    // TODO: Handle the scenario where Angular.json may not exists on a child folder instead of root.
+    // One way would be to send the location of angular.json instead of assuming it's on root.
     const configFile = `${projectFolder}/angular.json`;
 
     for (const testCase of context.testCases) {
@@ -101,9 +92,8 @@ const run_tests = function (context) {
         process.env.PROJECTPATH = projectPath;
         process.env.TESTCASES = JSON.stringify(context.testCases);
 
-        // TODO: Handle npx or some other way to run ng not using the node_modules path.
         const ngTest = spawn(
-            'E:/NodeJS/node-v13.11.0-win-x64/node.exe',
+            process.argv0, //Node executable path
             [
                 path.resolve(projectPath, "./node_modules/@angular/cli/bin/ng"),
                 'test',
@@ -114,15 +104,6 @@ const run_tests = function (context) {
                 shell: true,
                 stdio: ['pipe', 'ipc', 'pipe']
             });
-
-        // TODO: Handle multiple projects. aka. multiple spawns running.
-        // const ngTest = spawn(
-        //     'npx',
-        //     ['ng', 'test', `--karmaConfig="${vsKarmaConfigPath}"`],
-        //     {
-        //         cwd: projectPath,
-        //         shell: true,
-        //     });
 
         ngTest.on("message", message => {
             context.post({

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -20,7 +20,6 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
             const projectPath = path.dirname(configFile);
             const karmaConfigPath = path.resolve(projectPath, `./${karmaConfigName}`);
 
-            // process.chdir(configPath);
             if (!fs.existsSync(karmaConfigPath)) {
                 logError(`Failed to find "${karmaConfigName}" file. The "${karmaConfigName}" file must exists in the same path as the "angular.json" file.`);
                 continue;
@@ -28,6 +27,8 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
 
             // Set the environment variable to share it across processes.
             process.env.PROJECTPATH = projectPath;
+            process.env.TESTCASES = JSON.stringify([{ fullTitle: "NTVS_Discovery_ThisStringShouldExcludeAllTestCases" }]);
+            process.env.ISDISCOVERY = 'true';
 
             // TODO: Handle npx or some other way to run ng not using the node_modules path.
             const ngTest = spawn(
@@ -40,6 +41,7 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
                 {
                     cwd: projectPath,
                     shell: true,
+                    stdio: ['pipe', 'ipc', 'pipe']
                 });
 
             // TODO: Handle multiple projects. aka. multiple spawns running.
@@ -51,25 +53,93 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
             //         shell: true,
             //     });
 
-            let data = "";
-            ngTest.stdout.on('data', (chunk) => {
-                data += chunk
+            const testsDiscovered = [];
+
+            ngTest.on('message', message => {
+                testsDiscovered.push(message);
             });
 
-            ngTest.stdout.on('end', () => {
+            ngTest.on('exit', () => {
                 const fd = fs.openSync(discoverResultFile, 'w');
-                fs.writeSync(fd, data);
+                fs.writeSync(fd, JSON.stringify(testsDiscovered));
                 fs.closeSync(fd);
 
                 resolve();
             });
         };
     });
-
 }
 
 const run_tests = function (context) {
-    throw new Error('Not implemented');
+    const projectFolder = context.testCases[0].projectFolder;
+    
+    // TODO: Send the configuration path along with the test cases.
+    const configFile = "C:/Users/araguir/source/repos/AngularNTVSSample/AngularNTVSSample/angular.json";
+
+    for (const testCase of context.testCases) {
+        context.post({
+            type: 'test start',
+            fullyQualifiedName: testCase.fullyQualifiedName
+        });
+    }
+
+    return new Promise(async resolve => {
+        const angular = detectPackage(projectFolder, '@angular/cli');
+        if (!angular) {
+            return;
+        }
+        
+        const projectPath = path.dirname(configFile);
+        const karmaConfigPath = path.resolve(projectPath, `./${karmaConfigName}`);
+
+        if (!fs.existsSync(karmaConfigPath)) {
+            logError(`Failed to find "${karmaConfigName}" file. The "${karmaConfigName}" file must exists in the same path as the "angular.json" file.`);
+            return;
+        }
+
+        // Set the environment variable to share it across processes.
+        process.env.PROJECTPATH = projectPath;
+        process.env.TESTCASES = JSON.stringify(context.testCases);
+
+        // TODO: Handle npx or some other way to run ng not using the node_modules path.
+        const ngTest = spawn(
+            'E:/NodeJS/node-v13.11.0-win-x64/node.exe',
+            [
+                path.resolve(projectPath, "./node_modules/@angular/cli/bin/ng"),
+                'test',
+                `--karmaConfig="${vsKarmaConfigPath}"`
+            ],
+            {
+                cwd: projectPath,
+                shell: true,
+                stdio: ['pipe', 'ipc', 'pipe']
+            });
+
+        // TODO: Handle multiple projects. aka. multiple spawns running.
+        // const ngTest = spawn(
+        //     'npx',
+        //     ['ng', 'test', `--karmaConfig="${vsKarmaConfigPath}"`],
+        //     {
+        //         cwd: projectPath,
+        //         shell: true,
+        //     });
+
+        ngTest.on("message", message => {
+            context.post({
+                type: message.pending ? 'pending' : 'result',
+                fullyQualifiedName: context.getFullyQualifiedName(message.fullName),
+                result: message
+            });
+        });
+
+        ngTest.on('exit', () => {
+            context.post({
+                type: 'end'
+            });
+
+            resolve();
+        });
+    });
 }
 
 function detectPackage(projectFolder, packageName) {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -11,7 +11,7 @@ const karmaConfigName = "karma.conf.js";
 const vsKarmaConfigPath = path.resolve(__dirname, "./karmaConfig.js");
 
 const find_tests = function (configFiles, discoverResultFile, projectFolder) {
-    return new Promise(async resolve => {
+    return new Promise(resolve => {
         const angular = detectPackage(projectFolder, '@angular/cli');
         if (!angular) {
             return;
@@ -72,9 +72,9 @@ const find_tests = function (configFiles, discoverResultFile, projectFolder) {
 
 const run_tests = function (context) {
     const projectFolder = context.testCases[0].projectFolder;
-    
+
     // TODO: Send the configuration path along with the test cases.
-    const configFile = "C:/Users/araguir/source/repos/AngularNTVSSample/AngularNTVSSample/angular.json";
+    const configFile = `${projectFolder}/angular.json`;
 
     for (const testCase of context.testCases) {
         context.post({
@@ -83,12 +83,12 @@ const run_tests = function (context) {
         });
     }
 
-    return new Promise(async resolve => {
+    return new Promise(resolve => {
         const angular = detectPackage(projectFolder, '@angular/cli');
         if (!angular) {
             return;
         }
-        
+
         const projectPath = path.dirname(configFile);
         const karmaConfigPath = path.resolve(projectPath, `./${karmaConfigName}`);
 

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -1,5 +1,6 @@
 //@ts-check
 
+// Function used to add fileLocation to the result. Includes filepath, line and column of the test.
 function itReplacement(it) {
     return (description, testFunction, timeout) => {
         const spec = it(description, testFunction, timeout);
@@ -22,11 +23,39 @@ function getFileLocation() {
         : null;
 }
 
+// Example provided by MDN. Caused data loss by removing the circular reference.
+const getCircularReplacer = () => {
+    const seen = new WeakSet();
+
+    return (key, value) => {
+        if (isObject(value)) {
+            if (seen.has(value)) {
+                return;
+            }
+            seen.add(value);
+        }
+
+        return value;
+    };
+};
+
+function isObject(value) {
+    return typeof value === "object"
+        && value !== null
+        && !(value instanceof Boolean)
+        && !(value instanceof Date)
+        && !(value instanceof Number)
+        && !(value instanceof RegExp)
+        && !(value instanceof String)
+}
+
 var myReporter = {
     specDone: result => {
-        console.log(JSON.stringify(result));
+        // Communicate results through the console.
+        console.log(JSON.stringify(result, getCircularReplacer()));
     }
 };
 
 jasmine.getEnv().addReporter(myReporter);
 jasmine.getEnv().it = itReplacement(jasmine.getEnv().it);
+

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -16,7 +16,7 @@ function getFileLocation() {
 
     return match
         ? {
-            relativeFilePath: match[1], // Relative to root. This is due to webpack.
+            relativeFilePath: match[1], // Relative to karma config. This is due to webpack.
             line: match[2],
             column: match[3]
         }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -1,0 +1,32 @@
+//@ts-check
+
+function itReplacement(it) {
+    return (description, testFunction, timeout) => {
+        const spec = it(description, testFunction, timeout);
+        spec.result.fileLocation = getFileLocation();
+
+        return spec;
+    };
+}
+
+function getFileLocation() {
+    const stackLineRegex = /at.*\(.*_karma_webpack_(.*\.spec\.ts):(\d*):(\d*)/;
+    const match = (new Error()).stack.match(stackLineRegex);
+
+    return match
+        ? {
+            relativeFilePath: match[1], // Relative to root. This is due to webpack.
+            line: match[2],
+            column: match[3]
+        }
+        : null;
+}
+
+var myReporter = {
+    specDone: function (result) {
+        console.log(JSON.stringify(result));
+    }
+};
+
+jasmine.getEnv().addReporter(myReporter);
+jasmine.getEnv().it = itReplacement(jasmine.getEnv().it);

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -23,7 +23,7 @@ function getFileLocation() {
 }
 
 var myReporter = {
-    specDone: function (result) {
+    specDone: result => {
         console.log(JSON.stringify(result));
     }
 };

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -12,8 +12,7 @@ module.exports = function (config) {
     karmaConfig(config);
 
     config.autoWatch = false;
-    // config.browsers = ['ChromeHeadless'];
-    config.browsers = ['Chrome'];
+    config.browsers = ['ChromeHeadless'];
     config.logLevel = config.LOG_DISABLE;
     // Keep the original plugins
     config.plugins = config.plugins || [];
@@ -25,25 +24,19 @@ module.exports = function (config) {
 };
 
 function setGrep(config) {
-    // Search for an existing grep on clientArgs.
-    const clientArgs = [];
-    let hasGrep = false;
-    for (let arg of config.client.args) {
-        if (arg.substring(0, 6) === '--grep=') {
-            hasGrep = true;
-        }
-        clientArgs.push(arg);
-    }
+    // Remove any existing --grep argument
+    config.client.args = config.client.args.filter(x => x.substring(0, 7) !== '--grep=');
 
-    // If grep is not configured already, use VS configuration
-    if (!hasGrep) {
-        const testCasesRegex = testCases
-            .reduce((previous, current) => {
-                // TODO: Escape all of regex reserved characters.
-                previous.push(current.fullTitle);
-                return previous;
-            }, [])
-            .join('|');
-        config.client.args.push(`--grep=${testCasesRegex}`);
-    }
+    // Push custom grep.
+    const testCasesRegex = testCases
+        .reduce((previous, current) => {
+            previous.push(escapeRegExp(current.fullTitle));
+            return previous;
+        }, [])
+        .join('|');
+    config.client.args.push(`--grep=${testCasesRegex}`);
+}
+
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -1,0 +1,22 @@
+﻿// @ts-check
+
+const path = require('path');
+
+const karmaConfigPath = path.resolve(process.env.PROJECTPATH, 'karma.conf.js');
+const reporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'vsKarmaReporter.js');
+
+const karmaConfig = require(karmaConfigPath);
+
+module.exports = function (config) {
+    karmaConfig(config);
+
+    // config.browsers = ['ChromeHeadless'];
+    config.browsers = ['Chrome'];
+    config.autoWatch = false;
+    config.logLevel = config.LOG_DISABLE;
+    // Keep the original plugins
+    config.plugins = config.plugins || [];
+    config.plugins.push(require(reporterPath));
+    // Replace all reportrs.
+    config.reporters = ['vsKarmaReporter'];
+};

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -1,14 +1,13 @@
 ﻿// @ts-check
-
 const path = require('path');
 
-const karmaConfigPath = path.resolve(process.env.PROJECTPATH, 'karma.conf.js');
 const reporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'vsKarmaReporter.js');
 const testCases = JSON.parse(process.env.TESTCASES);
-
-const karmaConfig = require(karmaConfigPath);
+const karmaConfigPath = process.env.KARMACONFIGPATH;
 
 module.exports = function (config) {
+    const karmaConfig = require(karmaConfigPath);
+
     karmaConfig(config);
 
     config.autoWatch = false;
@@ -34,7 +33,7 @@ function setGrep(config) {
             return previous;
         }, [])
         .join('|');
-    config.client.args.push(`--grep=${testCasesRegex}`);
+    config.client.args.push(`--grep=/${testCasesRegex}/`);
 }
 
 function escapeRegExp(string) {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -3,15 +3,15 @@ const path = require('path');
 
 const reporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'vsKarmaReporter.js');
 const testCases = JSON.parse(process.env.TESTCASES);
-const karmaConfigPath = process.env.KARMACONFIGPATH;
+const project = JSON.parse(process.env.PROJECT);
 
 module.exports = function (config) {
-    const karmaConfig = require(karmaConfigPath);
+    const karmaConfig = require(project.karmaConfigPath);
 
     karmaConfig(config);
 
     config.autoWatch = false;
-    config.browsers = ['ChromeHeadless'];
+    config.browsers = ['Chrome'];
     config.logLevel = config.LOG_DISABLE;
     // Keep the original plugins
     config.plugins = config.plugins || [];

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -4,19 +4,46 @@ const path = require('path');
 
 const karmaConfigPath = path.resolve(process.env.PROJECTPATH, 'karma.conf.js');
 const reporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'vsKarmaReporter.js');
+const testCases = JSON.parse(process.env.TESTCASES);
 
 const karmaConfig = require(karmaConfigPath);
 
 module.exports = function (config) {
     karmaConfig(config);
 
+    config.autoWatch = false;
     // config.browsers = ['ChromeHeadless'];
     config.browsers = ['Chrome'];
-    config.autoWatch = false;
     config.logLevel = config.LOG_DISABLE;
     // Keep the original plugins
     config.plugins = config.plugins || [];
     config.plugins.push(require(reporterPath));
-    // Replace all reportrs.
+    // Replace all reporters
     config.reporters = ['vsKarmaReporter'];
+
+    setGrep(config);
 };
+
+function setGrep(config) {
+    // Search for an existing grep on clientArgs.
+    const clientArgs = [];
+    let hasGrep = false;
+    for (let arg of config.client.args) {
+        if (arg.substring(0, 6) === '--grep=') {
+            hasGrep = true;
+        }
+        clientArgs.push(arg);
+    }
+
+    // If grep is not configured already, use VS configuration
+    if (!hasGrep) {
+        const testCasesRegex = testCases
+            .reduce((previous, current) => {
+                // TODO: Escape all of regex reserved characters.
+                previous.push(current.fullTitle);
+                return previous;
+            }, [])
+            .join('|');
+        config.client.args.push(`--grep=${testCasesRegex}`);
+    }
+}

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -44,24 +44,20 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         }
 
         // Handles both scenarios, discovery and execution.
-        try {
-            process.send({
-                // Discovery properties
-                name: result.description,
-                suite,
-                filepath: fullFilePath,
-                line: result.fileLocation.line,
-                column: result.fileLocation.column,
+        process.send({
+            // Discovery properties
+            name: result.description,
+            suite,
+            filepath: fullFilePath,
+            line: result.fileLocation.line,
+            column: result.fileLocation.column,
 
-                // Execution properties
-                passed: result.status === "passed",
-                pending: result.status === "disabled" || result.status === "pending",
-                fullName: result.fullName,
-                stderr: errorLog
-            });
-        } catch (e) {
-            log.debug(`error: ${JSON.stringify(e)}`);
-        }
+            // Execution properties
+            passed: result.status === "passed",
+            pending: result.status === "disabled" || result.status === "pending",
+            fullName: result.fullName,
+            stderr: errorLog
+        });
 
         log.debug(`onBrowserLog: ${JSON.stringify(result)}`);
     }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const jasmineReporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'jasmineReporter.js');
 const isDiscovery = process.env.ISDISCOVERY === 'true';
+const project = JSON.parse(process.env.PROJECT);
 
 const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter) {
     baseReporterDecorator(this);
@@ -47,7 +48,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         // Increment the amount of test cases found.
         testCaseCount++;
 
-        const fullFilePath = `${process.env.PROJECTPATH}${result.fileLocation.relativeFilePath}`;
+        const fullFilePath = path.join(path.dirname(project.karmaConfigPath), result.fileLocation.relativeFilePath);
         const suite = result.fullName.substring(0, result.fullName.length - result.description.length - 1);
 
         let errorLog = "";

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -18,6 +18,10 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         watched: false
     });
 
+    this.onBrowserError = (browser, error) => {
+        log.debug(`onBrowserError: ${JSON.stringify(error)}`);
+    }
+
     // TODO: Is there a better option than onBrowserLog?
     this.onBrowserLog = (browser, browserLog, type) => {
         const cleaned = browserLog.substring(1, browserLog.length - 1); // Remove extra quote at start and end
@@ -33,7 +37,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
 
         let errorLog = "";
         for (const failedExpectation of result.failedExpectations) {
-            errorLog += `\n\nMessage: ${failedExpectation.message}\nStack:\n${failedExpectation.stack}`;
+            errorLog += `${failedExpectation.stack}\n`;
         }
 
         // Handles both scenarios, discovery and execution.
@@ -67,11 +71,14 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         }
     }
 
+    // Override specFailure to avoid crashing the process as Karma sends a string output that cannot be parsed as JSON.
+    this.specFailure = () => { }
+
     let hasStarted = false;
 
     // Check when browser is ready to request a run.
     emitter.on("browsers_ready", () => {
-        // There's Scenario that I'm not sure how to repro where the browser do something (refresh? crashes?)
+        // There's a scenario that I'm not sure how to repro where the browser do something (refresh? crashes?)
         // and we get the event again. We only want to executed it once.
         if (!hasStarted) {
             hasStarted = true;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -1,0 +1,86 @@
+﻿// @ts-check
+
+const http = require('http');
+const path = require('path');
+
+const jasmineReporterPath = path.resolve(process.env.VSTESTADAPTERPATH, 'jasmineReporter.js');
+
+const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter) {
+    baseReporterDecorator(this);
+    const log = logger.create('vsKarmaReporter');
+
+    config.files.push({
+        included: true,
+        pattern: jasmineReporterPath,
+        served: true,
+        watched: false
+    });
+
+    const testList = [];
+
+    // TODO: Is there a better option than onBrowserLog?
+    this.onBrowserLog = (browser, browserLog, type) => {
+        // TODO: handle status "Excluded";
+        const cleaned = browserLog.substring(1, browserLog.length - 1); // Remove extra quote at start and end
+        const result = JSON.parse(cleaned);
+
+        const fullFilePath = `${process.env.PROJECTPATH}${result.fileLocation.relativeFilePath}`;
+        const suite = result.fullName.substring(0, result.fullName.length - result.description.length - 1);
+
+        let errorLog = "";
+        for (const failedExpectation of result.failedExpectations) {
+            errorLog += `\n\nMessage: ${failedExpectation.message}\nStack:\n${failedExpectation.stack}`;
+        }
+
+        // Handles both scenarios, discovery and execution.
+        testList.push({
+            // Discovery properties
+            name: result.description,
+            suite,
+            filepath: fullFilePath,
+            line: result.fileLocation.line,
+            column: result.fileLocation.column,
+
+            // Execution properties
+            passed: result.status === "passed",
+            pending: result.status === "disabled" || result.status === "pending",
+            fullyQualifiedName: `${result.fileLocation.relativeFilePath}::${suite}::${result.description}`,
+            stderr: errorLog
+        });
+
+        log.debug(`onBrowserLog: ${JSON.stringify(result)}`);
+    }
+
+    this.onRunComplete = (browsers, results) => {
+        console.log(JSON.stringify(testList));
+
+        log.debug(`onRunComplete: ${JSON.stringify(results)}`);
+
+        // We need to exit the process as angular keeps listening, so it never emits an 'end' event.
+        process.exit();
+    }
+
+    // Check when browser is ready to request a run.
+    emitter.on("browsers_ready", () => {
+        const options = {
+            hostname: 'localhost',
+            path: '/run',
+            port: 9876, // Default karma port.
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        };
+
+        const request = http.request(options);
+        request.end(
+            JSON.stringify({ args: ['--grep="NTVS_AStringThatShouldNeverExists"'] })
+        );
+    });
+}
+
+vsKarmaReporter.$inject = ['baseReporterDecorator', 'config', 'logger', 'emitter'];
+
+module.exports = {
+    'reporter:vsKarmaReporter': ['type', vsKarmaReporter]
+}

--- a/Nodejs/Product/TestAdapter/TestFrameworks/ExportRunner/exportrunner.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/ExportRunner/exportrunner.js
@@ -8,82 +8,90 @@ var result = {
 };
 
 var find_tests = function (testFileList, discoverResultFile) {
-    var debug;
-    try {
-        if (vm.runInDebugContext) {
-            debug = vm.runInDebugContext('Debug');
-        }
-    } catch (ex) {
-        console.error("NTVS_ERROR:", ex);
-    }
-
-    var testList = [];
-    testFileList.split(';').forEach(function (testFile) {
-        var testCases;
-        process.chdir(path.dirname(testFile));
+    return new Promise(resolve => {
+        var debug;
         try {
-            testCases = require(testFile);
-        } catch (ex) {
-            console.error("NTVS_ERROR:", ex, "in", testFile);
-            return;
-        }
-        for (var test in testCases) {
-            var line = 0;
-            var column = 0;
-            if (debug !== undefined) {
-                try {
-                    var funcDetails = debug.findFunctionSourceLocation(testCases[test]);
-                    if (funcDetails !== undefined) {
-                        line = funcDetails.line; // 0 based
-                        column = funcDetails.column; // 0 based
-                    }
-                } catch (e) {
-                    //If we take an exception mapping the source line, simply fallback to unknown source map 
-                }
+            if (vm.runInDebugContext) {
+                debug = vm.runInDebugContext('Debug');
             }
-            testList.push({
-                name: test,
-                suite: '',
-                filepath: testFile,
-                line: line,
-                column: column
-            });
+        } catch (ex) {
+            console.error("NTVS_ERROR:", ex);
         }
-    });
 
-    var fd = fs.openSync(discoverResultFile, 'w');
-    fs.writeSync(fd, JSON.stringify(testList));
-    fs.closeSync(fd);
+        var testList = [];
+        testFileList.split(';').forEach(function (testFile) {
+            var testCases;
+            process.chdir(path.dirname(testFile));
+            try {
+                testCases = require(testFile);
+            } catch (ex) {
+                console.error("NTVS_ERROR:", ex, "in", testFile);
+                return;
+            }
+            for (var test in testCases) {
+                var line = 0;
+                var column = 0;
+                if (debug !== undefined) {
+                    try {
+                        var funcDetails = debug.findFunctionSourceLocation(testCases[test]);
+                        if (funcDetails !== undefined) {
+                            line = funcDetails.line; // 0 based
+                            column = funcDetails.column; // 0 based
+                        }
+                    } catch (e) {
+                        //If we take an exception mapping the source line, simply fallback to unknown source map 
+                    }
+                }
+                testList.push({
+                    name: test,
+                    suite: '',
+                    filepath: testFile,
+                    line: line,
+                    column: column
+                });
+            }
+        });
+
+        var fd = fs.openSync(discoverResultFile, 'w');
+        fs.writeSync(fd, JSON.stringify(testList));
+        fs.closeSync(fd);
+
+        resolve();
+    });
 };
 module.exports.find_tests = find_tests;
 
 var run_tests = function (context) {
-    for (var test of context.testCases) {
-        context.post({
-            type: 'test start',
-            fullyQualifiedName: test.fullyQualifiedName
-        });
-        try {
-            var testCase = require(test.testFile);
-            result.fullyQualifiedName = test.fullyQualifiedName;
-            testCase[test.fullTitle]();
-            result.passed = true;
-            console.log("Test passed.\n");
-        } catch (err) {
-            result.passed = false;
-            console.error(err.name);
-            console.error(err.message);
+    return new Promise(resolve => {
+        for (var test of context.testCases) {
+            context.post({
+                type: 'test start',
+                fullyQualifiedName: test.fullyQualifiedName
+            });
+            try {
+                var testCase = require(test.testFile);
+                result.fullyQualifiedName = test.fullyQualifiedName;
+                testCase[test.fullTitle]();
+                result.passed = true;
+                console.log("Test passed.\n");
+            } catch (err) {
+                result.passed = false;
+                console.error(err.name);
+                console.error(err.message);
+            }
+            context.post({
+                type: 'result',
+                fullyQualifiedName: test.fullyQualifiedName,
+                result: result
+            });
+            context.clearOutputs();
         }
-        context.post({
-            type: 'result',
-            fullyQualifiedName: test.fullyQualifiedName,
-            result: result
+
+        context.callback({
+            type: 'end'
         });
-        context.clearOutputs();
-    }
-    context.callback({
-        type: 'end'
+
+        resolve();
     });
-    process.exit();
 };
 module.exports.run_tests = run_tests;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -10,8 +10,6 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
     {
         public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir)
         {
-            Debug.Assert(testPath.EndsWith(".js", StringComparison.OrdinalIgnoreCase) || testPath.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase));
-
             var testFileRelative = CommonUtils.GetRelativeFilePath(projectRootDir, testPath);
 
             this.TestFile = testFileRelative;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Tape/tape.js
@@ -5,126 +5,135 @@ var fs = require('fs');
 var path = require('path');
 
 function find_tests(testFileList, discoverResultFile, projectFolder) {
-    var test = findTape(projectFolder);
-    if (test === null) {
-        return;
-    }
-
-    var harness = test.getHarness({ exit: false });
-    var tests = harness['_tests'];
-
-    var count = 0;
-    var testList = [];
-    testFileList.split(';').forEach(function (testFile) {
-        var testCases = loadTestCases(testFile);
-        if (testCases === null) return; // continue to next testFile
-
-        for (; count < tests.length; count++) {
-            var t = tests[count];
-            t._skip = true; // don't run tests
-            testList.push({
-                name: t.name,
-                suite: '',
-                filepath: testFile,
-                line: 0,
-                column: 0
-            });
+    return new Promise(resolve => {
+        var test = findTape(projectFolder);
+        if (test === null) {
+            return resolve();
         }
-    });
 
-    var fd = fs.openSync(discoverResultFile, 'w');
-    fs.writeSync(fd, JSON.stringify(testList));
-    fs.closeSync(fd);
+        var harness = test.getHarness({ exit: false });
+        var tests = harness['_tests'];
+
+        var count = 0;
+        var testList = [];
+        testFileList.split(';').forEach(function (testFile) {
+            var testCases = loadTestCases(testFile);
+            if (testCases === null) return; // continue to next testFile
+
+            for (; count < tests.length; count++) {
+                var t = tests[count];
+                t._skip = true; // don't run tests
+                testList.push({
+                    name: t.name,
+                    suite: '',
+                    filepath: testFile,
+                    line: 0,
+                    column: 0
+                });
+            }
+        });
+
+        var fd = fs.openSync(discoverResultFile, 'w');
+        fs.writeSync(fd, JSON.stringify(testList));
+        fs.closeSync(fd);
+
+        resolve();
+    });
 }
 module.exports.find_tests = find_tests;
 
 function run_tests(context) {
-
-    var tape = findTape(context.testCases[0].projectFolder);
-    if (tape === null) {
-        return;
-    }
-
-    // Since the test events don't come in order we store all of them in this array
-    // in the 'onFinish' event we loop through them and process anything remaining.
-    var testState = [];
-    var harness = tape.getHarness({ objectMode: true });
-
-    harness.createStream({ objectMode: true }).on('data', function (evt) {
-        var result;
-
-        switch (evt.type) {
-            case 'test':
-                result = {
-                    fullyQualifiedName: context.getFullyQualifiedName(evt.name),
-                    passed: undefined,
-                    stdout: '',
-                    stderr: ''
-                };
-
-                testState[evt.id] = result;
-
-                // Test is starting. Reset the result object. Send a "test start" event.
-                context.post({
-                    type: 'test start',
-                    fullyQualifiedName: result.fullyQualifiedName
-                });
-                break;
-            case 'assert':
-                result = testState[evt.test];
-                if (!result) { break; }
-
-                // Correlate the success/failure asserts for this test. There may be multiple per test
-                var msg = "Operator: " + evt.operator + ". Expected: " + evt.expected + ". Actual: " + evt.actual + ". evt: " + JSON.stringify(evt) + "\n";
-                if (evt.ok) {
-                    result.stdout += msg;
-                    result.passed = result.passed === undefined ? true : result.passed;
-                } else {
-                    result.stderr += msg + (evt.error.stack || evt.error.message) + "\n";
-                    result.passed = false;
-                }
-                break;
-            case 'end':
-                result = testState[evt.test];
-                if (!result) { break; }
-                // Test is done. Send a "result" event.
-                context.post({
-                    type: 'result',
-                    fullyQualifiedName: result.fullyQualifiedName,
-                    result
-                });
-                context.clearOutputs();
-                testState[evt.test] = undefined;
-                break;
-            default:
-                break;
+    return new Promise(resolve => {
+        var tape = findTape(context.testCases[0].projectFolder);
+        if (tape === null) {
+            return resolve();
         }
-    });
 
-    loadTestCases(context.testCases[0].testFile);
+        // Since the test events don't come in order we store all of them in this array
+        // in the 'onFinish' event we loop through them and process anything remaining.
+        var testState = [];
+        var harness = tape.getHarness({ objectMode: true });
 
-    // Skip those not selected to run. The rest will start running on the next tick.
-    harness['_tests'].forEach(function (test) {
-        if (!context.testCases.some(function (ti) { return ti.fullyQualifiedName === context.getFullyQualifiedName(test.name); })) {
-            test._skip = true;
-        }
-    });
+        harness.createStream({ objectMode: true }).on('data', function (evt) {
+            var result;
 
-    harness.onFinish(function () {
-        // TODO: Not used?
-        // loop through items in testState
-        for (var i = 0; i < testState.length; i++) {
-            if (testState[i]) {
-                var result = testState[i];
-                if (!result.passed) { result.passed = false; }
-                //callback({
-                //    'type': 'result',
-                //    'fullyQualifiedName': result.fullyQualifiedName,
-                //    'result': result
-                //});
+            switch (evt.type) {
+                case 'test':
+                    result = {
+                        fullyQualifiedName: context.getFullyQualifiedName(evt.name),
+                        passed: undefined,
+                        stdout: '',
+                        stderr: ''
+                    };
+
+                    testState[evt.id] = result;
+
+                    // Test is starting. Reset the result object. Send a "test start" event.
+                    context.post({
+                        type: 'test start',
+                        fullyQualifiedName: result.fullyQualifiedName
+                    });
+                    break;
+                case 'assert':
+                    result = testState[evt.test];
+                    if (!result) { break; }
+
+                    // Correlate the success/failure asserts for this test. There may be multiple per test
+                    var msg = "Operator: " + evt.operator + ". Expected: " + evt.expected + ". Actual: " + evt.actual + ". evt: " + JSON.stringify(evt) + "\n";
+                    if (evt.ok) {
+                        result.stdout += msg;
+                        result.passed = result.passed === undefined ? true : result.passed;
+                    } else {
+                        result.stderr += msg + (evt.error.stack || evt.error.message) + "\n";
+                        result.passed = false;
+                    }
+                    break;
+                case 'end':
+                    result = testState[evt.test];
+                    if (!result) { break; }
+                    // Test is done. Send a "result" event.
+                    context.post({
+                        type: 'result',
+                        fullyQualifiedName: result.fullyQualifiedName,
+                        result
+                    });
+                    context.clearOutputs();
+                    testState[evt.test] = undefined;
+                    break;
+                default:
+                    break;
             }
-        }
-        process.exit(0);
+        });
+
+        loadTestCases(context.testCases[0].testFile);
+
+        // Skip those not selected to run. The rest will start running on the next tick.
+        harness['_tests'].forEach(function (test) {
+            if (!context.testCases.some(function (ti) { return ti.fullyQualifiedName === context.getFullyQualifiedName(test.name); })) {
+                test._skip = true;
+            }
+        });
+
+        harness.onFinish(function () {
+            // loop through items in testState
+            for (var i = 0; i < testState.length; i++) {
+                if (testState[i]) {
+                    var result = testState[i];
+                    if (!result.passed) { result.passed = false; }
+                    //callback({
+                    //    'type': 'result',
+                    //    'fullyQualifiedName': result.fullyQualifiedName,
+                    //    'result': result
+                    //});
+                }
+            }
+
+            context.post({
+                type: 'end'
+            });
+
+            return resolve();
+        });
     });
 }
 module.exports.run_tests = run_tests;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
@@ -1,3 +1,4 @@
+//@ts-check
 const fs = require("fs");
 
 let framework;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
@@ -1,11 +1,13 @@
-var fs = require("fs");
-var framework;
+const fs = require("fs");
+
+let framework;
 try {
     framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
 } catch (exception) {
     console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
     process.exit(1);
 }
+
 try {
     var testFilesListInputFile = process.argv[3];
     if (!fs.existsSync(testFilesListInputFile)) {
@@ -24,4 +26,3 @@ try {
     console.log("NTVS_ERROR:TestFramework (" + process.argv[2] + ") threw an exception processing (" + process.argv[3] + "), " + exception);
     process.exit(1);
 }
-process.exit(0);

--- a/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/find_tests.js
@@ -1,29 +1,34 @@
 //@ts-check
 const fs = require("fs");
 
-let framework;
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
-
-try {
-    var testFilesListInputFile = process.argv[3];
-    if (!fs.existsSync(testFilesListInputFile)) {
-        throw new Error("testFilesListInputFile '" + testFilesListInputFile + "' does not exist.");
+async function findTests() {
+    let framework;
+    try {
+        framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
+    } catch (exception) {
+        throw new Error("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
     }
 
-    var testFilesList = fs.readFileSync(testFilesListInputFile, "utf-8");
+    try {
+        var testFilesListInputFile = process.argv[3];
+        if (!fs.existsSync(testFilesListInputFile)) {
+            throw new Error("testFilesListInputFile '" + testFilesListInputFile + "' does not exist.");
+        }
 
-    // strip the BOM in case of UTF-8
-    if (testFilesList.charCodeAt(0) === 0xFEFF) {
-        testFilesList = testFilesList.slice(1);
+        var testFilesList = fs.readFileSync(testFilesListInputFile, "utf-8");
+
+        // strip the BOM in case of UTF-8
+        if (testFilesList.charCodeAt(0) === 0xFEFF) {
+            testFilesList = testFilesList.slice(1);
+        }
+
+        await framework.find_tests(testFilesList, process.argv[4], process.argv[5]);
+    } catch (exception) {
+        throw new Error("NTVS_ERROR:TestFramework (" + process.argv[2] + ") threw an exception processing (" + process.argv[3] + "), " + exception);
     }
-
-    framework.find_tests(testFilesList, process.argv[4], process.argv[5]);
-} catch (exception) {
-    console.log("NTVS_ERROR:TestFramework (" + process.argv[2] + ") threw an exception processing (" + process.argv[3] + "), " + exception);
-    process.exit(1);
 }
+
+findTests().catch(e => {
+    console.log(e);
+    process.exit(1);
+});

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -6,30 +6,8 @@ var rl = readline.createInterface({
     output: process.stdout
 });
 
-rl.on('line', function (line2) {
+rl.on('line', function (line) {
     rl.close();
-
-    var line = line2 || JSON.stringify(
-        [{
-            "framework": "Angular",
-            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should fail\"",
-            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
-            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
-            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
-        }, {
-            "framework": "Angular",
-            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should fail as well\"",
-            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
-            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
-            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
-        }, {
-            "framework": "Angular",
-            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should not fail\"",
-            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
-            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
-            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
-        }]
-    );
 
     // strip the BOM in case of UTF-8
     if (line.charCodeAt(0) === 0xFEFF) {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -6,7 +6,7 @@ var rl = readline.createInterface({
     output: process.stdout
 });
 
-rl.on('line', function (line) {
+rl.on('line', async function (line) {
     rl.close();
 
     // strip the BOM in case of UTF-8
@@ -25,13 +25,11 @@ rl.on('line', function (line) {
 
     try {
         framework = require('./' + context.testCases[0].framework + '/' + context.testCases[0].framework + '.js');
+        await framework.run_tests(context);
     } catch (exception) {
         console.log("NTVS_ERROR:Failed to load TestFramework (" + context.testCases[0].framework + "), " + exception);
         process.exit(1);
     }
-
-    // run the test
-    framework.run_tests(context);
 });
 
 function createContext(line) {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -6,8 +6,30 @@ var rl = readline.createInterface({
     output: process.stdout
 });
 
-rl.on('line', function (line) {
+rl.on('line', function (line2) {
     rl.close();
+
+    var line = line2 || JSON.stringify(
+        [{
+            "framework": "Angular",
+            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should fail\"",
+            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
+            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
+            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
+        }, {
+            "framework": "Angular",
+            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should fail as well\"",
+            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
+            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
+            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
+        }, {
+            "framework": "Angular",
+            "fullyQualifiedName": "\"src\\app\\app.component2.spec.ts::CustomTest::Should not fail\"",
+            "testFile": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\\src\\app\\app.component2.spec.ts\"",
+            "workingFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\"",
+            "projectFolder": "\"C:\\Users\\araguir\\source\\repos\\NodeJsAngularUnitTestSample\\NodeJsAngularUnitTestSample\""
+        }]
+    );
 
     // strip the BOM in case of UTF-8
     if (line.charCodeAt(0) === 0xFEFF) {

--- a/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
+++ b/Nodejs/Product/TypeScript/TypeScriptHelpers.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NodejsTools.TypeScript
             return StringComparer.OrdinalIgnoreCase.Equals(extension, NodejsConstants.NodejsProjectExtension)
                 || StringComparer.OrdinalIgnoreCase.Equals(extension, NodejsConstants.CSharpProjectExtension)
                 || StringComparer.OrdinalIgnoreCase.Equals(extension, NodejsConstants.VisualBasicProjectExtension)
-                || StringComparer.OrdinalIgnoreCase.Equals(extension, NodejsConstants.AngularProjectExtension);
+                || StringComparer.OrdinalIgnoreCase.Equals(extension, NodejsConstants.JavaScriptProjectExtension);
         }
 
 #if !NETSTANDARD2_0


### PR DESCRIPTION
Adds the capability to run and discovers Angular tests.

Details:
- Changed the behavior of how it discovers tests. For Angular only, it will search for an `angular.json` file instead of the user manually specifying the test adapter. This is done with the purpose of facilitating the configuration but also for identifying the root path of the tests. Currently, it's only discoverable if the file is on the root path; this is an NTVS limitation that I will work on a separate PR.
- During execution, I have changed to send all of the selected tests instead of a by file basis. The by file basis strategy is not useful for angular as it requires to spin up a server every time, Causing execution to appear slow.
- Excluded searching for tests on node_modules folders. Affects all test adapters.
- Added support for `esproj`.

Extra notes:
- There are a bunch of todos that still require to be worked out. I'll be addressing those on a different PR as they are not required for Angular tests to work.
- No support yet for .NET Core. Will be coming next.
- Pending discussion of it's a good idea to implement discovery and execution by config file instead of manual configuration fot the rest of the tests adapters. 