### PR TITLE
Removed ProgressBar and disabled options

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -377,6 +377,7 @@ namespace Microsoft.NodejsTools.NpmUI
 
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(ExecutionProgressVisibility));
+                    OnPropertyChanged(nameof(AreOptionsEnabled));
                 }
             }
         }
@@ -385,6 +386,8 @@ namespace Microsoft.NodejsTools.NpmUI
         {
             get { return IsExecutingCommand ? Visibility.Visible : Visibility.Collapsed; }
         }
+
+        public bool AreOptionsEnabled => !this.IsExecutingCommand;
 
         #endregion
 

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -236,11 +236,6 @@
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <ProgressBar Name="_progress"
-                         Height="4"
-                         IsEnabled="{Binding Path=IsExecutingCommand}"
-                         IsIndeterminate="{Binding Path=IsExecutingCommand}"
-                         Visibility="{Binding Path=ExecutionProgressVisibility}" Grid.Row="1" Grid.ColumnSpan="2"/>
             <Button x:Name="CloseButton"
                         Grid.Column="1"
                         Command="ApplicationCommands.Close"
@@ -348,7 +343,8 @@
 
                 <StackPanel Grid.Row="1"
                             Orientation="Vertical"
-                            HorizontalAlignment="Stretch">
+                            HorizontalAlignment="Stretch" 
+                            IsEnabled="{Binding Path=AreOptionsEnabled}">
                     <Separator/>
                     <Grid x:Name="InstallOptions" DockPanel.Dock="Top" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>


### PR DESCRIPTION
Removed the Progress bar when installing a package from the npm window. Instead, now we disable the options and the install button and enable them back once the installation is complete.

The progress should still be visible from the background tasks area on Visual Studio. Details can still be seen on the npm output window.

This is how the window looks once the Install Package button has been clicked:
![image](https://user-images.githubusercontent.com/13305542/160503546-55fcda1f-ec08-44e9-819b-695fbee9ed1c.png)
