### PR TITLE
Remove stale Nuget feeds and internal dependencies

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1144,9 +1144,6 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel">
       <Version>16.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.AppDesigner">
-      <Version>15.3.0-rc-6162104</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost">
       <Version>16.6.255</Version>
     </PackageReference>

--- a/Nodejs/Product/Nodejs/NodejsPackage.cs
+++ b/Nodejs/Product/Nodejs/NodejsPackage.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Microsoft.NodejsTools.Commands;
 using Microsoft.NodejsTools.Debugger.DebugEngine;
 using Microsoft.NodejsTools.Debugger.Remote;
@@ -233,6 +234,66 @@ namespace Microsoft.NodejsTools
         private T GetDialogPage<T>() where T : NodejsDialogPage
         {
             return (T)GetDialogPage(typeof(T));
+        }
+
+        public string BrowseForDirectory(IntPtr owner, string initialDirectory = null)
+        {
+            var uiShell = GetService(typeof(SVsUIShell)) as IVsUIShell;
+            if (uiShell == null)
+            {
+                using (var ofd = new FolderBrowserDialog())
+                {
+                    ofd.RootFolder = Environment.SpecialFolder.Desktop;
+                    ofd.ShowNewFolderButton = false;
+                    DialogResult result;
+                    if (owner == IntPtr.Zero)
+                    {
+                        result = ofd.ShowDialog();
+                    }
+                    else
+                    {
+                        result = ofd.ShowDialog(NativeWindow.FromHandle(owner));
+                    }
+                    if (result == DialogResult.OK)
+                    {
+                        return ofd.SelectedPath;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
+
+            if (owner == IntPtr.Zero)
+            {
+                ErrorHandler.ThrowOnFailure(uiShell.GetDialogOwnerHwnd(out owner));
+            }
+
+            var browseInfo = new VSBROWSEINFOW[1];
+            browseInfo[0].lStructSize = (uint)Marshal.SizeOf(typeof(VSBROWSEINFOW));
+            browseInfo[0].pwzInitialDir = initialDirectory;
+            browseInfo[0].hwndOwner = owner;
+            browseInfo[0].nMaxDirName = 260;
+            var pDirName = IntPtr.Zero;
+            try
+            {
+                browseInfo[0].pwzDirName = pDirName = Marshal.AllocCoTaskMem(520);
+                var hr = uiShell.GetDirectoryViaBrowseDlg(browseInfo);
+                if (hr == VSConstants.OLE_E_PROMPTSAVECANCELLED)
+                {
+                    return null;
+                }
+                ErrorHandler.ThrowOnFailure(hr);
+                return Marshal.PtrToStringAuto(browseInfo[0].pwzDirName);
+            }
+            finally
+            {
+                if (pDirName != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(pDirName);
+                }
+            }
         }
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Runtime.InteropServices;
@@ -18,14 +18,7 @@ namespace Microsoft.NodejsTools.Project
             this.control = new NodejsGeneralPropertyPageControl(this);
         }
 
-        protected override Control CreateControl()
-        {
-            return this.control;
-        }
-
         public override Control Control => this.control;
-
-        protected override Type ControlType => typeof(NodejsGeneralPropertyPageControl);
 
         internal override CommonProjectNode Project
         {
@@ -46,8 +39,7 @@ namespace Microsoft.NodejsTools.Project
                 }
             }
         }
-
-        protected override void Apply()
+        public override void Apply()
         {
             this.Project.SetProjectProperty(CommonConstants.StartupFile, this.control.ScriptFile);
             this.Project.SetProjectProperty(NodeProjectProperty.ScriptArguments, this.control.ScriptArguments);
@@ -95,32 +87,40 @@ namespace Microsoft.NodejsTools.Project
                 this.Project.SetUserProjectProperty(NodeProjectProperty.DebuggerPort, this.control.DebuggerPort);
             }
 
-            this.control.IsDirty = false;
+            this.IsDirty = false;
         }
 
         public override void LoadSettings()
         {
-            this.control.NodeExeArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExeArguments);
-            this.control.NodeExePath = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExePath);
-            this.control.ScriptFile = this.Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
-            this.control.ScriptArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.ScriptArguments);
-            this.control.WorkingDirectory = this.Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
-            this.control.LaunchUrl = this.Project.GetUnevaluatedProperty(NodeProjectProperty.LaunchUrl);
-            this.control.NodejsPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodejsPort);
-            this.control.DebuggerPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.DebuggerPort);
-            this.control.Environment = this.Project.GetUnevaluatedProperty(NodeProjectProperty.Environment);
-            this.control.StartWebBrowser = GetBoolProperty(this.Project, NodeProjectProperty.StartWebBrowser);
-            this.control.SaveNodeSettingsInProject = GetBoolProperty(this.Project, NodeProjectProperty.SaveNodeJsSettingsInProjectFile);
-            this.control.TestRoot = this.Project.GetProjectProperty(NodeProjectProperty.TestRoot);
-            this.control.TestFramework = this.Project.GetProjectProperty(NodeProjectProperty.TestFramework);
-
-            bool GetBoolProperty(ProjectNode node, string property)
+            this.Loading = true;
+            try
             {
-                // Attempt to parse the boolean.  If we fail, assume it is true.
-                return bool.TryParse(node.GetUnevaluatedProperty(property), out var result) ? result : true;
+                this.control.NodeExeArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExeArguments);
+                this.control.NodeExePath = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodeExePath);
+                this.control.ScriptFile = this.Project.GetUnevaluatedProperty(CommonConstants.StartupFile);
+                this.control.ScriptArguments = this.Project.GetUnevaluatedProperty(NodeProjectProperty.ScriptArguments);
+                this.control.WorkingDirectory = this.Project.GetUnevaluatedProperty(CommonConstants.WorkingDirectory);
+                this.control.LaunchUrl = this.Project.GetUnevaluatedProperty(NodeProjectProperty.LaunchUrl);
+                this.control.NodejsPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.NodejsPort);
+                this.control.DebuggerPort = this.Project.GetUnevaluatedProperty(NodeProjectProperty.DebuggerPort);
+                this.control.Environment = this.Project.GetUnevaluatedProperty(NodeProjectProperty.Environment);
+                this.control.StartWebBrowser = GetBoolProperty(this.Project, NodeProjectProperty.StartWebBrowser);
+                this.control.SaveNodeSettingsInProject = GetBoolProperty(this.Project, NodeProjectProperty.SaveNodeJsSettingsInProjectFile);
+                this.control.TestRoot = this.Project.GetProjectProperty(NodeProjectProperty.TestRoot);
+                this.control.TestFramework = this.Project.GetProjectProperty(NodeProjectProperty.TestFramework);
+
+                bool GetBoolProperty(ProjectNode node, string property)
+                {
+                    // Attempt to parse the boolean.  If we fail, assume it is true.
+                    return bool.TryParse(node.GetUnevaluatedProperty(property), out var result) ? result : true;
+                }
+            }
+            finally
+            {
+                this.Loading = false;
             }
         }
 
-        protected override string Title => "General";
+        public override string Name => "General";
     }
 }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -254,10 +254,12 @@ namespace Microsoft.NodejsTools.Project
 
         private void BrowsePathClick(object sender, EventArgs e)
         {
-            var nodeExePath = this._nodeExePath.Text;
-            if (this.GetFileViaBrowse(nodeExePath, ref nodeExePath, _exeFilter) && !string.IsNullOrEmpty(nodeExePath))
+            var dialog = new OpenFileDialog();
+            dialog.CheckFileExists = true;
+            dialog.Filter = _exeFilter;
+            if (dialog.ShowDialog() == DialogResult.OK)
             {
-                this._nodeExePath.Text = nodeExePath;
+                this._nodeExePath.Text = dialog.FileName;
                 this._nodeExePath.ForeColor = SystemColors.ControlText;
             }
         }
@@ -270,10 +272,10 @@ namespace Microsoft.NodejsTools.Project
             {
                 dir = projectHome;
             }
-
-            if (this.GetDirectoryViaBrowseRelative(dir, projectHome, Resources.BrowseWorkingDirDialogTitle, ref dir))
+            var path = NodejsPackage.Instance.BrowseForDirectory(this.Handle, dir);
+            if (!string.IsNullOrEmpty(path))
             {
-                this._workingDir.Text = string.IsNullOrEmpty(dir) ? "." : dir;
+                this._workingDir.Text = path;
             }
         }
 
@@ -286,7 +288,8 @@ namespace Microsoft.NodejsTools.Project
                 dir = projectHome;
             }
 
-            if (this.GetDirectoryViaBrowseRelative(dir, projectHome, Resources.BrowseWorkingDirDialogTitle, ref dir))
+            var path = NodejsPackage.Instance.BrowseForDirectory(this.Handle, dir);
+            if (!string.IsNullOrEmpty(path))
             {
                 this._testRoot.Text = string.IsNullOrEmpty(dir) ? "." : dir;
             }

--- a/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsGeneralPropertyPageControl.cs
@@ -7,11 +7,11 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Microsoft.NodejsTools.TestFrameworks;
-using Microsoft.VisualStudio.Editors.PropertyPages;
+using Microsoft.VisualStudioTools.Project;
 
 namespace Microsoft.NodejsTools.Project
 {
-    internal sealed partial class NodejsGeneralPropertyPageControl : PropPageUserControlBase /*UserControl*/
+    internal partial class NodejsGeneralPropertyPageControl : UserControl
     {
         private readonly NodejsGeneralPropertyPage _propPage;
         private const string _exeFilter = "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*";
@@ -55,7 +55,7 @@ namespace Microsoft.NodejsTools.Project
             this._testRootLabel.Text = Resources.TestRoot;
 
             this._browsePath.AccessibleName = Resources.PropertiesBrowsePathAccessibleName;
-            this._browseDirectory.AccessibleName = Resources.PropertiesBrowseDirectoryAccessibleName;
+            this._browsePath.AccessibleName = Resources.PropertiesBrowseDirectoryAccessibleName;
             this._browseTestroot.AccessibleName = Resources.PropertiesBrowseTestRootAccessibleName;
         }
 
@@ -75,10 +75,6 @@ namespace Microsoft.NodejsTools.Project
             this._tooltip.SetToolTip(this._testRoot, Resources.TestRootToolTip);
             this._tooltip.SetToolTip(this._frameworkSelector, Resources.TestFrameworkToolTip);
         }
-
-        protected override bool DisableOnBuild => false;
-
-        protected override bool DisableOnDebug => false;
 
         public string NodeExePath
         {
@@ -242,7 +238,7 @@ namespace Microsoft.NodejsTools.Project
 
         private void Changed(object sender, EventArgs e)
         {
-            this.IsDirty = true;
+            this._propPage.IsDirty = true;
         }
 
         private void NodeExePathChanged(object sender, EventArgs e)

--- a/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodejsProjectNode.cs
@@ -404,7 +404,7 @@ namespace Microsoft.NodejsTools.Project
                     default:
                         if (propPage != null)
                         {
-                            propPage.IsDirty = true;
+                            this.PropertyPage.IsDirty = true;
                         }
                         break;
                 }

--- a/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonPropertyPage.cs
@@ -1,42 +1,373 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using Microsoft.VisualStudio.Editors.PropertyPages;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
 
 namespace Microsoft.VisualStudioTools.Project
 {
     /// <summary>
     /// Base class for property pages based on a WinForm control.
     /// </summary>
-    public abstract class CommonPropertyPage : PropPageBase
+    public abstract class CommonPropertyPage : IPropertyPage
     {
-        protected override Size DefaultSize { get; set; } = new Size(800, 600);
+        private IPropertyPageSite site;
+        private CommonProjectNode _project;
+        private bool dirty;
 
+        public abstract Control Control
+        {
+            get;
+        }
+
+        public virtual Size DefaultSize { get; } = new Size(800, 600);
+
+        public abstract void Apply();
         public abstract void LoadSettings();
 
-        public abstract Control Control { get; }
-
-        internal virtual CommonProjectNode Project { get; set; }
-
-        protected override void SetObjects(uint count, object[] objects)
+        public abstract string Name
         {
-            if (objects == null)
+            get;
+        }
+
+        internal virtual CommonProjectNode Project
+        {
+            get
+            {
+                return this._project;
+            }
+            set
+            {
+                this._project = value;
+            }
+        }
+
+        internal virtual IEnumerable<CommonProjectConfig> SelectedConfigs
+        {
+            get; set;
+        }
+
+        protected void SetProjectProperty(string propertyName, string propertyValue)
+        {
+            // SetProjectProperty's implementation will check whether the value
+            // has changed.
+            this.Project.SetProjectProperty(propertyName, propertyValue);
+        }
+
+        protected string GetProjectProperty(string propertyName)
+        {
+            return this.Project.GetUnevaluatedProperty(propertyName);
+        }
+
+        protected void SetUserProjectProperty(string propertyName, string propertyValue)
+        {
+            // SetUserProjectProperty's implementation will check whether the value
+            // has changed.
+            this.Project.SetUserProjectProperty(propertyName, propertyValue);
+        }
+
+        protected string GetUserProjectProperty(string propertyName)
+        {
+            return this.Project.GetUserProjectProperty(propertyName);
+        }
+
+        protected string GetConfigUserProjectProperty(string propertyName)
+        {
+            if (this.SelectedConfigs == null)
+            {
+                var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    ConfigProvider.configPlatformString,
+                    this.Project.CurrentConfig.GetPropertyValue("Configuration"),
+                    this.Project.CurrentConfig.GetPropertyValue("Platform"));
+
+                return GetUserPropertyUnderCondition(propertyName, condition);
+            }
+            else
+            {
+                var values = new StringCollection();
+
+                foreach (var config in this.SelectedConfigs)
+                {
+                    var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        ConfigProvider.configPlatformString,
+                        config.ConfigName,
+                        config.PlatformName);
+
+                    values.Add(GetUserPropertyUnderCondition(propertyName, condition));
+                }
+
+                switch (values.Count)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return values[0];
+                    default:
+                        return "<different values>";
+                }
+            }
+        }
+
+        protected void SetConfigUserProjectProperty(string propertyName, string propertyValue)
+        {
+            if (this.SelectedConfigs == null)
+            {
+                var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    ConfigProvider.configPlatformString,
+                    this.Project.CurrentConfig.GetPropertyValue("Configuration"),
+                    this.Project.CurrentConfig.GetPropertyValue("Platform"));
+
+                SetUserPropertyUnderCondition(propertyName, propertyValue, condition);
+            }
+            else
+            {
+                foreach (var config in this.SelectedConfigs)
+                {
+                    var condition = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        ConfigProvider.configPlatformString,
+                        config.ConfigName,
+                        config.GetConfigurationProperty("Platform", false));
+
+                    SetUserPropertyUnderCondition(propertyName, propertyValue, condition);
+                }
+            }
+        }
+
+        private string GetUserPropertyUnderCondition(string propertyName, string condition)
+        {
+            var conditionTrimmed = (condition == null) ? string.Empty : condition.Trim();
+
+            if (this.Project.UserBuildProject != null)
+            {
+                if (conditionTrimmed.Length == 0)
+                {
+                    return this.Project.UserBuildProject.GetProperty(propertyName).UnevaluatedValue;
+                }
+
+                // New OM doesn't have a convenient equivalent for setting a property with a particular property group condition. 
+                // So do it ourselves.
+                ProjectPropertyGroupElement matchingGroup = null;
+
+                foreach (var group in this.Project.UserBuildProject.Xml.PropertyGroups)
+                {
+                    if (StringComparer.OrdinalIgnoreCase.Equals(group.Condition.Trim(), conditionTrimmed))
+                    {
+                        matchingGroup = group;
+                        break;
+                    }
+                }
+
+                if (matchingGroup != null)
+                {
+                    foreach (var property in matchingGroup.PropertiesReversed) // If there's dupes, pick the last one so we win
+                    {
+                        if (StringComparer.OrdinalIgnoreCase.Equals(property.Name, propertyName)
+                            && (property.Condition == null || property.Condition.Length == 0))
+                        {
+                            return property.Value;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Emulates the behavior of SetProperty(name, value, condition) on the old MSBuild object model.
+        /// This finds a property group with the specified condition (or creates one if necessary) then sets the property in there.
+        /// </summary>
+        private void SetUserPropertyUnderCondition(string propertyName, string propertyValue, string condition)
+        {
+            var conditionTrimmed = (condition == null) ? string.Empty : condition.Trim();
+            const string userProjectCreateProperty = "UserProject";
+
+            if (this.Project.UserBuildProject == null)
+            {
+                this.Project.SetUserProjectProperty(userProjectCreateProperty, null);
+            }
+
+            if (conditionTrimmed.Length == 0)
+            {
+                var userProp = this.Project.UserBuildProject.GetProperty(userProjectCreateProperty);
+                if (userProp != null)
+                {
+                    this.Project.UserBuildProject.RemoveProperty(userProp);
+                }
+                this.Project.UserBuildProject.SetProperty(propertyName, propertyValue);
+                return;
+            }
+
+            // New OM doesn't have a convenient equivalent for setting a property with a particular property group condition. 
+            // So do it ourselves.
+            ProjectPropertyGroupElement newGroup = null;
+
+            foreach (var group in this.Project.UserBuildProject.Xml.PropertyGroups)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(group.Condition.Trim(), conditionTrimmed))
+                {
+                    newGroup = group;
+                    break;
+                }
+            }
+
+            if (newGroup == null)
+            {
+                newGroup = this.Project.UserBuildProject.Xml.AddPropertyGroup(); // Adds after last existing PG, else at start of project
+                newGroup.Condition = condition;
+            }
+
+            foreach (var property in newGroup.PropertiesReversed) // If there's dupes, pick the last one so we win
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(property.Name, propertyName)
+                    && (property.Condition == null || property.Condition.Length == 0))
+                {
+                    property.Value = propertyValue;
+                    return;
+                }
+            }
+
+            newGroup.AddProperty(propertyName, propertyValue);
+        }
+
+        public bool Loading { get; set; }
+
+        public bool IsDirty
+        {
+            get
+            {
+                return this.dirty;
+            }
+            set
+            {
+                if (this.dirty != value && !this.Loading)
+                {
+                    this.dirty = value;
+                    if (this.site != null)
+                    {
+                        this.site.OnStatusChange((uint)(this.dirty ? PropPageStatus.Dirty : PropPageStatus.Clean));
+                    }
+                }
+            }
+        }
+
+        void IPropertyPage.Activate(IntPtr hWndParent, RECT[] pRect, int bModal)
+        {
+            this.Control.Visible = false;
+
+            // suspend to reduce flashing
+            this.Control.SuspendLayout();
+
+            try
+            {
+                var parent = Control.FromHandle(hWndParent);
+                this.Control.Parent = parent;
+
+                // move to final location
+                ((IPropertyPage)this).Move(pRect);
+            }
+            finally
+            {
+                this.Control.ResumeLayout();
+                this.Control.Visible = true;
+                this.Control.Focus();
+            }
+        }
+
+        int IPropertyPage.Apply()
+        {
+            try
+            {
+                Apply();
+                return VSConstants.S_OK;
+            }
+            catch (Exception e)
+            {
+                return Marshal.GetHRForException(e);
+            }
+        }
+
+        void IPropertyPage.Deactivate()
+        {
+            this.Project = null;
+            this.Control.Dispose();
+        }
+
+        void IPropertyPage.GetPageInfo(PROPPAGEINFO[] pPageInfo)
+        {
+            Utilities.ArgumentNotNull("pPageInfo", pPageInfo);
+
+            var info = new PROPPAGEINFO();
+
+            info.cb = (uint)Marshal.SizeOf(typeof(PROPPAGEINFO));
+            info.dwHelpContext = 0;
+            info.pszDocString = null;
+            info.pszHelpFile = null;
+            info.pszTitle = this.Name;
+            info.SIZE.cx = this.DefaultSize.Width;
+            info.SIZE.cy = this.DefaultSize.Height;
+            pPageInfo[0] = info;
+        }
+
+        void IPropertyPage.Help(string pszHelpDir)
+        {
+            // not implemented
+        }
+
+        int IPropertyPage.IsPageDirty()
+        {
+            return (this.IsDirty ? (int)VSConstants.S_OK : (int)VSConstants.S_FALSE);
+        }
+
+        void IPropertyPage.Move(RECT[] pRect)
+        {
+            Utilities.ArgumentNotNull("pRect", pRect);
+
+            var r = pRect[0];
+
+            this.Control.Location = new Point(r.left, r.top);
+            this.Control.Size = new Size(r.right - r.left, r.bottom - r.top);
+        }
+
+        void IPropertyPage.SetObjects(uint count, object[] punk)
+        {
+            if (punk == null)
             {
                 return;
             }
 
             if (count > 0)
             {
-                if (this.Project == null)
+                if (punk[0] is ProjectConfig)
                 {
-                    if (objects[0] is CommonProjectConfig projectConfig)
+                    if (this._project == null)
                     {
-                        this.Project = (CommonProjectNode)projectConfig.ProjectMgr;
+                        this._project = (CommonProjectNode)((CommonProjectConfig)punk.First()).ProjectMgr;
                     }
-                    else if (objects[0] is NodeProperties properties)
+
+                    var configs = new List<CommonProjectConfig>();
+
+                    for (var i = 0; i < count; i++)
                     {
-                        this.Project = (CommonProjectNode)(properties).HierarchyNode.ProjectMgr;
+                        var config = (CommonProjectConfig)punk[i];
+
+                        configs.Add(config);
+                    }
+
+                    this.SelectedConfigs = configs;
+                }
+                else if (punk[0] is NodeProperties)
+                {
+                    if (this._project == null)
+                    {
+                        this.Project = (CommonProjectNode)(punk[0] as NodeProperties).HierarchyNode.ProjectMgr;
                     }
                 }
             }
@@ -45,10 +376,53 @@ namespace Microsoft.VisualStudioTools.Project
                 this.Project = null;
             }
 
-            if (this.Project != null)
+            if (this._project != null)
             {
                 LoadSettings();
             }
+        }
+
+        void IPropertyPage.SetPageSite(IPropertyPageSite pPageSite)
+        {
+            this.site = pPageSite;
+        }
+
+        void IPropertyPage.Show(uint nCmdShow)
+        {
+            const int SW_HIDE = 0;
+
+            if (nCmdShow != SW_HIDE)
+            {
+                this.Control.Visible = true;
+                this.Control.Show();
+            }
+            else
+            {
+                this.Control.Visible = false;
+                this.Control.Hide();
+            }
+        }
+
+        int IPropertyPage.TranslateAccelerator(MSG[] pMsg)
+        {
+            Utilities.ArgumentNotNull("pMsg", pMsg);
+
+            var msg = pMsg[0];
+
+            var message = Message.Create(msg.hwnd, (int)msg.message, msg.wParam, msg.lParam);
+
+            var target = Control.FromChildHandle(message.HWnd);
+            if (target != null && target.PreProcessMessage(ref message))
+            {
+                // handled the message
+                pMsg[0].message = (uint)message.Msg;
+                pMsg[0].wParam = message.WParam;
+                pMsg[0].lParam = message.LParam;
+
+                return VSConstants.S_OK;
+            }
+
+            return VSConstants.S_FALSE;
         }
     }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -1,10 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet myget" value="https://dotnet.myget.org/f/dotnet-core/api/v3/index.json" />
-    <add key="roslyn myget" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
-    <add key="Interactive Window" value="https://dotnet.myget.org/f/interactive-window/api/v3/index.json" />
-    <add key="VSSDK Preview" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
* Remove all sources from nuget.config but nuget.org
* Remove internal dependency `Microsoft.VisualStudio.AppDesigner`
* Revert sections of #1719 which introduced a dependency on `PropPageBase` from the internal assembly. This restores the previous custom implementation of the property page.
* Revert sections of #1754 which introduced a dependency on `PropPageUserControlBase` from the internal assembly. This restores the previous implementation of File/Folder browse dialogs.