### PR TITLE
Added description, author and version to ListItemView

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
@@ -322,6 +322,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Version:.
+        /// </summary>
+        public static string VersionLabel {
+            get {
+                return ResourceManager.GetString("VersionLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Install New npm Packages.
         /// </summary>
         public static string WindowTitle {

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
@@ -208,4 +208,7 @@
   <data name="KeywordLabel" xml:space="preserve">
     <value>Keywords:</value>
   </data>
+  <data name="VersionLabel" xml:space="preserve">
+    <value>Version:</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -41,6 +41,16 @@
                 <ResourceDictionary>
                     <Style TargetType="{x:Type ListViewItem}" BasedOn="{StaticResource {x:Type ListViewItem}}">
                         <Setter Property="HorizontalAlignment" Value="Stretch" />
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name}" />
+                        <Setter Property="AutomationProperties.HelpText">
+                            <Setter.Value>
+                                <MultiBinding StringFormat="{} {0}, {1}, {2}">
+                                    <Binding Path="Description"/>
+                                    <Binding Path="VersionWithLabel" />
+                                    <Binding Path="AuthorWithLabel" />
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
                     </Style>
 
                     <DataTemplate x:Key="PackageInfoTemplate">

--- a/Nodejs/Product/Nodejs/NpmUI/PackageCatalogEntryViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/PackageCatalogEntryViewModel.cs
@@ -40,11 +40,13 @@ namespace Microsoft.NodejsTools.NpmUI
         public virtual string Name { get; }
 
         public string Version => this.version?.ToString() ?? string.Empty;
+        public string VersionWithLabel => String.IsNullOrWhiteSpace(this.version?.ToString()) ? string.Empty : $"{NpmInstallWindowResources.VersionLabel} {this.version?.ToString()}";
 
         public IEnumerable<SemverVersion> AvailableVersions { get; }
 
         public string Author { get; }
         public Visibility AuthorVisibility => string.IsNullOrEmpty(this.Author) ? Visibility.Collapsed : Visibility.Visible;
+        public string AuthorWithLabel => String.IsNullOrWhiteSpace(this.Author) ? string.Empty : $"{NpmInstallWindowResources.AuthorLabel} {this.Author}";
 
         public string Description { get; }
         public Visibility DescriptionVisibility => string.IsNullOrEmpty(this.Description) ? Visibility.Collapsed : Visibility.Visible;


### PR DESCRIPTION
Fixes an accessibility bug: 

- A11y_When using down arrow to the list items screen reader is not announcing the information of the more data present beside the list items which is selected._JSTS in VS_Install New npm Packages_ScreenReader

This allows NVDA to narrate the whole item content.