### PR TITLE
fix: updated typings causing build errors in templates

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/Express4App/app.js
@@ -1,5 +1,5 @@
 'use strict';
-var debug = require('debug');
+var debug = require('debug')('my express app');
 var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/app.ts
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/app.ts
@@ -1,6 +1,7 @@
-import debug = require('debug');
-import express = require('express');
-import path = require('path');
+import * as debug from 'debug';
+import * as express from 'express';
+import { AddressInfo } from "net";
+import * as path from 'path';
 
 import routes from './routes/index';
 import users from './routes/user';
@@ -50,5 +51,5 @@ app.use((err, req, res, next) => { // eslint-disable-line @typescript-eslint/no-
 app.set('port', process.env.PORT || 3000);
 
 const server = app.listen(app.get('port'), function () {
-    debug('Express server listening on port ' + server.address().port);
+    debug('Express server listening on port ' + (server.address() as AddressInfo).port);
 });

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/app.ts
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptAzureExpressApp/app.ts
@@ -1,4 +1,3 @@
-import * as debug from 'debug';
 import * as express from 'express';
 import { AddressInfo } from "net";
 import * as path from 'path';
@@ -6,6 +5,7 @@ import * as path from 'path';
 import routes from './routes/index';
 import users from './routes/user';
 
+const debug = require('debug')('my express app');
 const app = express();
 
 // view engine setup
@@ -51,5 +51,5 @@ app.use((err, req, res, next) => { // eslint-disable-line @typescript-eslint/no-
 app.set('port', process.env.PORT || 3000);
 
 const server = app.listen(app.get('port'), function () {
-    debug('Express server listening on port ' + (server.address() as AddressInfo).port);
+    debug(`Express server listening on port ${ (server.address() as AddressInfo).port }`);
 });

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/app.ts
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/app.ts
@@ -1,4 +1,3 @@
-import * as debug from 'debug';
 import * as express from 'express';
 import { AddressInfo } from "net";
 import * as path from 'path';
@@ -6,6 +5,7 @@ import * as path from 'path';
 import routes from './routes/index';
 import users from './routes/user';
 
+const debug = require('debug')('my express app');
 const app = express();
 
 // view engine setup
@@ -20,7 +20,7 @@ app.use('/users', users);
 // catch 404 and forward to error handler
 app.use((req, res, next) => {
     const err = new Error('Not Found');
-    err['status'] = 404;
+    err[ 'status' ] = 404;
     next(err);
 });
 
@@ -30,7 +30,7 @@ app.use((req, res, next) => {
 // will print stacktrace
 if (app.get('env') === 'development') {
     app.use((err, req, res, next) => { // eslint-disable-line @typescript-eslint/no-unused-vars
-        res.status(err['status'] || 500);
+        res.status(err[ 'status' ] || 500);
         res.render('error', {
             message: err.message,
             error: err
@@ -51,5 +51,5 @@ app.use((err, req, res, next) => { // eslint-disable-line @typescript-eslint/no-
 app.set('port', process.env.PORT || 3000);
 
 const server = app.listen(app.get('port'), function () {
-    debug('Express server listening on port ' + (server.address() as AddressInfo).port);
+    debug(`Express server listening on port ${(server.address() as AddressInfo).port}`);
 });

--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/app.ts
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptExpressApp/app.ts
@@ -1,6 +1,7 @@
-import debug = require('debug');
-import express = require('express');
-import path = require('path');
+import * as debug from 'debug';
+import * as express from 'express';
+import { AddressInfo } from "net";
+import * as path from 'path';
 
 import routes from './routes/index';
 import users from './routes/user';
@@ -50,5 +51,5 @@ app.use((err, req, res, next) => { // eslint-disable-line @typescript-eslint/no-
 app.set('port', process.env.PORT || 3000);
 
 const server = app.listen(app.get('port'), function () {
-    debug('Express server listening on port ' + server.address().port);
+    debug('Express server listening on port ' + (server.address() as AddressInfo).port);
 });


### PR DESCRIPTION
The latest node types have the result of `server.address()` as a `string | AddressInfo`, which was causing a build error on the default template. Updated the templates to fix this, and also standardized the imports.
