### PR TITLE
Add support for customizing Jest config with react-app-rewired

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Jest/jest.js
@@ -129,6 +129,12 @@ function readConfigs(projectFolder, context)
     const pathToReactConfig = path.join(projectFolder, 'node_modules/react-scripts/scripts/utils/createJestConfig.js');
     if(fs.existsSync(pathToReactConfig))
     {
+        const pathToReactAppRewired = path.join(projectFolder, 'node_modules/react-app-rewired/overrides/jest.js');
+        if (fs.existsSync(pathToReactAppRewired)) {
+            // Support react-app-rewired.  This overrides the normal createJestConfig
+            require(pathToReactAppRewired);
+        }
+
         const createJestConfig = require(pathToReactConfig);
         config = createJestConfig(
             relativePath => path.join(projectFolder, 'node_modules/react-scripts/', relativePath),


### PR DESCRIPTION
Loads the react-app-rewired library (if present) in order to customize the Jest config provided by react-scripts.  This allows customizing the config further than what react-scripts normally allows, without ejecting.

This is normally accomplished via the command line like "npx react-app-rewired test".  I think requiring the overrides/jest.js file is the most appropriate way to load it directly.