### PR TITLE
Add test adapter telemetry

### DIFF
--- a/Nodejs/Product/Nodejs/Telemetry/TelemetryEvents.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/TelemetryEvents.cs
@@ -40,6 +40,11 @@ namespace Microsoft.NodejsTools.Telemetry
         public const string UsedRepl = Prefix + "UsedRepl";
         
         public const string OperationRegistrationFaulted = Prefix + "OperationRegistrationFaulted";
+
+        /// <summary>
+        /// User started discovery on the test adapters.
+        /// </summary>
+        public const string TestDiscoveryStarted = Prefix + "TestDiscoveryStarted";
     }
 
     internal static class TelemetryProperties
@@ -64,5 +69,15 @@ namespace Microsoft.NodejsTools.Telemetry
         /// The version of Node the user is using.
         /// </summary>
         public const string NodeVersion = Prefix + "NodeVersion";
+
+        /// <summary>
+        /// The test adapter the user is using when test discovery launched.
+        /// </summary>
+        public const string TestAdapterName = Prefix + "TestAdapterName";
+
+        /// <summary>
+        /// The type of test adapter that launched discovery.
+        /// </summary>
+        public const string TestDiscovererName = Prefix + "TestDiscovererName";
     }
 }

--- a/Nodejs/Product/Nodejs/Telemetry/TelemetryHelper.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/TelemetryHelper.cs
@@ -41,6 +41,11 @@ namespace Microsoft.NodejsTools.Telemetry
             TelemetryService.DefaultSession?.PostUserTask(UsedRepl, TelemetryResult.Success);
         }
 
+        public static void LogTestDiscoveryStarted(string testAdapterName, string testDiscovererName)
+        {
+            LogUserTaskEvent(TestDiscoveryStarted, (TestAdapterName, testAdapterName), (TestDiscovererName, testDiscovererName));
+        }
+
         private static void LogUserTaskEvent(string eventName, bool isProject)
         {
             LogUserTaskEvent(eventName, (IsProject, isProject));

--- a/Nodejs/Product/TestAdapter/DefaultTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/DefaultTestDiscoverer.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.NodejsTools.TestAdapter
+{
+    // We require to put a non-existent file extension to avoid duplicate discovery executions.
+    [FileExtension("NTVS_NonExistentFileExtension")]
+    public sealed class DefaultTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer
+    {
+        public override string TestDiscovererName => nameof(DefaultTestDiscoverer);
+    }
+}

--- a/Nodejs/Product/TestAdapter/DefaultTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/DefaultTestDiscoverer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Microsoft.NodejsTools.TestAdapter

--- a/Nodejs/Product/TestAdapter/DotNetTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/DotNetTestDiscoverer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.NodejsTools.TestAdapter
+{
+    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    [FileExtension(NodejsConstants.CSharpProjectExtension), FileExtension(NodejsConstants.VisualBasicProjectExtension)]
+    [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
+    public sealed class DotNetTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer
+    {
+        public override string TestDiscovererName => nameof(DotNetTestDiscoverer);
+    }
+}

--- a/Nodejs/Product/TestAdapter/DotNetTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/DotNetTestDiscoverer.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
-    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    /// Keep in sync the method <see cref="TypeScript.TypeScriptHelpers.IsSupportedTestProjectFile(string)" /> if there's a change on the supported projects.
     [FileExtension(NodejsConstants.CSharpProjectExtension), FileExtension(NodejsConstants.VisualBasicProjectExtension)]
     [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
     public sealed class DotNetTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer

--- a/Nodejs/Product/TestAdapter/JavascriptProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/JavascriptProjectTestDiscoverer.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
-    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    /// Keep in sync the method <see cref="TypeScript.TypeScriptHelpers.IsSupportedTestProjectFile(string)" /> if there's a change on the supported projects.
     [FileExtension(NodejsConstants.JavaScriptProjectExtension)]
     [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
     public sealed class JavascriptProjectTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer

--- a/Nodejs/Product/TestAdapter/JavascriptProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/JavascriptProjectTestDiscoverer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.NodejsTools.TestAdapter
+{
+    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    [FileExtension(NodejsConstants.JavaScriptProjectExtension)]
+    [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
+    public sealed class JavascriptProjectTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer
+    {
+        public override string TestDiscovererName => nameof(JavascriptProjectTestDiscoverer);
+    }
+}

--- a/Nodejs/Product/TestAdapter/NodejsToolsTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/NodejsToolsTestDiscoverer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.NodejsTools.TestAdapter
+{
+    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    [FileExtension(NodejsConstants.NodejsProjectExtension)]
+    [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
+    public sealed class NodejsToolsTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer
+    {
+        public override string TestDiscovererName => nameof(NodejsToolsTestDiscoverer);
+    }
+}

--- a/Nodejs/Product/TestAdapter/NodejsToolsTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/NodejsToolsTestDiscoverer.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
-    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
+    /// Keep in sync the method <see cref="TypeScript.TypeScriptHelpers.IsSupportedTestProjectFile(string)" /> if there's a change on the supported projects.
     [FileExtension(NodejsConstants.NodejsProjectExtension)]
     [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
     public sealed class NodejsToolsTestDiscoverer : ProjectTestDiscoverer, ITestDiscoverer

--- a/Nodejs/Product/TestAdapter/PackageJsonTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/PackageJsonTestDiscoverer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             var nodeExePath = Nodejs.GetPathToNodeExecutableFromEnvironment();
             var worker = new TestDiscovererWorker(packageJsonPath, nodeExePath);
-            worker.DiscoverTests(testFolderPath, testFx, logger, discoverySink);
+            worker.DiscoverTests(testFolderPath, testFx, logger, discoverySink, nameof(PackageJsonTestDiscoverer));
         }
     }
 }

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
                 var fileList = testItems[testFx];
 
-                discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink);
+                discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink, nameof(ProjectTestDiscoverer));
             }
         }
     }

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -12,11 +12,9 @@ using MSBuild = Microsoft.Build.Evaluation;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
-    // We require to put a non-existent file extension to avoid duplicate discovery executions.
-    [FileExtension("NTVS_NonExistentFileExtension")]
-    public class ProjectTestDiscoverer : ITestDiscoverer
+    public abstract class ProjectTestDiscoverer
     {
-        public virtual string TestDiscovererName => nameof(ProjectTestDiscoverer);
+        public abstract string TestDiscovererName { get; }
 
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {

--- a/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestDiscoverer.cs
@@ -12,11 +12,12 @@ using MSBuild = Microsoft.Build.Evaluation;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
-    // Keep in sync the method TypeScriptHelpers.IsSupportedTestProjectFile if there's a change on the supported projects.
-    [FileExtension(NodejsConstants.NodejsProjectExtension), FileExtension(NodejsConstants.CSharpProjectExtension), FileExtension(NodejsConstants.VisualBasicProjectExtension), FileExtension(NodejsConstants.JavaScriptProjectExtension)]
-    [DefaultExecutorUri(NodejsConstants.ExecutorUriString)]
-    public partial class ProjectTestDiscoverer : ITestDiscoverer
+    // We require to put a non-existent file extension to avoid duplicate discovery executions.
+    [FileExtension("NTVS_NonExistentFileExtension")]
+    public class ProjectTestDiscoverer : ITestDiscoverer
     {
+        public virtual string TestDiscovererName => nameof(ProjectTestDiscoverer);
+
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {
             AssemblyResolver.SetupHandler();
@@ -110,7 +111,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
                 var fileList = testItems[testFx];
 
-                discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink, nameof(ProjectTestDiscoverer));
+                discoverWorker.DiscoverTests(fileList, testFramework, logger, discoverySink, this.TestDiscovererName);
             }
         }
     }

--- a/Nodejs/Product/TestAdapter/ProjectTestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/ProjectTestExecutor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NodejsTools.TestAdapter
 
             this.Cancel();
             this.worker = new TestExecutorWorker(runContext, frameworkHandle);
-            this.worker.RunTests(sources, new ProjectTestDiscoverer());
+            this.worker.RunTests(sources, new DefaultTestDiscoverer());
         }
 
         public void Cancel()

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -54,6 +54,7 @@
     <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
     <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="AssemblyResolver.cs" />
+    <Compile Include="DefaultTestDiscoverer.cs" />
     <Compile Include="DotNetTestDiscoverer.cs" />
     <Compile Include="JavascriptProjectTestDiscoverer.cs" />
     <Compile Include="NodejsToolsTestDiscoverer.cs" />

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -51,6 +51,8 @@
     <Compile Include="..\TypeScript\TypeScriptHelpers.cs">
       <Link>TypeScriptHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
+    <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="PackageJsonTestDiscoverer.cs" />
     <Compile Include="PackageJsonTestExecutor.cs" />
@@ -81,6 +83,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry">
+      <Version>16.3.59</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
       <Version>0.4.1</Version>

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -54,6 +54,9 @@
     <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
     <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="AssemblyResolver.cs" />
+    <Compile Include="DotNetTestDiscoverer.cs" />
+    <Compile Include="JavascriptProjectTestDiscoverer.cs" />
+    <Compile Include="NodejsToolsTestDiscoverer.cs" />
     <Compile Include="PackageJsonTestDiscoverer.cs" />
     <Compile Include="PackageJsonTestExecutor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -47,10 +47,8 @@ namespace Microsoft.NodejsTools.TestAdapter
         public void DiscoverTests(IEnumerable<string> fileList, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, string testDiscovererName)
         {
             // If it's a framework name we support, is safe to submit the string to telemetry.
-            if (supportedFrameworks.Contains(testFx.Name))
-            {
-                TelemetryHelper.LogTestDiscoveryStarted(testFx.Name, testDiscovererName);
-            }
+            var testAdapterName = supportedFrameworks.Contains(testFx.Name) ? testFx.Name : "Other";
+            TelemetryHelper.LogTestDiscoveryStarted(testAdapterName, testDiscovererName);
 
             if (!File.Exists(this.nodeExePath))
             {

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -16,6 +16,17 @@ namespace Microsoft.NodejsTools.TestAdapter
 {
     public sealed class TestDiscovererWorker
     {
+        // Keep in sync with the folder names of ./Product/TestAdapter/TestFrameworks.
+        private readonly HashSet<string> supportedFrameworks = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Angular",
+            "ExportRunner",
+            "Jasmine",
+            "Jest",
+            "mocha",
+            "Tape",
+        };
+
         private readonly string testSource;
         private readonly string workingDir;
         private readonly string nodeExePath;
@@ -35,7 +46,11 @@ namespace Microsoft.NodejsTools.TestAdapter
 
         public void DiscoverTests(IEnumerable<string> fileList, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, string testDiscovererName)
         {
-            TelemetryHelper.LogTestDiscoveryStarted(testFx.Name, testDiscovererName);
+            // If it's a framework name we support, is safe to submit the string to telemetry.
+            if (supportedFrameworks.Contains(testFx.Name))
+            {
+                TelemetryHelper.LogTestDiscoveryStarted(testFx.Name, testDiscovererName);
+            }
 
             if (!File.Exists(this.nodeExePath))
             {

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.NodejsTools.SourceMapping;
+using Microsoft.NodejsTools.Telemetry;
 using Microsoft.NodejsTools.TestAdapter.TestFrameworks;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -26,14 +27,16 @@ namespace Microsoft.NodejsTools.TestAdapter
             this.nodeExePath = nodeExePath;
         }
 
-        public void DiscoverTests(string testFolderPath, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        public void DiscoverTests(string testFolderPath, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, string testDiscovererName)
         {
             var fileList = Directory.EnumerateFiles(testFolderPath, "*.js", SearchOption.AllDirectories).Where(x => !x.Contains(NodejsConstants.NodeModulesFolder));
-            this.DiscoverTests(fileList, testFx, logger, discoverySink);
+            this.DiscoverTests(fileList, testFx, logger, discoverySink, testDiscovererName);
         }
 
-        public void DiscoverTests(IEnumerable<string> fileList, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        public void DiscoverTests(IEnumerable<string> fileList, TestFramework testFx, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, string testDiscovererName)
         {
+            TelemetryHelper.LogTestDiscoveryStarted(testFx.Name, testDiscovererName);
+
             if (!File.Exists(this.nodeExePath))
             {
                 logger.SendMessage(TestMessageLevel.Error, "Node.exe was not found. Please install Node.js before running tests.");

--- a/Nodejs/Product/TestAdapterNetStandard/Microsoft.JavaScript.UnitTest.nuspec
+++ b/Nodejs/Product/TestAdapterNetStandard/Microsoft.JavaScript.UnitTest.nuspec
@@ -21,6 +21,7 @@
       <dependency id="Newtonsoft.Json" version="12.0.2" />
       <dependency id="Microsoft.TestPlatform.ObjectModel" version="16.1.1" />
       <dependency id="Microsoft.NET.Test.Sdk" version="16.1.1" />
+      <dependency id="Microsoft.VisualStudio.Telemetry" version="16.3.59" />
     </dependencies>
   </metadata>
   <files>

--- a/Nodejs/Product/TestAdapterNetStandard/NetCoreTestDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterNetStandard/NetCoreTestDiscoverer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.NodejsTools.TestAdapter
             }
 
             var discoverWorker = new TestDiscovererWorker(projectFullPath, nodeExePath);
-            discoverWorker.DiscoverTests(testItems, testFramework, logger, discoverySink);
+            discoverWorker.DiscoverTests(testItems, testFramework, logger, discoverySink, nameof(NetCoreTestDiscoverer));
         }
 
         private IEnumerable<string> GetConfigItems(string projectRoot)

--- a/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
+++ b/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
@@ -34,6 +34,8 @@
     <Compile Include="..\Nodejs\SourceMapping\SourceMap.cs" Link="SourceMapping\SourceMap.cs" />
     <Compile Include="..\Nodejs\SourceMapping\SourceMapper.cs" Link="SourceMapping\SourceMapper.cs" />
     <Compile Include="..\Nodejs\TestFrameworks\TestFrameworkDirectories.cs" Link="TestFrameworks\TestFrameworkDirectories.cs" />
+    <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
+    <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="..\TestAdapter\JavaScriptTestCaseProperties.cs" Link="JavaScriptTestCaseProperties.cs" />
     <Compile Include="..\TestAdapter\SerializationHelpers.cs" Link="SerializationHelpers.cs" />
     <Compile Include="..\TestAdapter\TestDiscovererWorker.cs" Link="TestDiscovererWorker.cs" />
@@ -98,6 +100,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="16.3.59" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds a telemetry event triggered when discovery starts.

It will capture information of the test adapter used (angular, mocha, jasmine, etc.) and the test adapter name (.NET Core, .NET Framework, NTVS, etc).