### PR TITLE
Various fixes to allow building with MSBuild 17

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1116,7 +1116,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>16.6.0</Version>
+      <Version>17.0.0-preview-21256-03</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
+++ b/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
@@ -84,6 +84,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.0.1597</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/Nodejs/Product/NodejsToolsVsix/source.extension.vsixmanifest
+++ b/Nodejs/Product/NodejsToolsVsix/source.extension.vsixmanifest
@@ -15,9 +15,15 @@
        Id specifications are minimums; any SKU equal or 'higher' will accept
        them. -->
     <Installation SystemComponent="true">
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise" />
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Nodejs" Path="|Nodejs;PkgdefProjectOutputGroup|" />

--- a/Nodejs/Product/TargetsVsix/TargetsVsix.csproj
+++ b/Nodejs/Product/TargetsVsix/TargetsVsix.csproj
@@ -89,6 +89,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.0.1597</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/Nodejs/Product/TargetsVsix/source.extension.vsixmanifest
+++ b/Nodejs/Product/TargetsVsix/source.extension.vsixmanifest
@@ -12,9 +12,15 @@
         <AllowClientRole>true</AllowClientRole>
     </Metadata>
     <Installation SystemComponent="true" AllUsers="true">
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise" />
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -83,7 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build">
-      <Version>16.6.0</Version>
+      <Version>17.0.0-preview-21256-03</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
+++ b/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
@@ -77,7 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build">
-      <Version>16.6.0</Version>
+      <Version>17.0.0-preview-21256-03</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/Nodejs/Product/TestAdapterVsix/TestAdapterVsix.csproj
+++ b/Nodejs/Product/TestAdapterVsix/TestAdapterVsix.csproj
@@ -74,6 +74,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.0.1597</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" />

--- a/Nodejs/Product/TestAdapterVsix/source.extension.vsixmanifest
+++ b/Nodejs/Product/TestAdapterVsix/source.extension.vsixmanifest
@@ -12,9 +12,15 @@
         <AllowClientRole>true</AllowClientRole>
     </Metadata>
     <Installation SystemComponent="true">
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise" />
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.0.0-preview-21256-03" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.15.1" />


### PR DESCRIPTION
Here, we make a few updates for dev17:
- Update references to Microsoft.Build for the test adapter. There was no API break, but when deploying the test adapter locally, we need a newer version of Microsoft.Build than we currently have in order to successfully load NTVS projects while discovering tests. This does not happen in the real product because the copy of Microsoft.Build.dll from VS is used.
- Add references to VSSDK build tools - this is the recommended practice for VSIX projects.
- Update VSIX manifest files with `ProductArchitecture`. This is required to make VSIXs Dev17-compatible.