### PR TITLE
Update dependency versions in Vue project templates

### DIFF
--- a/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/TypeScriptVuejsApp/package.json
@@ -11,16 +11,16 @@
     "name": ""
   },
   "dependencies": {
-    "vue": "2.5.17",
-    "vue-class-component": "6.0.0",
-    "vue-property-decorator": "7.0.0"
+    "vue": "2.6.12",
+    "vue-class-component": "7.2.6",
+    "vue-property-decorator": "9.1.2"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "3.0.4",
-    "@vue/cli-plugin-typescript": "3.0.4",
-    "@vue/cli-service": "3.0.4",
-    "typescript": "^4.0.5",
-    "vue-template-compiler": "2.5.17"
+    "@vue/cli-plugin-babel": "4.5.13",
+    "@vue/cli-plugin-typescript": "4.5.13",
+    "@vue/cli-service": "4.5.13",
+    "typescript": "4.1.5",
+    "vue-template-compiler": "2.6.12"
   },
   "postcss": {
     "plugins": {

--- a/Nodejs/Product/Nodejs/ProjectTemplates/VuejsApp/package.json
+++ b/Nodejs/Product/Nodejs/ProjectTemplates/VuejsApp/package.json
@@ -12,15 +12,16 @@
     "name": ""
   },
   "dependencies": {
-    "vue": "2.5.17"
+    "vue": "2.6.12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "3.0.4",
-    "@vue/cli-plugin-eslint": "3.0.4",
-    "@vue/cli-service": "3.0.4",
-    "eslint": "5.6.0",
-    "eslint-plugin-vue": "4.7.1",
-    "vue-template-compiler": "2.5.17"
+    "@vue/cli-plugin-babel": "4.5.13",
+    "@vue/cli-plugin-eslint": "4.5.13",
+    "@vue/cli-service": "4.5.13",
+    "babel-eslint": "10.1.0",
+    "eslint": "6.8.0",
+    "eslint-plugin-vue": "6.2.2",
+    "vue-template-compiler": "2.6.12"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
##### Bug
When using npm 7, the initial npm install for the JS Vue App and TS Vue App project templates fails due to conflicting peer dependencies.

##### Fix
Update the dependencies specified in the package.json template to those installed by a project created by the latest version of `@vue/cli` (v4.5.13).
The dependencies for the JS project template are what's generated by the default `vue create` settings, and those for the TS project template are what's generated by instructing `vue create` to support Babel and TypeScript.

##### Testing
Locally updated the packages to these in a newly created project (one of each of the templates) and verified that npm 7 is able to install successfully with no runtime security vulnerabilities.