### PR TITLE
fix: source map overrides changed to dictionary

### DIFF
--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -652,7 +652,7 @@ namespace Microsoft.NodejsTools.Project
         public object Server { get; set; } 
 
         [JsonProperty("sourceMapPathOverrides")]
-        public string[] SourceMapPathOverrides { get; set; }
+        public Dictionary<string, string> SourceMapPathOverrides { get; set; }
 
         [JsonProperty("restart")]
         public bool RestartPolicy { get; set; }
@@ -669,7 +669,6 @@ namespace Microsoft.NodejsTools.Project
         public object toPwaChromeServerConfig()
         {
             this.Console = "internalConsole";
-            this.SourceMapPathOverrides = new string[0];
             return this;
         }
     }

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectLauncher.cs
@@ -669,6 +669,7 @@ namespace Microsoft.NodejsTools.Project
         public object toPwaChromeServerConfig()
         {
             this.Console = "internalConsole";
+            this.SourceMapPathOverrides = new Dictionary<string, string>();
             return this;
         }
     }


### PR DESCRIPTION
The "sourceMapPathOverrides" field in WebDiagnosticsComponents changed from a string array to a Dictionary<string, string>. Reflecting that change here.