### PR TITLE
Accessibility bug fixes

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NodejsTools.NpmUI {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NpmInstallWindowResources {
@@ -237,6 +237,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         public static string OtherNpmArgumentsLabel {
             get {
                 return ResourceManager.GetString("OtherNpmArgumentsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package list.
+        /// </summary>
+        public static string PackageListName {
+            get {
+                return ResourceManager.GetString("PackageListName", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
@@ -199,4 +199,7 @@
     <value>{0} results found</value>
     <comment>Parameter is a number representing the amount of results.</comment>
   </data>
+  <data name="PackageListName" xml:space="preserve">
+    <value>Package list</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -296,6 +296,7 @@
             <ContentControl Style="{StaticResource SearchStyle}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsTabStop="False" Focusable="False" />
             <Grid Grid.Row="1" Background="{Binding ElementName=packageList, Path=Background}">
                 <ListView x:Name="packageList"
+                          AutomationProperties.Name="{x:Static resx:NpmInstallWindowResources.PackageListName}"
                           ItemsSource="{Binding FilteredPackages}"
                           SelectedItem="{Binding SelectedPackage}"
                           SelectionChanged="packageList_SelectionChanged"

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -1,4 +1,4 @@
-﻿<vsui:DialogWindow
+﻿<vsui:DialogWindow 
     x:Class="Microsoft.NodejsTools.NpmUI.NpmPackageInstallWindow"
     x:ClassModifier="public"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -343,7 +343,7 @@
                               Content="{Binding Path=SelectedPackage}"
                               ContentTemplate="{StaticResource PackageInfoTemplate}"
                               IsTabStop="True" AutomationProperties.Name="{Binding Path=SelectedPackage.Name}"
-                              TabIndex="3" />
+                              Focusable="False"/>
 
                 <StackPanel Grid.Row="1"
                             Orientation="Vertical"

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -1,4 +1,4 @@
-﻿<vsui:DialogWindow 
+﻿<vsui:DialogWindow
     x:Class="Microsoft.NodejsTools.NpmUI.NpmPackageInstallWindow"
     x:ClassModifier="public"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -344,7 +344,7 @@
                               Content="{Binding Path=SelectedPackage}"
                               ContentTemplate="{StaticResource PackageInfoTemplate}"
                               IsTabStop="True" AutomationProperties.Name="{Binding Path=SelectedPackage.Name}"
-                              Focusable="False"/>
+                              TabIndex="3" />
 
                 <StackPanel Grid.Row="1"
                             Orientation="Vertical"


### PR DESCRIPTION
Fixes bugs:
- Keyboard tab stop is provided for non actionable content. Keyboard tab stop is provided for the entire section
- MAS4.2.1: The Name property of a focusable element must not be null.
