### PR TITLE
Fix performance-killer in test-discovery.

### DIFF
--- a/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
@@ -261,6 +261,12 @@ namespace Microsoft.NodejsTools.TestAdapter
                 yield break;
             }
 
+            // No need to search for tests in not supported projects.
+            if (!TypeScriptHelpers.IsSupportedTestProjectFile(path))
+            {
+                yield break;
+            }
+
             if (this.detectingChanges)
             {
                 this.SaveModifiedFiles(project);


### PR DESCRIPTION
Fix performance-killing test-discovery, reported in https://github.com//microsoft/nodejstools/issues/2256.

##### Bug

NodeJS Tools analyzes non-Node projects and this causes a huge performance overhead in bigger solutions with lots of .NET/C++ projects.

In short:

* Load big project, as provided in reported issue.
* Try to start unit-tests in Visual Studio with NodeJS development tools installed.
* Observe that starting tests takes forever, and that uninstalling NodeJS development tools causes tests to start almost instantly.

On my end I've had test-start delayed with up **30 minutes** (not a typo).

##### Fix

Don't run testcontainer-discovery for non-nodejs project-types.

##### Testing

Repeat procedure outlined in bug, but with patched test-discovery implementation. Tests should now be run quickly.