### PR TITLE
update regex for angular 11 tests

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -11,7 +11,7 @@ function itReplacement(it) {
 }
 
 function getFileLocation() {
-    const stackLineRegex = /at.*\(.*_karma_webpack_(.*\.spec\.ts):(\d*):(\d*)/;
+    const stackLineRegex = /at.*\(.*_karma_webpack_(?:\/webpack\:)(.*\.spec\.ts):(\d*):(\d*)/;
     const match = (new Error()).stack.match(stackLineRegex);
 
     return match

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -11,7 +11,7 @@ function itReplacement(it) {
 }
 
 function getFileLocation() {
-    const stackLineRegex = /at.*\(.*_karma_webpack_(?:\/webpack\:)(.*\.spec\.ts):(\d*):(\d*)/;
+    const stackLineRegex = /at.*\(.*_karma_webpack_(?:\/webpack\:)?(.*\.spec\.ts):(\d*):(\d*)/;
     const match = (new Error()).stack.match(stackLineRegex);
 
     return match


### PR DESCRIPTION
##### Bug
Projects created with the latest Angular CLI produce the following error during test discovery:
```
[5/24/2021 2:17:16.347 PM] Processing: C:\Users\pranas\source\repos\Project18\Project18\ClientApp\angular.json
[5/24/2021 2:17:27.265 PM] - Generating browser application bundles...
[5/24/2021 2:17:31.246 PM] ΓêÜ Browser application bundle generation complete.
[5/24/2021 2:17:35.319 PM] The given path's format is not supported.
[5/24/2021 2:17:35.323 PM] An exception occurred while test discoverer 'DotNetTestDiscoverer' was loading tests. Exception: The given path's format is not supported.
[5/24/2021 2:17:35.325 PM] No test is available in C:\Users\pranas\source\repos\Project18\Project18\Project18.csproj. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.
[5/24/2021 2:17:35.359 PM] ========== Test discovery finished: 0 Tests found in 24.2 sec ==========
```

The root cause is that the path that the test is located in has changed from (as an example):

`http://localhost:9876/_karma_webpack_/src/app/counter/counter.component.spec.ts:20:3`

to

`http://localhost:9876/_karma_webpack_/webpack:/src/app/counter/counter.component.spec.ts:20:3`

##### Fix
The regex is updated to take the extra `webpack:` into account.

##### Testing
Still in progress (will update this once finished).