### PR TITLE
Ignore exceptions when unloading already unloaded projects

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -474,7 +474,15 @@ namespace Microsoft.VisualStudioTools.Project
 
                 if (this.UserBuildProject != null)
                 {
-                    this.UserBuildProject.ProjectCollection.UnloadProject(this.UserBuildProject);
+                    try
+                    {
+                        this.UserBuildProject.ProjectCollection.UnloadProject(this.UserBuildProject);
+                    }
+                    catch(InvalidOperationException)
+                    {
+                        // The project was already been unloaded. Ignore the exception and continue execution.
+                    }
+                    
                 }
 
                 this.idleManager.OnIdle -= this.OnIdle;


### PR DESCRIPTION
This issue happens during integration tests. If a project has already been unloaded, we ignore the exception and just continue to dispose.