### PR TITLE
Update MicroBuild reference

### DIFF
--- a/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
+++ b/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.3.0">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
+++ b/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.3.0">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
`MicroBuild.Core` has been superseded by `Microsoft.VisualStudioEng.MicroBuild.Core`.