### PR TITLE
Fixing operator for older Node versions

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -151,8 +151,8 @@ function readConfigs(projectFolder, context)
         config = require(jestConfigPathJS);
     }
 
-    config ||= {};
-    config.testMatch ||= [context.testCases[0].testFile];    
+    config = config || {};
+    config.testMatch = config.testMatch || [context.testCases[0].testFile];    
     
     return config;
 }


### PR DESCRIPTION
Older Node versions do not support the operator `||=`
