### PR TITLE
Fixing a bug after Jasmine update.

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/jasmineReporter.js
@@ -13,7 +13,7 @@ function itReplacement(it) {
 function getFileLocation() {
     const stackLineRegex = /at.*\(.*_karma_webpack_(?:\/webpack\:)?(.*\.spec\.ts):(\d*):(\d*)/;
     const match = (new Error()).stack.match(stackLineRegex);
-
+    
     return match
         ? {
             relativeFilePath: match[1], // Relative to project root defined on angular.json.
@@ -57,5 +57,5 @@ var myReporter = {
 };
 
 jasmine.getEnv().addReporter(myReporter);
-jasmine.getEnv().it = itReplacement(jasmine.getEnv().it);
+jasmine.getEnv().it_ = itReplacement(jasmine.getEnv().it_);
 

--- a/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Fixing the Jasmine bug after an update that moved the 'it()' function to another place in their internal code.

Issue #
Angular tests were not being found.

##### Bug
Jasmine made some internal changes and moved some logic related to the 'it()' function that we use to describe and run the tests. Internally, NTVS needs to replace Jasmine's 'it()' function and after their changes on update, this replacement was failing.

##### Fix
We found out on their code that there's an 'it_()' that seems to be the old 'it()'. After making this change, our tests were being found again.

##### Testing
The Angular test are now being found, tested locally.