### PR TITLE
Add .NET Core Angular unit test support

### DIFF
--- a/Nodejs/Product/TestAdapter/JavaScriptTestCaseProperties.cs
+++ b/Nodejs/Product/TestAdapter/JavaScriptTestCaseProperties.cs
@@ -11,5 +11,6 @@ namespace Microsoft.NodejsTools.TestAdapter
         public static readonly TestProperty NodeExePath = TestProperty.Register(id: $"NodeTools.{nameof(NodeExePath)}", label: nameof(NodeExePath), valueType: typeof(string), owner: typeof(TestCase));
         public static readonly TestProperty ProjectRootDir = TestProperty.Register(id: $"NodeTools.{nameof(ProjectRootDir)}", label: nameof(ProjectRootDir), valueType: typeof(string), owner: typeof(TestCase));
         public static readonly TestProperty TestFile = TestProperty.Register(id: $"NodeTools.{nameof(TestFile)}", label: nameof(TestFile), valueType: typeof(string), owner: typeof(TestCase));
+        public static readonly TestProperty ConfigPath = TestProperty.Register(id: $"NodeTools.{nameof(ConfigPath)}", label: nameof(ConfigPath), valueType: typeof(string), owner: typeof(TestCase));
     }
 }

--- a/Nodejs/Product/TestAdapter/JavaScriptTestCaseProperties.cs
+++ b/Nodejs/Product/TestAdapter/JavaScriptTestCaseProperties.cs
@@ -11,6 +11,6 @@ namespace Microsoft.NodejsTools.TestAdapter
         public static readonly TestProperty NodeExePath = TestProperty.Register(id: $"NodeTools.{nameof(NodeExePath)}", label: nameof(NodeExePath), valueType: typeof(string), owner: typeof(TestCase));
         public static readonly TestProperty ProjectRootDir = TestProperty.Register(id: $"NodeTools.{nameof(ProjectRootDir)}", label: nameof(ProjectRootDir), valueType: typeof(string), owner: typeof(TestCase));
         public static readonly TestProperty TestFile = TestProperty.Register(id: $"NodeTools.{nameof(TestFile)}", label: nameof(TestFile), valueType: typeof(string), owner: typeof(TestCase));
-        public static readonly TestProperty ConfigPath = TestProperty.Register(id: $"NodeTools.{nameof(ConfigPath)}", label: nameof(ConfigPath), valueType: typeof(string), owner: typeof(TestCase));
+        public static readonly TestProperty ConfigDirPath = TestProperty.Register(id: $"NodeTools.{nameof(ConfigDirPath)}", label: nameof(ConfigDirPath), valueType: typeof(string), owner: typeof(TestCase));
     }
 }

--- a/Nodejs/Product/TestAdapter/PackageJsonTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/PackageJsonTestDiscoverer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             testFx = testFx ?? this.frameworkDiscoverer.GetFramework(TestFrameworkDirectories.ExportRunnerFrameworkName);
 
             var nodeExePath = Nodejs.GetPathToNodeExecutableFromEnvironment();
-            var worker = new TestDiscovererWorker(packageJsonPath, NodejsConstants.PackageJsonExecutorUri, nodeExePath);
+            var worker = new TestDiscovererWorker(packageJsonPath, nodeExePath);
             worker.DiscoverTests(testFolderPath, testFx, logger, discoverySink);
         }
     }

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -97,6 +97,8 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         private void DiscoverTests(Dictionary<string, HashSet<string>> testItems, FrameworkDiscoverer frameworkDiscoverer, ITestCaseDiscoverySink discoverySink, IMessageLogger logger, string nodeExePath, string projectFullPath)
         {
+            var discoverWorker = new TestDiscovererWorker(projectFullPath, nodeExePath);
+
             foreach (var testFx in testItems.Keys)
             {
                 var testFramework = frameworkDiscoverer.GetFramework(testFx);
@@ -108,7 +110,6 @@ namespace Microsoft.NodejsTools.TestAdapter
 
                 var fileList = testItems[testFx];
 
-                var discoverWorker = new TestDiscovererWorker(projectFullPath, NodejsConstants.ExecutorUri, nodeExePath);
                 discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink);
             }
         }

--- a/Nodejs/Product/TestAdapter/SerializationHelpers.cs
+++ b/Nodejs/Product/TestAdapter/SerializationHelpers.cs
@@ -40,22 +40,22 @@ internal sealed class TestCaseObject
         this.testFile = string.Empty;
         this.workingFolder = string.Empty;
         this.projectFolder = string.Empty;
-        this.configPath = string.Empty;
+        this.configDirPath = string.Empty;
     }
 
-    public TestCaseObject(string framework, string fullyQualifiedName, string testFile, string workingFolder, string projectFolder, string configPath)
+    public TestCaseObject(string framework, string fullyQualifiedName, string testFile, string workingFolder, string projectFolder, string configDirPath)
     {
         this.framework = framework;
         this.fullyQualifiedName = fullyQualifiedName;
         this.testFile = testFile;
         this.workingFolder = workingFolder;
         this.projectFolder = projectFolder;
-        this.configPath = configPath;
+        this.configDirPath = configDirPath;
     }
     public string framework { get; set; }
     public string fullyQualifiedName { get; set; }
     public string testFile { get; set; }
     public string workingFolder { get; set; }
     public string projectFolder { get; set; }
-    public string configPath { get; set; }
+    public string configDirPath { get; set; }
 }

--- a/Nodejs/Product/TestAdapter/SerializationHelpers.cs
+++ b/Nodejs/Product/TestAdapter/SerializationHelpers.cs
@@ -40,19 +40,22 @@ internal sealed class TestCaseObject
         this.testFile = string.Empty;
         this.workingFolder = string.Empty;
         this.projectFolder = string.Empty;
+        this.configPath = string.Empty;
     }
 
-    public TestCaseObject(string framework, string fullyQualifiedName, string testFile, string workingFolder, string projectFolder)
+    public TestCaseObject(string framework, string fullyQualifiedName, string testFile, string workingFolder, string projectFolder, string configPath)
     {
         this.framework = framework;
         this.fullyQualifiedName = fullyQualifiedName;
         this.testFile = testFile;
         this.workingFolder = workingFolder;
         this.projectFolder = projectFolder;
+        this.configPath = configPath;
     }
     public string framework { get; set; }
     public string fullyQualifiedName { get; set; }
     public string testFile { get; set; }
     public string workingFolder { get; set; }
     public string projectFolder { get; set; }
+    public string configPath { get; set; }
 }

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -78,6 +78,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.ProjectRootDir, this.workingDir);
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.NodeExePath, this.nodeExePath);
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.TestFile, filePath);
+                testCase.SetPropertyValue(JavaScriptTestCaseProperties.ConfigPath, discoveredTest.ConfigPath);
 
                 discoverySink.SendTestCase(testCase);
             }

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -17,14 +17,12 @@ namespace Microsoft.NodejsTools.TestAdapter
     {
         private readonly string testSource;
         private readonly string workingDir;
-        private readonly Uri testExecutorUri;
         private readonly string nodeExePath;
 
-        public TestDiscovererWorker(string testSource, Uri testExecutorUri, string nodeExePath)
+        public TestDiscovererWorker(string testSource, string nodeExePath)
         {
             this.testSource = testSource;
             this.workingDir = Path.GetDirectoryName(this.testSource);
-            this.testExecutorUri = testExecutorUri;
             this.nodeExePath = nodeExePath;
         }
 
@@ -78,7 +76,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.ProjectRootDir, this.workingDir);
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.NodeExePath, this.nodeExePath);
                 testCase.SetPropertyValue(JavaScriptTestCaseProperties.TestFile, filePath);
-                testCase.SetPropertyValue(JavaScriptTestCaseProperties.ConfigPath, discoveredTest.ConfigPath);
+                testCase.SetPropertyValue(JavaScriptTestCaseProperties.ConfigDirPath, discoveredTest.ConfigDirPath);
 
                 discoverySink.SendTestCase(testCase);
             }

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -190,7 +190,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                     testFile: args.TestFile,
                     workingFolder: args.WorkingDirectory,
                     projectFolder: args.ProjectRootDir,
-                    configPath: args.ConfigPath));
+                    configDirPath: args.ConfigDirPath));
             }
 
             var port = 0;
@@ -384,8 +384,8 @@ namespace Microsoft.NodejsTools.TestAdapter
         {
             var testFile = test.GetPropertyValue(JavaScriptTestCaseProperties.TestFile, defaultValue: test.CodeFilePath);
             var testFramework = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFramework, defaultValue: null);
-            var configPath = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.ConfigPath, defaultValue: null);
-            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.FullyQualifiedName, testFile, workingDir, projectRootDir, configPath);
+            var configDirPath = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.ConfigDirPath, defaultValue: null);
+            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.FullyQualifiedName, testFile, workingDir, projectRootDir, configDirPath);
         }
 
         private static string GetDebugArgs(Version nodeVersion, out int port)

--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -157,7 +157,6 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             // All tests being run are for the same test file, so just use the first test listed to get the working dir
             var firstTest = tests.First().TestCase;
-            var testFramework = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.TestFramework, defaultValue: TestFrameworkDirectories.ExportRunnerFrameworkName);
             var workingDir = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.WorkingDir, defaultValue: Path.GetDirectoryName(firstTest.CodeFilePath));
             var nodeExePath = firstTest.GetPropertyValue<string>(JavaScriptTestCaseProperties.NodeExePath, defaultValue: null);
             var projectRootDir = firstTest.GetPropertyValue(JavaScriptTestCaseProperties.ProjectRootDir, defaultValue: Path.GetDirectoryName(firstTest.CodeFilePath));
@@ -190,7 +189,8 @@ namespace Microsoft.NodejsTools.TestAdapter
                     fullyQualifiedName: args.fullyQualifiedName,
                     testFile: args.TestFile,
                     workingFolder: args.WorkingDirectory,
-                    projectFolder: args.ProjectRootDir));
+                    projectFolder: args.ProjectRootDir,
+                    configPath: args.ConfigPath));
             }
 
             var port = 0;
@@ -384,7 +384,8 @@ namespace Microsoft.NodejsTools.TestAdapter
         {
             var testFile = test.GetPropertyValue(JavaScriptTestCaseProperties.TestFile, defaultValue: test.CodeFilePath);
             var testFramework = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFramework, defaultValue: null);
-            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.FullyQualifiedName, testFile, workingDir, projectRootDir);
+            var configPath = test.GetPropertyValue<string>(JavaScriptTestCaseProperties.ConfigPath, defaultValue: null);
+            return this.frameworkDiscoverer.GetFramework(testFramework).GetArgumentsToRunTests(test.FullyQualifiedName, testFile, workingDir, projectRootDir, configPath);
         }
 
         private static string GetDebugArgs(Version nodeVersion, out int port)

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -7,7 +7,7 @@ const { fork } = require("child_process");
 
 process.env.VSTESTADAPTERPATH = __dirname;
 
-const vsKarmaConfigPath = path.resolve(__dirname, "./karmaConfig.js");
+const vsKarmaConfigFilePath = path.resolve(__dirname, "./karmaConfig.js");
 
 function getTestProjects(configFile) {
     const configPath = path.dirname(configFile);
@@ -17,16 +17,17 @@ function getTestProjects(configFile) {
     for (const projectName of Object.keys(angularConfig.projects)) {
         const project = angularConfig.projects[projectName];
 
-        const karmaConfigPath = project.architect.test
+        const karmaConfigFilePath = project.architect.test
             && project.architect.test.options
             && project.architect.test.options.karmaConfig
             && path.resolve(configPath, project.architect.test.options.karmaConfig);
 
-        if (karmaConfigPath) {
+        if (karmaConfigFilePath) {
             angularProjects.push({
                 angularConfigPath: configPath,
-                karmaConfigPath,
+                karmaConfigFilePath,
                 name: projectName,
+                rootPath: path.join(configPath, project.root),
             });
         }
     }
@@ -61,7 +62,7 @@ const find_tests = async function (configFiles, discoverResultFile) {
                 [
                     'test',
                     project.name,
-                    `--karmaConfig=${vsKarmaConfigPath}`
+                    `--karmaConfig=${vsKarmaConfigFilePath}`
                 ],
                 {
                     env: {
@@ -78,7 +79,7 @@ const find_tests = async function (configFiles, discoverResultFile) {
                     ngTest.send({});
                 }).on('error', err => {
                     reject(err);
-                }).on('exit', (code) => {
+                }).on('exit', code => {
                     resolve(code);
                 });
         });
@@ -125,7 +126,7 @@ const run_tests = async function (context) {
                 [
                     'test',
                     project.name,
-                    `--karmaConfig=${vsKarmaConfigPath}`
+                    `--karmaConfig=${vsKarmaConfigFilePath}`
                 ],
                 {
                     env: {
@@ -142,8 +143,8 @@ const run_tests = async function (context) {
                     });
 
                     ngTest.send({});
-                }).on('exit', () => {
-                    resolve();
+                }).on('exit', code => {
+                    resolve(code);
                 }).on('error', err => {
                     reject(err);
                 });

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/Angular.js
@@ -103,14 +103,14 @@ const run_tests = async function (context) {
     const projects = [];
     const angularConfigPaths = new Set();
     for (let testCase of context.testCases) {
-        if (!angularConfigPaths.has(testCase.projectFolder)) {
-            angularConfigPaths.add(testCase.projectFolder);
+        if (!angularConfigPaths.has(testCase.configPath)) {
+            angularConfigPaths.add(testCase.configPath);
 
-            if (!detectPackage(testCase.projectFolder, '@angular/cli')) {
+            if (!detectPackage(testCase.configPath, '@angular/cli')) {
                 continue;
             }
 
-            projects.push(...getTestProjects(`${testCase.projectFolder}/angular.json`));
+            projects.push(...getTestProjects(`${testCase.configPath}/angular.json`));
         }
     }
 
@@ -157,18 +157,18 @@ const run_tests = async function (context) {
 }
 
 function detectPackage(projectFolder, packageName) {
-    try {
-        const packagePath = path.join(projectFolder, 'node_modules', packageName);
-        const pkg = require(packagePath);
+    const packagePath = path.join(projectFolder, 'node_modules', packageName);
 
-        return pkg;
-    } catch (ex) {
+    if (!fs.existsSync(packagePath)) {
         logError(
             `Failed to find "${packageName}" package. "${packageName}" must be installed in the project locally.` + os.EOL +
             `Install "${packageName}" locally using the npm manager via solution explorer` + os.EOL +
             `or with ".npm install ${packageName} --save-dev" via the Node.js interactive window.`);
-        return null;
+
+        return false;
     }
+
+    return true;
 }
 
 function logError() {

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -16,7 +16,7 @@ function getFileLocation() {
 
     return match
         ? {
-            relativeFilePath: match[1], // Relative to karma config. This is due to webpack.
+            relativeFilePath: match[1], // Relative to project root defined on angular.json.
             line: match[2],
             column: match[3]
         }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -6,7 +6,7 @@ const testCases = JSON.parse(process.env.TESTCASES);
 const project = JSON.parse(process.env.PROJECT);
 
 module.exports = function (config) {
-    const karmaConfig = require(project.karmaConfigPath);
+    const karmaConfig = require(project.karmaConfigFilePath);
 
     karmaConfig(config);
 

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -48,6 +48,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         // Increment the amount of test cases found.
         testCaseCount++;
 
+        // rootPath will be the directory of angular.json plus the "root" configuration defined in it.
         const fullFilePath = path.join(project.rootPath, result.fileLocation.relativeFilePath);
         const suite = result.fullName.substring(0, result.fullName.length - result.description.length - 1);
 
@@ -64,7 +65,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
             filepath: fullFilePath,
             line: result.fileLocation.line,
             column: result.fileLocation.column,
-            configPath: project.angularConfigPath,
+            configDirPath: project.angularConfigDirPath,
 
             // Execution properties
             passed: result.status === "passed",

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -48,7 +48,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
         // Increment the amount of test cases found.
         testCaseCount++;
 
-        const fullFilePath = path.join(path.dirname(project.karmaConfigPath), result.fileLocation.relativeFilePath);
+        const fullFilePath = path.join(project.rootPath, result.fileLocation.relativeFilePath);
         const suite = result.fullName.substring(0, result.fullName.length - result.description.length - 1);
 
         let errorLog = "";

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/vsKarmaReporter.js
@@ -64,6 +64,7 @@ const vsKarmaReporter = function (baseReporterDecorator, config, logger, emitter
             filepath: fullFilePath,
             line: result.fileLocation.line,
             column: result.fileLocation.column,
+            configPath: project.angularConfigPath,
 
             // Execution properties
             passed: result.status === "passed",

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 {
     public sealed class NodejsTestInfo
     {
-        public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir, string configPath)
+        public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir, string configDirPath)
         {
             var testFileRelative = CommonUtils.GetRelativeFilePath(projectRootDir, testPath);
 
@@ -19,7 +19,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             this.SourceLine = line;
             this.SourceColumn = column;
             this.Suite = suite;
-            this.ConfigPath = configPath;
+            this.ConfigDirPath = configDirPath;
         }
 
         public string FullyQualifiedName
@@ -54,6 +54,6 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 
         public string Suite { get; }
 
-        public string ConfigPath { get; }
+        public string ConfigDirPath { get; }
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/NodejsTestInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 {
     public sealed class NodejsTestInfo
     {
-        public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir)
+        public NodejsTestInfo(string testPath, string suite, string testName, string testFramework, int line, int column, string projectRootDir, string configPath)
         {
             var testFileRelative = CommonUtils.GetRelativeFilePath(projectRootDir, testPath);
 
@@ -19,6 +19,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             this.SourceLine = line;
             this.SourceColumn = column;
             this.Suite = suite;
+            this.ConfigPath = configPath;
         }
 
         public string FullyQualifiedName
@@ -52,5 +53,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
         public int SourceColumn { get; }
 
         public string Suite { get; }
+
+        public string ConfigPath { get; }
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -96,14 +96,14 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 {
                     var line = discoveredTest.Line + 1;
                     var column = discoveredTest.Column + 1;
-                    var test = new NodejsTestInfo(discoveredTest.Filepath, discoveredTest.Suite, discoveredTest.Name, this.Name, line, column, projectRoot, discoveredTest.ConfigPath);
+                    var test = new NodejsTestInfo(discoveredTest.Filepath, discoveredTest.Suite, discoveredTest.Name, this.Name, line, column, projectRoot, discoveredTest.ConfigDirPath);
                     testCases.Add(test);
                 }
             }
             return testCases;
         }
 
-        public ArgumentsToRunTests GetArgumentsToRunTests(string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configPath)
+        public ArgumentsToRunTests GetArgumentsToRunTests(string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configDirPath)
         {
             workingDirectory = workingDirectory.TrimEnd('\\');
             projectRootDir = projectRootDir.TrimEnd('\\');
@@ -114,12 +114,12 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 testFile,
                 workingDirectory,
                 projectRootDir,
-                configPath);
+                configDirPath);
         }
 
         private static string WrapWithQuotes(string path)
         {
-            if (!path.StartsWith("\"", StringComparison.Ordinal) && !path.StartsWith("\'", StringComparison.Ordinal))
+            if (!string.IsNullOrWhiteSpace(path) && !path.StartsWith("\"", StringComparison.Ordinal) && !path.StartsWith("\'", StringComparison.Ordinal))
             {
                 path = "\"" + path + "\"";
             }
@@ -173,7 +173,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             public string Filepath;
             public int Line;
             public int Column;
-            public string ConfigPath;
+            public string ConfigDirPath;
 #pragma warning restore CS0649
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 
         public sealed class ArgumentsToRunTests
         {
-            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configPath)
+            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configDirPath)
             {
                 this.RunTestsScriptFile = WrapWithQuotes(runTestsScriptFile);
                 this.TestFramework = testFramework;
@@ -216,7 +216,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 this.TestFile = WrapWithQuotes(testFile);
                 this.WorkingDirectory = WrapWithQuotes(workingDirectory);
                 this.ProjectRootDir = WrapWithQuotes(projectRootDir);
-                this.ConfigPath = WrapWithQuotes(configPath);
+                this.ConfigDirPath = WrapWithQuotes(configDirPath);
             }
 
             public readonly string RunTestsScriptFile;
@@ -225,7 +225,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             public readonly string TestFile;
             public readonly string WorkingDirectory;
             public readonly string ProjectRootDir;
-            public readonly string ConfigPath;
+            public readonly string ConfigDirPath;
         }
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/TestFramework.cs
@@ -96,14 +96,14 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 {
                     var line = discoveredTest.Line + 1;
                     var column = discoveredTest.Column + 1;
-                    var test = new NodejsTestInfo(discoveredTest.Filepath, discoveredTest.Suite, discoveredTest.Name, this.Name, line, column, projectRoot);
+                    var test = new NodejsTestInfo(discoveredTest.Filepath, discoveredTest.Suite, discoveredTest.Name, this.Name, line, column, projectRoot, discoveredTest.ConfigPath);
                     testCases.Add(test);
                 }
             }
             return testCases;
         }
 
-        public ArgumentsToRunTests GetArgumentsToRunTests(string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir)
+        public ArgumentsToRunTests GetArgumentsToRunTests(string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configPath)
         {
             workingDirectory = workingDirectory.TrimEnd('\\');
             projectRootDir = projectRootDir.TrimEnd('\\');
@@ -113,7 +113,8 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 fullyQualifiedName,
                 testFile,
                 workingDirectory,
-                projectRootDir);
+                projectRootDir,
+                configPath);
         }
 
         private static string WrapWithQuotes(string path)
@@ -172,6 +173,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             public string Filepath;
             public int Line;
             public int Column;
+            public string ConfigPath;
 #pragma warning restore CS0649
         }
 
@@ -206,7 +208,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
 
         public sealed class ArgumentsToRunTests
         {
-            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir)
+            public ArgumentsToRunTests(string runTestsScriptFile, string testFramework, string fullyQualifiedName, string testFile, string workingDirectory, string projectRootDir, string configPath)
             {
                 this.RunTestsScriptFile = WrapWithQuotes(runTestsScriptFile);
                 this.TestFramework = testFramework;
@@ -214,6 +216,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
                 this.TestFile = WrapWithQuotes(testFile);
                 this.WorkingDirectory = WrapWithQuotes(workingDirectory);
                 this.ProjectRootDir = WrapWithQuotes(projectRootDir);
+                this.ConfigPath = WrapWithQuotes(configPath);
             }
 
             public readonly string RunTestsScriptFile;
@@ -222,6 +225,7 @@ namespace Microsoft.NodejsTools.TestAdapter.TestFrameworks
             public readonly string TestFile;
             public readonly string WorkingDirectory;
             public readonly string ProjectRootDir;
+            public readonly string ConfigPath;
         }
     }
 }

--- a/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/run_tests.js
@@ -19,7 +19,7 @@ rl.on('line', async function (line) {
     // get rid of leftover quotations from C# (necessary?)
     for (var test in context.testCases) {
         for (var value in context.testCases[test]) {
-            context.testCases[test][value] = context.testCases[test][value].replace(/["]+/g, '');
+            context.testCases[test][value] = context.testCases[test][value] && context.testCases[test][value].replace(/["]+/g, '');
         }
     }
 

--- a/Nodejs/Product/TestAdapterNetStandard/Microsoft.JavaScript.UnitTest.nuspec
+++ b/Nodejs/Product/TestAdapterNetStandard/Microsoft.JavaScript.UnitTest.nuspec
@@ -32,6 +32,7 @@
     <file src="$outdir$TestFrameworks\Tape\Tape.js" target="build\_common\TestFrameworks\Tape\" />
     <file src="$outdir$TestFrameworks\Jest\jest.js" target="build\_common\TestFrameworks\Jest\" />
     <file src="$outdir$TestFrameworks\Jest\jestReporter.js" target="build\_common\TestFrameworks\Jest\" />
+    <file src="$outdir$TestFrameworks\Angular\*.js" target="build\_common\TestFrameworks\Angular\" />
      <!--net standard library--> 
     <file src="$outdir$Microsoft.JavaScript.UnitTest.props" target="build\netstandard2.0\" />
     <file src="$outdir$Microsoft.JavaScript.UnitTest.targets" target="build\netstandard2.0\" />

--- a/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
+++ b/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
@@ -78,6 +78,18 @@
     <Content Include="..\TestAdapter\TestFrameworks\Jest\jestReporter.js" Link="TestFrameworks\Jest\jestReporter.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\TestAdapter\TestFrameworks\Angular\Angular.js" Link="TestFrameworks\Angular\Angular.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\TestAdapter\TestFrameworks\Angular\jasmineReporter.js" Link="TestFrameworks\Angular\jasmineReporter.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\TestAdapter\TestFrameworks\Angular\karmaConfig.js" Link="TestFrameworks\Angular\karmaConfig.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\TestAdapter\TestFrameworks\Angular\vsKarmaReporter.js" Link="TestFrameworks\Angular\vsKarmaReporter.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adds support for identifying Angular/Karma/Jasmine unit tests in .NET Core projects. Works for Visual Studio and dotnet cli.
- Fixes issue with identifying a root path.
- Some refactoring.