### PR TITLE
Support Jasmine 4.0

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -123,10 +123,10 @@ async function find_tests(testFileList, discoverResultFile, projectFolder) {
             jasmineInstance.specFiles = [];
             jasmineInstance.addMatchingSpecFiles([testFile]);
             
-			var p = jasmineInstance.loadSpecs();
-			if (p instanceof Promise) {
-				await p;
-			}
+            var p = jasmineInstance.loadSpecs();
+            if (p instanceof Promise) {
+                await p;
+            }
 
             var topSuite = jasmineInstance.env.topSuite();
             // In Jasmine 4.0+ the Suite object is not top level anymore and is instead in the suite_ property

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -122,7 +122,11 @@ async function find_tests(testFileList, discoverResultFile, projectFolder) {
             jasmineInstance.specDir = "";
             jasmineInstance.specFiles = [];
             jasmineInstance.addMatchingSpecFiles([testFile]);
-            await jasmineInstance.loadSpecs();
+            
+			var p = jasmineInstance.loadSpecs();
+			if (p instanceof Promise) {
+				await p;
+			}
 
             var topSuite = jasmineInstance.env.topSuite();
             // In Jasmine 4.0+ the Suite object is not top level anymore and is instead in the suite_ property

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -107,38 +107,40 @@ function enumerateSpecs(suite, testList, testFile) {
  * @param {string} discoverResultFile
  * @param {string} projectFolder
  */
-function find_tests(testFileList, discoverResultFile, projectFolder) {
-    return new Promise(resolve => {
-        var Jasmine = detectJasmine(projectFolder);
-        if (!Jasmine) {
-            return resolve();
+async function find_tests(testFileList, discoverResultFile, projectFolder) {
+    var Jasmine = detectJasmine(projectFolder);
+    if (!Jasmine) {
+        return;
+    }
+    
+    var jasmineInstance = initializeJasmine(Jasmine, projectFolder);
+    setSpecFilter(jasmineInstance, _ => false);
+
+    var testList = [];
+    for (var testFile of testFileList.split(";")) {
+        try {
+            jasmineInstance.specDir = "";
+            jasmineInstance.specFiles = [];
+            jasmineInstance.addMatchingSpecFiles([testFile]);
+            await jasmineInstance.loadSpecs();
+
+            var topSuite = jasmineInstance.env.topSuite();
+            // In Jasmine 4.0+ the Suite object is not top level anymore and is instead in the suite_ property
+            if (topSuite && topSuite.suite_) {
+                topSuite = topSuite.suite_;
+            }
+            
+            enumerateSpecs(topSuite, testList, testFile);
         }
-        var jasmineInstance = initializeJasmine(Jasmine, projectFolder);
-        setSpecFilter(jasmineInstance, _ => false);
+        catch (ex) {
+            //we would like continue discover other files, so swallow, log and continue;
+            console.error("Test discovery error:", ex, "in", testFile);
+        }
+    }
 
-        var testList = [];
-        testFileList.split(";").forEach((testFile) => {
-            try {
-                jasmineInstance.specDir = "";
-                jasmineInstance.specFiles = [];
-                jasmineInstance.addSpecFiles([testFile]);
-                jasmineInstance.loadSpecs();
-
-                var topSuite = jasmineInstance.env.topSuite();
-                enumerateSpecs(topSuite, testList, testFile);
-            }
-            catch (ex) {
-                //we would like continue discover other files, so swallow, log and continue;
-                console.error("Test discovery error:", ex, "in", testFile);
-            }
-        });
-
-        var fd = fs.openSync(discoverResultFile, 'w');
-        fs.writeSync(fd, JSON.stringify(testList));
-        fs.closeSync(fd);
-
-        resolve();
-    });
+    var fd = fs.openSync(discoverResultFile, 'w');
+    fs.writeSync(fd, JSON.stringify(testList));
+    fs.closeSync(fd);
 }
 
 exports.find_tests = find_tests;

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -121,8 +121,8 @@ async function find_tests(testFileList, discoverResultFile, projectFolder) {
         try {
             jasmineInstance.specDir = "";
             jasmineInstance.specFiles = [];
-			
-			// In Jasmine 4.0+ addSpecFiles has been deprecated in favor of addMatchingSpecFiles
+
+            // In Jasmine 4.0+ addSpecFiles has been deprecated in favor of addMatchingSpecFiles
             (jasmineInstance.addMatchingSpecFiles || jasmineInstance.addSpecFiles).apply(jasmineInstance, [[testFile]]);
             
             var p = jasmineInstance.loadSpecs();

--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jasmine/jasmine.js
@@ -121,7 +121,9 @@ async function find_tests(testFileList, discoverResultFile, projectFolder) {
         try {
             jasmineInstance.specDir = "";
             jasmineInstance.specFiles = [];
-            jasmineInstance.addMatchingSpecFiles([testFile]);
+			
+			// In Jasmine 4.0+ addSpecFiles has been deprecated in favor of addMatchingSpecFiles
+            (jasmineInstance.addMatchingSpecFiles || jasmineInstance.addSpecFiles).apply(jasmineInstance, [[testFile]]);
             
             var p = jasmineInstance.loadSpecs();
             if (p instanceof Promise) {


### PR DESCRIPTION
Jasmine 4.0 has two major breaking changes that affect us.

1) addSpecFiles is deprecated and addMatchingSpecFiles should be used instead

2) topSuite() now returns a metadata object containing the Suite instead of returning the Suite itself

In addition, the version update also exposed a bug where we call `loadSpecs` and don't await the result (previously this was a void returning function but now it's an async function).