### PR TITLE
Update VsWebsite.Interop

### DIFF
--- a/Nodejs/Product/Nodejs/Nodejs.csproj
+++ b/Nodejs/Product/Nodejs/Nodejs.csproj
@@ -1154,7 +1154,7 @@
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="VsWebSite.Interop">
-      <Version>17.0.0-previews-1-31318-023</Version>
+      <Version>17.0.0-previews-4-31619-031</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <Version>1.0.0</Version>


### PR DESCRIPTION
There was a bad reference in the old version, leading to problems like [this](https://developercommunity.visualstudio.com/t/Error-creating-Blank-Nodejs-Web-Applica/1488976).