### PR TITLE
fix: extra slash in devenv path for launching vsix project

### DIFF
--- a/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
+++ b/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
@@ -30,7 +30,7 @@
     <IncludePackageReferencesInVSIXContainer>false</IncludePackageReferencesInVSIXContainer>
     <!--For F5 debugging-->
     <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Removing an extra slash in the devenv path which seems to break launching the vsix project