### PR TITLE
Stop saving all files on TestContainer acquisition during change detection

### DIFF
--- a/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
@@ -267,11 +267,6 @@ namespace Microsoft.NodejsTools.TestAdapter
                 yield break;
             }
 
-            if (this.detectingChanges)
-            {
-                this.SaveModifiedFiles(project);
-            }
-
             if (!this.knownProjects.TryGetValue(path, out var projectInfo) || !TryGetProjectUnitTestProperties(projectInfo.Project, out _, out _))
             {
                 // Don't return any containers for projects we don't know about or that we know that they are not configured for JavaScript unit tests.
@@ -295,22 +290,6 @@ namespace Microsoft.NodejsTools.TestAdapter
                 });
 
             yield return new TestContainer(this, path, latestWrite);
-        }
-
-        private void SaveModifiedFiles(IVsProject project)
-        {
-            // save all the open files in the project...
-            foreach (var itemPath in project.GetProjectItems())
-            {
-                if (string.IsNullOrEmpty(itemPath))
-                {
-                    continue;
-                }
-
-                var solution = (IVsSolution)this.serviceProvider.GetService(typeof(SVsSolution));
-                ErrorHandler.ThrowOnFailure(
-                    solution.SaveSolutionElement((uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_SaveIfDirty, (IVsHierarchy)project, /* save entire project */ 0));
-            }
         }
 
         private bool ShouldDiscover(string pathToItem)

--- a/Nodejs/Product/TestAdapterImpl/VsProjectExtensions.cs
+++ b/Nodejs/Product/TestAdapterImpl/VsProjectExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.NodejsTools.TestAdapter
         /// <summary>
         /// Get the items present in the project
         /// </summary>
-        public static IEnumerable<string> GetProjectItems(this IVsProject project)
+        private static IEnumerable<string> GetProjectItems(this IVsProject project)
         {
             if (project == null)
             {


### PR DESCRIPTION
##### Bug
If the test explorer requests our Test Containers while it's trying to determine if there have been changes to its known set of test containers, we go through every file in the solution and save it if necessary.
ETW tracing shows that in a large solution, like Roslyn.sln, this incurs a massive performance hit, particularly due to the amount of COM marshaling we do.

##### Fix
This behavior was originally introduced here, and thankfully there's a fair bit of context provided: https://github.com/microsoft/PTVS/commit/a53c162bea318f57aa1113ffdeda37550f551f93

Here, we simply remove the logic to save all files in this scenario. 
As far as I can tell, PTVS also ended up removing this logic here: https://github.com/microsoft/PTVS/pull/1337

##### Testing
The original bug this intended to fix was as follows (found on Codeplex):
```
Create a new python project
Create a new python test template item
Save all
Add a new test_foo function to the test class
Do NOT save
Click run all

You'll get this message in the output window:

------ Run test started ------
Test adapter sent back a result for an unknown test case. Ignoring result for 'test_foo'.
========== Run test finished: 3 run (0:00:00.7869987) ==========
------ Discover test started ------
========== Discover test finished: 4 found (0:00:00.1126771) ==========


and test_foo will appear in test explorer with an exclamation icon
```

I've confirmed manually that, with this change, clicking "run all" handles the save for us and the additional, unsaved test is discovered correctly.