### PR TITLE
Allow WebRole project to be opened in dev16 and dev17

### DIFF
--- a/Nodejs/Product/WebRole/WebRole.csproj
+++ b/Nodejs/Product/WebRole/WebRole.csproj
@@ -63,7 +63,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VSTarget)\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" />
   <Import Project="..\ProjectAfter.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Currently, the WebRole project doesn't load in Dev17 because Microsoft.WebApplication.targets cannot be found.
Here, we update the import to find the file regardless of VS version.