### PR TITLE
Refactor npm install --save command

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NodejsTools.NpmUI {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NpmInstallWindowResources {
@@ -133,6 +133,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No Save.
+        /// </summary>
+        public static string DevTypeNoSaveChoice {
+            get {
+                return ResourceManager.GetString("DevTypeNoSaveChoice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Optional.
         /// </summary>
         public static string DevTypeOptionalChoice {
@@ -142,11 +151,11 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Standard.
+        ///   Looks up a localized string similar to Production.
         /// </summary>
-        public static string DevTypeStandardChoice {
+        public static string DevTypeProductionChoice {
             get {
-                return ResourceManager.GetString("DevTypeStandardChoice", resourceCulture);
+                return ResourceManager.GetString("DevTypeProductionChoice", resourceCulture);
             }
         }
         

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
@@ -144,8 +144,11 @@
   <data name="DevTypeOptionalChoice" xml:space="preserve">
     <value>Optional</value>
   </data>
-  <data name="DevTypeStandardChoice" xml:space="preserve">
-    <value>Standard</value>
+  <data name="DevTypeProductionChoice" xml:space="preserve">
+    <value>Production</value>
+  </data>
+  <data name="DevTypeNoSaveChoice" xml:space="preserve">
+    <value>No Save</value>
   </data>
   <data name="HomepageLabel" xml:space="preserve">
     <value>Homepage: </value>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -22,6 +22,7 @@ namespace Microsoft.NodejsTools.NpmUI
             IndexStandard = 0,
             IndexDev = 1,
             IndexOptional = 2,
+            IndexNoSave = 3,
         }
 
         internal static class FilterState
@@ -44,7 +45,6 @@ namespace Microsoft.NodejsTools.NpmUI
         private int selectedDependencyTypeIndex;
         private string filterText = string.Empty;
         private string arguments = string.Empty;
-        private bool saveToPackageJson = true;
         private bool isExecutingCommand = false;
         private object selectedVersion;
 
@@ -303,15 +303,17 @@ namespace Microsoft.NodejsTools.NpmUI
 
         internal void Install(PackageCatalogEntryViewModel package)
         {
-            var type = DependencyType.Standard;
+            var type = DependencyType.Production;
             switch ((Indices)this.SelectedDependencyTypeIndex)
             {
                 case Indices.IndexDev:
                     type = DependencyType.Development;
                     break;
-
                 case Indices.IndexOptional:
                     type = DependencyType.Optional;
+                    break;
+                case Indices.IndexNoSave:
+                    type = DependencyType.NoSave;
                     break;
             }
 
@@ -327,7 +329,6 @@ namespace Microsoft.NodejsTools.NpmUI
                         selectedVersion,
                         type,
                         false,
-                        this.SaveToPackageJson,
                         this.Arguments));
             }
         }
@@ -348,16 +349,6 @@ namespace Microsoft.NodejsTools.NpmUI
             set
             {
                 this.arguments = value;
-                OnPropertyChanged();
-            }
-        }
-
-        public bool SaveToPackageJson
-        {
-            get { return this.saveToPackageJson; }
-            set
-            {
-                this.saveToPackageJson = value;
                 OnPropertyChanged();
             }
         }

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -374,13 +374,6 @@
                                 <Binding ElementName="OtherNpmArgumentsLabel" />
                             </AutomationProperties.LabeledBy>
                         </TextBox>
-                        <Label Grid.Row="3" HorizontalAlignment="Right" VerticalAlignment="Center" Content="{x:Static resx:NpmInstallWindowResources.AddToPackageJsonLabel}" x:Name="AddToPackageJsonLabel"/>
-                        <CheckBox x:Name="SaveToPackageJsonCheckbox" Grid.Column="1" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Left" 
-                                  IsChecked="{Binding SaveToPackageJson}" Margin="4" TabIndex="10" Content="{x:Static resx:NpmInstallWindowResources.AddToPackageJsonCheckboxLabel}">
-                            <AutomationProperties.LabeledBy>
-                                <Binding ElementName="AddToPackageJsonLabel" />
-                            </AutomationProperties.LabeledBy>
-                        </CheckBox>
 
                         <Label Grid.Row="2" HorizontalAlignment="Right" VerticalAlignment="Center" Content="{x:Static resx:NpmInstallWindowResources.DependencyTypeLabel}" x:Name="DependencyTypeLabel" />
                         <ComboBox Name="DependencyComboBox"
@@ -394,9 +387,10 @@
                             <AutomationProperties.LabeledBy>
                                 <Binding ElementName="DependencyTypeLabel" />
                             </AutomationProperties.LabeledBy>
-                            <ComboBoxItem Tag="St" IsSelected="True" Content="{x:Static resx:NpmInstallWindowResources.DevTypeStandardChoice}" />
+                            <ComboBoxItem Tag="St" IsSelected="True" Content="{x:Static resx:NpmInstallWindowResources.DevTypeProductionChoice}" />
                             <ComboBoxItem Tag="Dev" Content="{x:Static resx:NpmInstallWindowResources.DevTypeDevelopmentChoice}" />
                             <ComboBoxItem Tag="Opt" Content="{x:Static resx:NpmInstallWindowResources.DevTypeOptionalChoice}" />
+                            <ComboBoxItem Tag="NoS" Content="{x:Static resx:NpmInstallWindowResources.DevTypeNoSaveChoice}" />
                         </ComboBox>
 
                         <Label Grid.Row="4" HorizontalAlignment="Right" VerticalAlignment="Center" Content="{x:Static resx:NpmInstallWindowResources.SelectedVersionLabel}" x:Name="SelectedVersionLabel"/>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NodejsTools.NpmUI
         private readonly NpmPackageInstallViewModel viewModel;
         private const string NpmResultGuid = "2A7B6678-DFC9-40AA-BF2C-AD08B40A3031";
 
-        internal NpmPackageInstallWindow(INpmController controller, NpmWorker npmWorker, DependencyType dependencyType = DependencyType.Standard)
+        internal NpmPackageInstallWindow(INpmController controller, NpmWorker npmWorker, DependencyType dependencyType = DependencyType.Production)
         {
             this.DataContext = this.viewModel = new NpmPackageInstallViewModel(npmWorker, this.Dispatcher);
 
@@ -129,8 +129,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
         private void ResetOptionsButton_Click(object sender, RoutedEventArgs e)
         {
-            this.DependencyComboBox.SelectedIndex = (int)DependencyType.Standard;
-            this.SaveToPackageJsonCheckbox.IsChecked = true;
+            this.DependencyComboBox.SelectedIndex = (int)DependencyType.Production;
 
             this.OtherNpmArgumentsTextBox.Text = string.Empty;
             this.OtherNpmArgumentsTextBox.GetBindingExpression(TextBox.TextProperty).UpdateSource();

--- a/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
+++ b/Nodejs/Product/Nodejs/Project/NodeModulesNode.cs
@@ -400,7 +400,7 @@ namespace Microsoft.NodejsTools.Project
             return base.ExecCommandOnNode(cmdGroup, cmd, nCmdexecopt, pvaIn, pvaOut);
         }
 
-        public void ManageModules(DependencyType dependencyType = DependencyType.Standard)
+        public void ManageModules(DependencyType dependencyType = DependencyType.Production)
         {
             CheckNotDisposed();
 
@@ -528,8 +528,7 @@ namespace Microsoft.NodejsTools.Project
                 await commander.InstallPackageByVersionAsync(
                     package.Name,
                     null == dep ? "*" : dep.VersionRangeText,
-                    DependencyType.Standard,
-                    false);
+                    DependencyType.Production);
             });
         }
 

--- a/Nodejs/Product/Npm/DependencyType.cs
+++ b/Nodejs/Product/Npm/DependencyType.cs
@@ -4,8 +4,9 @@ namespace Microsoft.NodejsTools.Npm
 {
     public enum DependencyType
     {
-        Standard = 0,
+        Production = 0,
         Development,
         Optional,
+        NoSave
     }
 }

--- a/Nodejs/Product/Npm/INpmCommander.cs
+++ b/Nodejs/Product/Npm/INpmCommander.cs
@@ -20,14 +20,12 @@ namespace Microsoft.NodejsTools.Npm
         /// <param name="packageName"></param>
         /// <param name="versionRange"></param>
         /// <param name="type"></param>
-        /// <param name="saveToPackageJson"></param>
         /// <exception cref="PackageJsonException">If there is an error reading a package.json file when modules are refreshed.</exception>
         /// <returns></returns>
         Task<bool> InstallPackageByVersionAsync(
             string packageName,
             string versionRange,
-            DependencyType type,
-            bool saveToPackageJson);
+            DependencyType type);
 
         /// <summary>
         /// 

--- a/Nodejs/Product/Npm/NpmArgumentBuilder.cs
+++ b/Nodejs/Product/Npm/NpmArgumentBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
@@ -11,7 +11,6 @@ namespace Microsoft.NodejsTools.Npm
             string versionRange,
             DependencyType type,
             bool global = false,
-            bool saveToPackageJson = true,
             string otherArguments = "")
         {
             string dependencyArguments = "";
@@ -19,18 +18,21 @@ namespace Microsoft.NodejsTools.Npm
             {
                 dependencyArguments = "-g";
             }
-            else if (saveToPackageJson)
+            else
             {
                 switch (type)
                 {
-                    case DependencyType.Standard:
-                        dependencyArguments = "--save";
+                    case DependencyType.Production:
+                        dependencyArguments = "--save-prod";
                         break;
                     case DependencyType.Development:
                         dependencyArguments = "--save-dev";
                         break;
                     case DependencyType.Optional:
                         dependencyArguments = "--save-optional";
+                        break;
+                    case DependencyType.NoSave:
+                        dependencyArguments = "--no-save";
                         break;
                 }
             }

--- a/Nodejs/Product/Npm/SPI/NpmCommander.cs
+++ b/Nodejs/Product/Npm/SPI/NpmCommander.cs
@@ -135,8 +135,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
             string packageName,
             string versionRange,
             DependencyType type,
-            bool global,
-            bool saveToPackageJson)
+            bool global)
         {
             return DoCommandExecute(true,
                 new NpmInstallCommand(
@@ -145,22 +144,20 @@ namespace Microsoft.NodejsTools.Npm.SPI
                     versionRange,
                     type,
                     global,
-                    saveToPackageJson,
                     this.npmController.PathToNpm));
         }
 
         public Task<bool> InstallPackageByVersionAsync(
             string packageName,
             string versionRange,
-            DependencyType type,
-            bool saveToPackageJson)
+            DependencyType type)
         {
-            return InstallPackageByVersionAsync(this.npmController.FullPathToRootPackageDirectory, packageName, versionRange, type, false, saveToPackageJson);
+            return InstallPackageByVersionAsync(this.npmController.FullPathToRootPackageDirectory, packageName, versionRange, type, false);
         }
 
         private DependencyType GetDependencyType(string packageName)
         {
-            var type = DependencyType.Standard;
+            var type = DependencyType.Production;
             var root = this.npmController.RootPackage;
             if (null != root)
             {

--- a/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmInstallCommand.cs
@@ -19,7 +19,6 @@ namespace Microsoft.NodejsTools.Npm.SPI
             string versionRange,
             DependencyType type,
             bool global = false,
-            bool saveToPackageJson = true,
             string pathToNpm = null,
             bool useFallbackIfNpmNotFound = true)
             : base(fullPathToRootPackageDirectory, showConsole: false, pathToNpm: pathToNpm)
@@ -28,8 +27,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
                 packageName,
                 versionRange,
                 type,
-                global,
-                saveToPackageJson);
+                global);
         }
     }
 }

--- a/Nodejs/Product/Npm/SPI/NpmUninstallCommand.cs
+++ b/Nodejs/Product/Npm/SPI/NpmUninstallCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NodejsTools.Npm.SPI
                             : string.Format(CultureInfo.InvariantCulture,
                                 "uninstall {0} --{1}",
                                 packageName,
-                                (type == DependencyType.Standard
+                                (type == DependencyType.Production
                                      ? "save"
                                      : (type == DependencyType.Development ? "save-dev" : "save-optional")));
         }


### PR DESCRIPTION
The save command has been deprecated for some time now so the UI doesn't make sense anymore. 

I have refactored to instead remove the save checkbox and added the "no save" command on the combo box.

This also fixes an accessibility issue that the "(recommended)" text was not read by the screen reader, since I have removed it.