### PR TITLE
Added execution tests to test adapters

### DIFF
--- a/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutorWorker.cs
@@ -18,14 +18,14 @@ using Newtonsoft.Json;
 
 namespace Microsoft.NodejsTools.TestAdapter
 {
+    public class TestCaseResult
+    {
+        public TestCase TestCase;
+        public TestResult TestResult;
+    }
+
     internal sealed partial class TestExecutorWorker
     {
-        private sealed class TestCaseResult
-        {
-            public TestCase TestCase;
-            public TestResult TestResult;
-        }
-
         private static readonly Version Node8Version = new Version(8, 0);
 
         //get from NodeRemoteDebugPortSupplier::PortSupplierId

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -36,35 +36,31 @@ const find_tests = function (testFileList, discoverResultFile, projectFolder) {
     });
 };
 
-const run_tests = function (context) {
-    return new Promise(async resolve => {
-        const jest = detectPackage(context.testCases[0].projectFolder, 'jest');
-        if (!jest) {
-            return resolve();
-        }
+const run_tests = async function (context) {
+    const jest = detectPackage(context.testCases[0].projectFolder, 'jest');
+    if (!jest) {
+        return;
+    }
 
-        // Start all test cases, as jest is unable to filter out independently
-        for (const testCase of context.testCases) {
-            context.post({
-                type: 'test start',
-                fullyQualifiedName: testCase.fullyQualifiedName
-            });
-        }
+    // Start all test cases, as jest is unable to filter out independently
+    for (const testCase of context.testCases) {
+        context.post({
+            type: 'test start',
+            fullyQualifiedName: testCase.fullyQualifiedName
+        });
+    }
 
-        const config = {
-            json: true,
-            reporters: [[__dirname + '/jestReporter.js', { context }]],
-            testMatch: [context.testCases[0].testFile]
-        };
+    const config = {
+        json: true,
+        reporters: [[__dirname + '/jestReporter.js', { context }]],
+        testMatch: [context.testCases[0].testFile]
+    };
 
-        try {
-            await jest.runCLI(config, [context.testCases[0].projectFolder]);
-        } catch (error) {
-            logError(error);
-        }
-
-        resolve();
-    });
+    try {
+        await jest.runCLI(config, [context.testCases[0].projectFolder]);
+    } catch (error) {
+        logError(error);
+    }
 };
 
 function visitNodes(nodes, suites, tests) {

--- a/Nodejs/Tests/TestAdapter.Tests/ProjectTestExecutorTests.cs
+++ b/Nodejs/Tests/TestAdapter.Tests/ProjectTestExecutorTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.NodejsTools.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
+namespace TestAdapter.Tests
+{
+    [TestClass]
+    public class ProjectTestExecutorTests
+    {
+        private static void AssertProject(TestProjectFactory.ProjectName projectName)
+        {
+            // Arrange
+            var testCaseResult = TestProjectFactory.GetTestCaseResults(projectName);
+            var expectedTestCases = testCaseResult.Select(x => x.TestCase);
+            var expectedResults = testCaseResult.Select(x => x.TestResult);
+            var expectedEnds = testCaseResult.Select(x => (x.TestCase, x.TestResult.Outcome));
+
+            var runContext = new Mock<IRunContext>();
+            runContext.Setup(x => x.RunSettings.SettingsXml)
+                .Returns(@"<EmptyXml></EmptyXml>");
+
+            var actualStarts = new List<TestCase>();
+            var actualResults = new List<TestResult>();
+            var actualEnds = new List<(TestCase, TestOutcome)>();
+
+            var frameworkHandle = new Mock<IFrameworkHandle>();
+            frameworkHandle.Setup(x => x.RecordStart(It.IsAny<TestCase>()))
+                .Callback<TestCase>(x => actualStarts.Add(x));
+            frameworkHandle.Setup(x => x.RecordResult(It.IsAny<TestResult>()))
+                .Callback<TestResult>(x => actualResults.Add(x));
+            frameworkHandle.Setup(x => x.RecordEnd(It.IsAny<TestCase>(), It.IsAny<TestOutcome>()))
+                .Callback<TestCase, TestOutcome>((tc, to) => actualEnds.Add((tc, to)));
+
+            TestHelpers.AssureNodeModules(TestProjectFactory.GetProjectDirPath(projectName));
+
+            var testExecutor = new ProjectTestExecutor();
+
+            // Act
+            testExecutor.RunTests(expectedTestCases, runContext.Object, frameworkHandle.Object);
+
+            // Assert
+            frameworkHandle.Verify(x => x.RecordStart(It.IsAny<TestCase>()), Times.Exactly(expectedTestCases.Count()));
+            frameworkHandle.Verify(x => x.RecordResult(It.IsAny<TestResult>()), Times.Exactly(expectedTestCases.Count()));
+            frameworkHandle.Verify(x => x.RecordEnd(It.IsAny<TestCase>(), It.IsAny<TestOutcome>()), Times.Exactly(expectedTestCases.Count()));
+
+            TestHelpers.AssertTestCasesAreEqual(expectedTestCases, actualStarts);
+            TestHelpers.AssertTestResultsAreEqual(expectedResults, actualResults);
+            TestHelpers.AssertRecordEnds(expectedEnds, actualEnds);
+
+        }
+
+        [TestInitialize]
+        public void InitializeTests()
+        {
+            // Setup the variable due to LoadProjects looks for a specific path of Microsoft.NodejsToolsV2.targets.
+            // TODO: Probably we could remove this dependency by configuring the BuildOutput path, but I haven't found how to do it.
+            Environment.SetEnvironmentVariable("VSINSTALLDIR", @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview");
+        }
+
+        [TestMethod]
+        public void ExecutesTests_NodeAppWithTestsConfiguredPerFile()
+        {
+            // TODO: Note that this tests is going to fail until the following issues had been resolved:
+            // - Jasmine stdout contains the configuration output plus a random seed. Probably don't want to include it.
+            // - Jest test does not runs the tests. This is an issue with the test not the adapter.
+            AssertProject(TestProjectFactory.ProjectName.NodeAppWithTestsConfiguredPerFile);
+        }
+
+        [TestMethod]
+        public void ExecutesTests_NodeAppWithTestsConfiguredOnProject()
+        {
+            AssertProject(TestProjectFactory.ProjectName.NodeAppWithTestsConfiguredOnProject);
+        }
+
+        [TestMethod]
+        public void ExecutesTests_NodeAppWithAngularTests()
+        {
+            AssertProject(TestProjectFactory.ProjectName.NodeAppWithAngularTests);
+        }
+    }
+}

--- a/Nodejs/Tests/TestAdapter.Tests/TestHelpers.cs
+++ b/Nodejs/Tests/TestAdapter.Tests/TestHelpers.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.NodejsTools.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
+namespace TestAdapter.Tests
+{
+    public static class TestHelpers
+    {
+        public static void AssertTestCasesAreEqual(IEnumerable<TestCase> expected, IEnumerable<TestCase> actual)
+        {
+            if (expected.Count() != actual.Count())
+            {
+                Assert.Fail($"Expected and actual does not have the same amount of items. Expected.Count = {expected.Count()}, Actual.Count = {actual.Count()}");
+            }
+
+            var expectedCopy = new List<TestCase>(expected);
+            foreach (var testCase in actual)
+            {
+                var found = expectedCopy.Find(x => AreTestCasesEqual(x, testCase));
+                if (found == null)
+                {
+                    Assert.Fail($"Expected does not have item: {JsonConvert.SerializeObject(testCase)}");
+                }
+
+                expectedCopy.Remove(found);
+            }
+        }
+
+        public static void AssertTestResultsAreEqual(IEnumerable<TestResult> expected, IEnumerable<TestResult> actual)
+        {
+            if (expected.Count() != actual.Count())
+            {
+                Assert.Fail($"Expected and actual does not have the same amount of items. Expected.Count = {expected.Count()}, Actual.Count = {actual.Count()}");
+            }
+
+            var expectedCopy = new List<TestResult>(expected);
+            foreach (var testResult in actual)
+            {
+                var found = expectedCopy.Find(x =>
+                    AreTestCasesEqual(x.TestCase, testResult.TestCase)
+                    && x.Outcome == testResult.Outcome
+                    && AreMessagesEqual(x.Messages, testResult.Messages));
+
+                if (found == null)
+                {
+                    Assert.Fail($"Expected does not have item: {JsonConvert.SerializeObject(testResult)}");
+                }
+
+                expectedCopy.Remove(found);
+            }
+        }
+
+        public static void AssertRecordEnds(IEnumerable<(TestCase, TestOutcome)> expected, IEnumerable<(TestCase, TestOutcome)> actual)
+        {
+            if (expected.Count() != actual.Count())
+            {
+                Assert.Fail($"Expected and actual does not have the same amount of items. Expected.Count = {expected.Count()}, Actual.Count = {actual.Count()}");
+            }
+
+            var expectedCopy = new List<(TestCase, TestOutcome)>(expected);
+            foreach (var (testCase, testOutcome) in actual)
+            {
+                var found = expectedCopy.Find(x =>
+                    AreTestCasesEqual(x.Item1, testCase)
+                    && x.Item2 == testOutcome);
+
+                if (found.Item1 == null)
+                {
+                    Assert.Fail($"Expected does not have item: {JsonConvert.SerializeObject(testCase)}");
+                }
+
+                expectedCopy.Remove(found);
+            }
+        }
+
+        public static void AssureNodeModules(string path)
+        {
+            if (Directory.Exists(Path.Combine(path, "node_modules")))
+            {
+                return;
+            }
+
+            var processStartInfo = new ProcessStartInfo()
+            {
+                FileName = "cmd.exe",
+                Arguments = "/C npm install",
+                WorkingDirectory = path
+            };
+
+            var process = Process.Start(processStartInfo);
+            process.WaitForExit(10 * 60 * 1000); // 10 minutes
+        }
+
+        private static bool PathEquals(string path1, string path2)
+        {
+            return (path1 == null && path2 == null)
+                || (path1 != null && path2 != null && string.Equals(Path.GetFullPath(path1), Path.GetFullPath(path2), StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool AreTestCasesEqual(TestCase expected, TestCase actual)
+        {
+            return expected.FullyQualifiedName == actual.FullyQualifiedName
+                && expected.DisplayName == actual.DisplayName
+                && expected.LineNumber == actual.LineNumber
+                && expected.ExecutorUri == actual.ExecutorUri
+                && PathEquals(expected.Source, actual.Source)
+                && PathEquals(expected.CodeFilePath, actual.CodeFilePath)
+                && string.Equals(expected.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFramework, default), actual.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFramework, default), StringComparison.OrdinalIgnoreCase) // For some reason, mocha test framework is all lowercase.
+                && PathEquals(expected.GetPropertyValue<string>(JavaScriptTestCaseProperties.WorkingDir, default), actual.GetPropertyValue<string>(JavaScriptTestCaseProperties.WorkingDir, default))
+                && PathEquals(expected.GetPropertyValue<string>(JavaScriptTestCaseProperties.ProjectRootDir, default), actual.GetPropertyValue<string>(JavaScriptTestCaseProperties.ProjectRootDir, default))
+                && PathEquals(expected.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFile, default), actual.GetPropertyValue<string>(JavaScriptTestCaseProperties.TestFile, default))
+                && PathEquals(expected.GetPropertyValue<string>(JavaScriptTestCaseProperties.ConfigDirPath, default), actual.GetPropertyValue<string>(JavaScriptTestCaseProperties.ConfigDirPath, default));
+        }
+
+        private static bool AreMessagesEqual(IEnumerable<TestResultMessage> expected, IEnumerable<TestResultMessage> actual)
+        {
+            if (expected.Count() != actual.Count())
+            {
+                return false;
+            }
+
+            var expectedCopy = new List<TestResultMessage>(expected);
+            foreach (var message in actual)
+            {
+                var found = expectedCopy.Find(x =>
+                    x.Category == message.Category
+                    && x.Text == message.Text);
+
+                if (found == null)
+                {
+                    return false;
+                }
+
+                expectedCopy.Remove(found);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Nodejs/Tests/TestAdapter.Tests/TestProjectFactory.cs
+++ b/Nodejs/Tests/TestAdapter.Tests/TestProjectFactory.cs
@@ -25,6 +25,7 @@ namespace TestAdapter.Tests
             public string Source;
             public string WorkingDir;
             public string ConfigDirPath;
+            public string NodeExePath;
         }
 
         public static string GetProjectDirPath(ProjectName projectName)
@@ -45,15 +46,15 @@ namespace TestAdapter.Tests
             throw new NotImplementedException($"ProjectName {projectName} has not been implemented.");
         }
 
-        public static List<TestCase> GetTestCases(ProjectName projectName)
+        public static List<TestCaseResult> GetTestCaseResults(ProjectName projectName)
         {
             switch (projectName)
             {
                 case ProjectName.NodeAppWithTestsConfiguredOnProject:
-                    return new List<TestCase>(GetTestCases(projectName, SupportedFramework.Mocha));
+                    return new List<TestCaseResult>(GetTestCases(projectName, SupportedFramework.Mocha));
 
                 case ProjectName.NodeAppWithTestsConfiguredPerFile:
-                    var result = new List<TestCase>();
+                    var result = new List<TestCaseResult>();
                     result.AddRange(GetTestCases(projectName, SupportedFramework.Jasmine));
                     result.AddRange(GetTestCases(projectName, SupportedFramework.ExportRunner));
                     result.AddRange(GetTestCases(projectName, SupportedFramework.Jest));
@@ -63,21 +64,21 @@ namespace TestAdapter.Tests
                     return result;
 
                 case ProjectName.NodeAppWithAngularTests:
-                    return new List<TestCase>(GetTestCases(projectName, SupportedFramework.Angular));
-
+                    return new List<TestCaseResult>(GetTestCases(projectName, SupportedFramework.Angular));
             };
 
             throw new NotImplementedException($"ProjectName {projectName} has not been implemented.");
         }
 
-        private static List<TestCase> GetTestCases(ProjectName projectName, SupportedFramework testFramework)
+        private static TestCaseResult[] GetTestCases(ProjectName projectName, SupportedFramework testFramework)
         {
             var testCaseOptions = new TestCaseOptions()
             {
                 TestFramework = testFramework,
                 WorkingDir = GetProjectDirPath(projectName),
                 Source = GetProjectFilePath(projectName),
-                ConfigDirPath = projectName == ProjectName.NodeAppWithAngularTests ? GetProjectDirPath(projectName) : null
+                ConfigDirPath = projectName == ProjectName.NodeAppWithAngularTests ? GetProjectDirPath(projectName) : null,
+                NodeExePath = Nodejs.GetPathToNodeExecutableFromEnvironment()
             };
 
             switch (testFramework)
@@ -85,63 +86,168 @@ namespace TestAdapter.Tests
                 case SupportedFramework.Jasmine:
                     {
                         var filePath = Path.Combine(GetProjectDirPath(projectName), "JasmineUnitTest.js");
-                        return new List<TestCase>()
+                        return new[]
                         {
-                            GetTestCase(testCaseOptions, "JasmineUnitTest.js::Test Suite 1::Test 1", "Test 1", 1, filePath),
-                            GetTestCase(testCaseOptions, "JasmineUnitTest.js::Test Suite 1::Test 2", "Test 2", 1, filePath),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "JasmineUnitTest.js::Test Suite 1::Test 1",
+                                "Test 1",
+                                1,
+                                filePath,
+                                TestOutcome.Passed,
+                                "."),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "JasmineUnitTest.js::Test Suite 1::Test 2",
+                                "Test 2",
+                                1,
+                                filePath,
+                                TestOutcome.Failed,
+                                "F"),
                         };
                     }
                 case SupportedFramework.ExportRunner:
                     {
                         var filePath = Path.Combine(GetProjectDirPath(projectName), "ExportRunnerUnitTest.js");
-                        return new List<TestCase>()
+                        return new[]
                         {
-                            GetTestCase(testCaseOptions, "ExportRunnerUnitTest.js::global::Test 1", "Test 1", 1, filePath),
-                            GetTestCase(testCaseOptions, "ExportRunnerUnitTest.js::global::Test 2", "Test 2", 1, filePath),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "ExportRunnerUnitTest.js::global::Test 1",
+                                "Test 1",
+                                1,
+                                filePath,
+                                TestOutcome.Passed,
+                                "Test passed.\r\n\r\n"),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "ExportRunnerUnitTest.js::global::Test 2",
+                                "Test 2",
+                                1,
+                                filePath,
+                                TestOutcome.Failed,
+                                "Test passed.\r\n\r\n", // TODO: Fix bug on the stdout stating that the test passed when the outcome is failure. Outcome is the corect status.
+                                "AssertionError\r\nThis should fail\r\n",
+                                "AssertionError\r\nThis should fail\r\n"),
                         };
                     }
                 case SupportedFramework.Jest:
                     {
                         var filePath = Path.Combine(GetProjectDirPath(projectName), "JestUnitTest.js");
-                        return new List<TestCase>()
+                        return new[]
                         {
-                            GetTestCase(testCaseOptions, "JestUnitTest.js::Test Suite 1::Test 1 - This shouldn't fail", "Test 1 - This shouldn't fail", 3, filePath),
-                            GetTestCase(testCaseOptions, "JestUnitTest.js::Test Suite 1::Test 2 - This should fail", "Test 2 - This should fail", 7, filePath),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "JestUnitTest.js::Test Suite 1::Test 1 - This shouldn't fail",
+                                "Test 1 - This shouldn't fail",
+                                3,
+                                filePath,
+                                TestOutcome.Passed),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "JestUnitTest.js::Test Suite 1::Test 2 - This should fail",
+                                "Test 2 - This should fail",
+                                7,
+                                filePath,
+                                TestOutcome.Failed),
                         };
                     }
                 case SupportedFramework.Mocha:
                     {
                         var filePath = Path.Combine(GetProjectDirPath(projectName), "MochaUnitTest.js");
-                        return new List<TestCase>()
+                        return new[]
                         {
-                            GetTestCase(testCaseOptions, "MochaUnitTest.js::Test Suite 1::Test 1", "Test 1", 1, filePath),
-                            GetTestCase(testCaseOptions, "MochaUnitTest.js::Test Suite 1::Test 2", "Test 2", 1, filePath),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "MochaUnitTest.js::Test Suite 1::Test 1",
+                                "Test 1",
+                                1,
+                                filePath,
+                                TestOutcome.Passed,
+                                "Using default Mocha settings\r\nok 1 Test Suite 1 Test 1\r\n"), // TODO: Bug fix. Exclude the settings message.
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "MochaUnitTest.js::Test Suite 1::Test 2",
+                                "Test 2",
+                                1,
+                                filePath,
+                                TestOutcome.Failed,
+                                "not ok 2 Test Suite 1 Test 2\r\n  This should fail\r\n  AssertionError [ERR_ASSERTION]: This should fail\r\n      at Context.<anonymous> (MochaUnitTest.js:10:16)\r\n      at processImmediate (internal/timers.js:456:21)\r\n"),
                         };
                     }
                 case SupportedFramework.Tape:
                     {
                         var filePath = Path.Combine(GetProjectDirPath(projectName), "TapeUnitTest.js");
-                        return new List<TestCase>()
+                        return new[]
                         {
-                            GetTestCase(testCaseOptions, "TapeUnitTest.js::global::Test A", "Test A", 1, filePath),
-                            GetTestCase(testCaseOptions, "TapeUnitTest.js::global::Test B", "Test B", 1, filePath),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "TapeUnitTest.js::global::Test A",
+                                "Test A",
+                                1,
+                                filePath,
+                                TestOutcome.Passed,
+                                "Operator: ok. Expected: true. Actual: true. evt: {\"id\":0,\"ok\":true,\"todo\":false,\"name\":\"This shouldn't fail\",\"operator\":\"ok\",\"objectPrintDepth\":5,\"actual\":true,\"expected\":true,\"test\":0,\"type\":\"assert\"}\r\n"),
+                            GetTestCaseResult(
+                                testCaseOptions,
+                                "TapeUnitTest.js::global::Test B",
+                                "Test B",
+                                1,
+                                filePath,
+                                TestOutcome.Failed,
+                                "Operator: ok. Expected: true. Actual: true. evt: {\"id\":0,\"ok\":true,\"todo\":false,\"name\":\"This shouldn't fail\",\"operator\":\"ok\",\"objectPrintDepth\":5,\"actual\":true,\"expected\":true,\"test\":1,\"type\":\"assert\"}\r\n",
+                                "Operator: equal. Expected: 2. Actual: 1. evt: {\"id\":1,\"ok\":false,\"todo\":false,\"name\":\"This should fail\",\"operator\":\"equal\",\"objectPrintDepth\":5,\"actual\":1,\"expected\":2,\"error\":{},\"functionName\":\"Test.<anonymous>\",\"file\":\"C:\\\\Repos\\\\nodejstools\\\\Nodejs\\\\Tests\\\\MockProjects\\\\NodeAppWithTestsConfiguredPerFile\\\\TapeUnitTest.js:11:7\",\"line\":11,\"column\":7,\"at\":\"Test.<anonymous> (C:\\\\Repos\\\\nodejstools\\\\Nodejs\\\\Tests\\\\MockProjects\\\\NodeAppWithTestsConfiguredPerFile\\\\TapeUnitTest.js:11:7)\",\"test\":1,\"type\":\"assert\"}\r\nError: This should fail\r\n    at Test.assert [as _assert] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:260:54)\r\n    at Test.bound [as _assert] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.strictEqual (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:424:10)\r\n    at Test.bound [as equal] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.<anonymous> (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\TapeUnitTest.js:11:7)\r\n    at Test.bound [as _cb] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.run (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:101:31)\r\n    at Test.bound [as run] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Immediate.next [as _onImmediate] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\results.js:85:19)\r\n    at processImmediate (internal/timers.js:456:21)\r\n",
+                                "Operator: equal. Expected: 2. Actual: 1. evt: {\"id\":1,\"ok\":false,\"todo\":false,\"name\":\"This should fail\",\"operator\":\"equal\",\"objectPrintDepth\":5,\"actual\":1,\"expected\":2,\"error\":{},\"functionName\":\"Test.<anonymous>\",\"file\":\"C:\\\\Repos\\\\nodejstools\\\\Nodejs\\\\Tests\\\\MockProjects\\\\NodeAppWithTestsConfiguredPerFile\\\\TapeUnitTest.js:11:7\",\"line\":11,\"column\":7,\"at\":\"Test.<anonymous> (C:\\\\Repos\\\\nodejstools\\\\Nodejs\\\\Tests\\\\MockProjects\\\\NodeAppWithTestsConfiguredPerFile\\\\TapeUnitTest.js:11:7)\",\"test\":1,\"type\":\"assert\"}\r\nError: This should fail\r\n    at Test.assert [as _assert] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:260:54)\r\n    at Test.bound [as _assert] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.strictEqual (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:424:10)\r\n    at Test.bound [as equal] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.<anonymous> (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\TapeUnitTest.js:11:7)\r\n    at Test.bound [as _cb] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Test.run (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:101:31)\r\n    at Test.bound [as run] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\test.js:84:32)\r\n    at Immediate.next [as _onImmediate] (C:\\Repos\\nodejstools\\Nodejs\\Tests\\MockProjects\\NodeAppWithTestsConfiguredPerFile\\node_modules\\tape\\lib\\results.js:85:19)\r\n    at processImmediate (internal/timers.js:456:21)\r\n"),
                         };
                     }
                 case SupportedFramework.Angular:
-                    return new List<TestCase>()
+                    return new[]
                     {
-                        GetTestCase(testCaseOptions, @"src\app\app.component.spec.ts::AppComponent::should create the app","should create the app", 14, Path.Combine(GetProjectDirPath(projectName), @"src\app\app.component.spec.ts")),
-                        GetTestCase(testCaseOptions, @"src\app\app.component.spec.ts::AppComponent::should have as title 'my-app'","should have as title 'my-app'", 20, Path.Combine(GetProjectDirPath(projectName), @"src\app\app.component.spec.ts")),
-                        GetTestCase(testCaseOptions, @"src\app\app.component.spec.ts::AppComponent::should render title","should render title", 26, Path.Combine(GetProjectDirPath(projectName), @"src\app\app.component.spec.ts")),
-                        GetTestCase(testCaseOptions, @"src\app\customTest.spec.ts::CustomTest::should succeed","should succeed", 4, Path.Combine(GetProjectDirPath(projectName), @"src\app\customTest.spec.ts")),
-                        GetTestCase(testCaseOptions, @"src\app\customTest.spec.ts::CustomTest::should fail","should fail", 8, Path.Combine(GetProjectDirPath(projectName), @"src\app\customTest.spec.ts")),
+                        GetTestCaseResult(
+                            testCaseOptions,
+                            @"src\app\app.component.spec.ts::AppComponent::should create the app","should create the app",
+                            14,
+                            Path.Combine(GetProjectDirPath(projectName),
+                            @"src\app\app.component.spec.ts"),
+                            TestOutcome.Passed),
+                        GetTestCaseResult(
+                            testCaseOptions,
+                            @"src\app\app.component.spec.ts::AppComponent::should have as title 'my-app'","should have as title 'my-app'",
+                            20,
+                            Path.Combine(GetProjectDirPath(projectName),
+                            @"src\app\app.component.spec.ts"),
+                            TestOutcome.Passed),
+                        GetTestCaseResult(
+                            testCaseOptions,
+                            @"src\app\app.component.spec.ts::AppComponent::should render title","should render title",
+                            26,
+                            Path.Combine(GetProjectDirPath(projectName),
+                            @"src\app\app.component.spec.ts"),
+                            TestOutcome.Passed),
+                        GetTestCaseResult(
+                            testCaseOptions,
+                            @"src\app\customTest.spec.ts::CustomTest::should succeed","should succeed",
+                            4,
+                            Path.Combine(GetProjectDirPath(projectName),
+                            @"src\app\customTest.spec.ts"),
+                            TestOutcome.Passed),
+                        GetTestCaseResult(
+                            testCaseOptions,
+                            @"src\app\customTest.spec.ts::CustomTest::should fail","should fail",
+                            8,
+                            Path.Combine(GetProjectDirPath(projectName),
+                            @"src\app\customTest.spec.ts"),
+                            TestOutcome.Failed,
+                            string.Empty,
+                            "Error: Expected false to be truthy.\r\n    at <Jasmine>\r\n    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/src/app/customTest.spec.ts:8:19)\r\n    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/node_modules/zone.js/dist/zone-evergreen.js:364:1)\r\n    at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/node_modules/zone.js/dist/zone-testing.js:292:1)\r\n",
+                            "Error: Expected false to be truthy.\r\n    at <Jasmine>\r\n    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/src/app/customTest.spec.ts:8:19)\r\n    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/node_modules/zone.js/dist/zone-evergreen.js:364:1)\r\n    at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/node_modules/zone.js/dist/zone-testing.js:292:1)\r\n"),
                     };
             }
 
             throw new NotImplementedException($"ProjectName {projectName} has not been implemented.");
         }
 
-        private static TestCase GetTestCase(TestCaseOptions testCaseOptions, string fullyQualifiedName, string displayName, int lineNumber, string filePath)
+        private static TestCaseResult GetTestCaseResult(TestCaseOptions testCaseOptions, string fullyQualifiedName, string displayName, int lineNumber, string filePath, TestOutcome testOutcome, string standardOutMessage = "", string standardErrorMessage = "", string additionalInfo = "")
         {
             var testCase = new TestCase()
             {
@@ -156,12 +262,24 @@ namespace TestAdapter.Tests
             testCase.SetPropertyValue(JavaScriptTestCaseProperties.TestFramework, testCaseOptions.TestFramework.ToString());
             testCase.SetPropertyValue(JavaScriptTestCaseProperties.WorkingDir, testCaseOptions.WorkingDir);
             testCase.SetPropertyValue(JavaScriptTestCaseProperties.ProjectRootDir, testCaseOptions.WorkingDir);
-            // TODO: We might only want to check that this is not empty. The value changes depending on the environment.
-            //testCase.SetPropertyValue(JavaScriptTestCaseProperties.NodeExePath, nodeExePath);
+            testCase.SetPropertyValue(JavaScriptTestCaseProperties.NodeExePath, testCaseOptions.NodeExePath);
             testCase.SetPropertyValue(JavaScriptTestCaseProperties.TestFile, filePath);
             testCase.SetPropertyValue(JavaScriptTestCaseProperties.ConfigDirPath, testCaseOptions.ConfigDirPath);
 
-            return testCase;
+            var testResult = new TestResult(testCase)
+            {
+                Outcome = testOutcome,
+            };
+
+            testResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, standardOutMessage));
+            testResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, standardErrorMessage));
+            testResult.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory, additionalInfo));
+
+            return new TestCaseResult()
+            {
+                TestCase = testCase,
+                TestResult = testResult
+            };
         }
     }
 }


### PR DESCRIPTION
Added execution tests to test adapters. Only nodejstools scenarios are covered.

Note that one of the added tests is always going to until a regression with Jasmine and a test failure with jest are fixed. Probably we want to `[Ignore]` this test until fixed, but I have decided to leave it broken so that we don't forget about it.

