### PR TITLE
Fixing perf issue in TestFilesUpdateWatcher

### DIFF
--- a/Nodejs/Product/Nodejs/Telemetry/TelemetryEvents.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/TelemetryEvents.cs
@@ -42,6 +42,11 @@ namespace Microsoft.NodejsTools.Telemetry
         public const string OperationRegistrationFaulted = Prefix + "OperationRegistrationFaulted";
 
         /// <summary>
+        /// An error occurred within a TestFilesUpdateWatcher event handler
+        /// </summary>
+        public const string TestFilesWatcherEventFaulted = Prefix + "TestFilesWatcherEventFaulted";
+
+        /// <summary>
         /// User started discovery on the test adapters.
         /// </summary>
         public const string TestDiscoveryStarted = Prefix + "TestDiscoveryStarted";

--- a/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
+++ b/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\TypeScript\TypeScriptHelpers.cs">
       <Link>TypeScriptHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RunFromContextFileExtensions.cs" />
     <Compile Include="ServiceProviderExtension.cs" />


### PR DESCRIPTION
Currently, we use JTF.Run() on each time we get a FilesChanged event, or a DirectoryChangedEx event. This blocks the current (threadpool) thread until the work is complete. This can cause threadpool starvation, and has done so for users, as evidenced by telemetry.

See Issue # 1393794 (Azure DevOps)