### PR TITLE
Added speech action to HelpListItem

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.Designer.cs
@@ -160,6 +160,15 @@ namespace Microsoft.NodejsTools.NpmUI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to press tab to get more details.
+        /// </summary>
+        public static string HelpTextSpeechAction {
+            get {
+                return ResourceManager.GetString("HelpTextSpeechAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Homepage: .
         /// </summary>
         public static string HomepageLabel {

--- a/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmInstallWindowResources.resx
@@ -211,4 +211,7 @@
   <data name="VersionLabel" xml:space="preserve">
     <value>Version:</value>
   </data>
+  <data name="HelpTextSpeechAction" xml:space="preserve">
+    <value>press tab to get more details</value>
+  </data>
 </root>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -44,10 +44,11 @@
                         <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name}" />
                         <Setter Property="AutomationProperties.HelpText">
                             <Setter.Value>
-                                <MultiBinding StringFormat="{} {0}, {1}, {2}">
+                                <MultiBinding StringFormat="{} {0}, {1}, {2}, {3}">
                                     <Binding Path="Description"/>
                                     <Binding Path="VersionWithLabel" />
                                     <Binding Path="AuthorWithLabel" />
+                                    <Binding Path="SpeechAction" />
                                 </MultiBinding>
                             </Setter.Value>
                         </Setter>

--- a/Nodejs/Product/Nodejs/NpmUI/PackageCatalogEntryViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/PackageCatalogEntryViewModel.cs
@@ -56,6 +56,8 @@ namespace Microsoft.NodejsTools.NpmUI
 
         public string Keywords { get; }
 
+        public string SpeechAction => NpmInstallWindowResources.HelpTextSpeechAction;
+
         public bool IsInstalledLocally => !this.IsLocalInstallMissing && this.localVersion.HasValue;
         public bool IsLocalInstallOutOfDate => this.IsInstalledLocally && this.localVersion < this.version;
 


### PR DESCRIPTION
Addes a speech action to each Item on the npm package list.

Fixes accessibility bug: A11y_When using down arrow to the list items screen reader is not announcing the information of the more data present beside the list items which is selected._JSTS in VS_Install New npm Packages_ScreenReader.