### PR TITLE
Fix npm window color

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -15,6 +15,7 @@
     MinWidth="600"
     WindowStartupLocation="CenterOwner"
     Background="{DynamicResource {x:Static wpf:Controls.BackgroundKey}}"
+    Foreground="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}"
     ResizeMode="CanResizeWithGrip">
 
     <!-- Theming -->
@@ -278,7 +279,6 @@
                            Text="{x:Static resx:NpmInstallWindowResources.SearchForPackagesLabel}">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}" />
                             <Setter Property="Visibility" Value="Hidden"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding FilterText}"  Value="">


### PR DESCRIPTION
Fixes an accessibility issue where when using Dark theme, the text didn't display the correct color.

Before
![image](https://user-images.githubusercontent.com/13305542/159596609-93196089-7156-4d23-9f41-adc3481fb222.png)

After
![image](https://user-images.githubusercontent.com/13305542/159596644-41a24204-f0fd-40f8-ac14-07dd3b648dd7.png)
