### PR TITLE
Update TS and Node types versions for TypeScript Template

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/package.json
@@ -22,8 +22,8 @@
     "@types/express-serve-static-core": "^4.0.50",
     "@types/mime": "^1.3.1",
     "@types/serve-static": "^1.7.32",
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   },
   "engines": {
     "node": "^8.0.0"

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureNodejsWorker/package.json
@@ -11,8 +11,8 @@
     "name": ""
   },
   "devDependencies": {
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   },
   "engines": {
     "node": "^8.0.x"

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebApp/package.json
@@ -11,8 +11,8 @@
     "name": ""
   },
   "devDependencies": {
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   },
   "engines": {
     "node": "^8.0.0"

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureWebRole/package.json
@@ -11,8 +11,8 @@
     "name": ""
   },
   "devDependencies": {
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   },
   "engines": {
     "node": "^8.0.0"

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptConsoleApp/package.json
@@ -11,7 +11,7 @@
     "clean": "tsc --build --clean"
   },
   "devDependencies": {
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/package.json
@@ -23,7 +23,7 @@
     "@types/express-serve-static-core": "^4.0.50",
     "@types/mime": "^1.3.1",
     "@types/serve-static": "^1.7.32",
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   }
 }

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/package.json
@@ -19,7 +19,7 @@
     "@vue/cli-plugin-babel": "3.0.4",
     "@vue/cli-plugin-typescript": "3.0.4",
     "@vue/cli-service": "3.0.4",
-    "typescript": "3.1.1",
+    "typescript": "^4.0.5",
     "vue-template-compiler": "2.5.17"
   },
   "postcss": {

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptWebApp/package.json
@@ -11,7 +11,7 @@
     "clean": "tsc --build --clean"
   },
   "devDependencies": {
-    "@types/node": "^8.0.14",
-    "typescript": "^3.2.2"
+    "@types/node": "^14.14.7",
+    "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
We need at least TS `4.1` to fix the occurrence of [this](https://github.com/microsoft/TypeScript/issues/40951) issue in VS.

Two things
1) These versions were acquired via `npm install --save-dev typescript @types/node`. There is nothing special about them, they are just the latest published at this time. As long as the major version is `^4` we can change these to anything reasonable.
2) We should probably also update these versions for the other `TypeScript*` templates. Any reason not to? 
