### PR TITLE
Moved Telemetry to be within the VS process instead of the test console

### DIFF
--- a/Nodejs/Product/Nodejs/Telemetry/TelemetryHelper.cs
+++ b/Nodejs/Product/Nodejs/Telemetry/TelemetryHelper.cs
@@ -41,9 +41,9 @@ namespace Microsoft.NodejsTools.Telemetry
             TelemetryService.DefaultSession?.PostUserTask(UsedRepl, TelemetryResult.Success);
         }
 
-        public static void LogTestDiscoveryStarted(string testAdapterName, string testDiscovererName)
+        public static void LogTestDiscoveryStarted(string testAdapterName)
         {
-            LogUserTaskEvent(TestDiscoveryStarted, (TestAdapterName, testAdapterName), (TestDiscovererName, testDiscovererName));
+            LogUserTaskEvent(TestDiscoveryStarted, (TestAdapterName, testAdapterName));
         }
 
         private static void LogUserTaskEvent(string eventName, bool isProject)
@@ -55,7 +55,7 @@ namespace Microsoft.NodejsTools.Telemetry
         {
             if (TelemetryService.DefaultSession != null)
             {
-                var userTask = new UserTaskEvent(DebbugerStarted, TelemetryResult.Success);
+                var userTask = new UserTaskEvent(eventName, TelemetryResult.Success);
                 foreach (var (PropertName, Value) in args)
                 {
                     userTask.Properties[PropertName] = Value;

--- a/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
+++ b/Nodejs/Product/NodejsToolsVsix/NodejsToolsVsix.csproj
@@ -85,7 +85,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.1597</Version>
+      <Version>17.4.2118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Nodejs/Product/TargetsVsix/TargetsVsix.csproj
+++ b/Nodejs/Product/TargetsVsix/TargetsVsix.csproj
@@ -90,7 +90,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.1597</Version>
+      <Version>17.4.2118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Nodejs/Product/TestAdapter/TestAdapter.csproj
+++ b/Nodejs/Product/TestAdapter/TestAdapter.csproj
@@ -51,8 +51,6 @@
     <Compile Include="..\TypeScript\TypeScriptHelpers.cs">
       <Link>TypeScriptHelpers.cs</Link>
     </Compile>
-    <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
-    <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="DefaultTestDiscoverer.cs" />
     <Compile Include="DotNetTestDiscoverer.cs" />

--- a/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
+++ b/Nodejs/Product/TestAdapter/TestDiscovererWorker.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.NodejsTools.SourceMapping;
-using Microsoft.NodejsTools.Telemetry;
 using Microsoft.NodejsTools.TestAdapter.TestFrameworks;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -38,8 +37,6 @@ namespace Microsoft.NodejsTools.TestAdapter
         {
             // If it's a framework name we support, is safe to submit the string to telemetry.
             var testAdapterName = Enum.GetNames(typeof(SupportedFramework)).Contains(testFx.Name, StringComparer.OrdinalIgnoreCase) ? testFx.Name : "Other";
-
-            TelemetryHelper.LogTestDiscoveryStarted(testAdapterName, testDiscovererName);
 
             if (!File.Exists(this.nodeExePath))
             {

--- a/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
+++ b/Nodejs/Product/TestAdapterImpl/TestAdapterImpl.csproj
@@ -54,6 +54,9 @@
     <Compile Include="..\Nodejs\NodejsConstants.cs">
       <Link>NodejsConstants.cs</Link>
     </Compile>
+    <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs">
+      <Link>Telemetry\TelemetryHelper.cs</Link>
+    </Compile>
     <Compile Include="..\TypeScript\TypeScriptHelpers.cs">
       <Link>TypeScriptHelpers.cs</Link>
     </Compile>

--- a/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
+++ b/Nodejs/Product/TestAdapterImpl/TestContainerDiscoverer.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.Internal.VisualStudio.Shell;
 using Microsoft.NodejsTools.TypeScript;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -267,7 +268,7 @@ namespace Microsoft.NodejsTools.TestAdapter
                 yield break;
             }
 
-            if (!this.knownProjects.TryGetValue(path, out var projectInfo) || !TryGetProjectUnitTestProperties(projectInfo.Project, out _, out _))
+            if (!this.knownProjects.TryGetValue(path, out var projectInfo) || !TryGetProjectUnitTestProperties(projectInfo.Project, out _, out var testFramework))
             {
                 // Don't return any containers for projects we don't know about or that we know that they are not configured for JavaScript unit tests.
                 yield break;
@@ -288,6 +289,11 @@ namespace Microsoft.NodejsTools.TestAdapter
                     }
                     return latest;
                 });
+
+            if (!string.IsNullOrEmpty(testFramework))
+            { 
+                Microsoft.NodejsTools.Telemetry.TelemetryHelper.LogTestDiscoveryStarted(testFramework);
+            }
 
             yield return new TestContainer(this, path, latestWrite);
         }

--- a/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
+++ b/Nodejs/Product/TestAdapterNetStandard/TestAdapterNetStandard.csproj
@@ -34,8 +34,6 @@
     <Compile Include="..\Nodejs\SourceMapping\SourceMap.cs" Link="SourceMapping\SourceMap.cs" />
     <Compile Include="..\Nodejs\SourceMapping\SourceMapper.cs" Link="SourceMapping\SourceMapper.cs" />
     <Compile Include="..\Nodejs\TestFrameworks\TestFrameworkDirectories.cs" Link="TestFrameworks\TestFrameworkDirectories.cs" />
-    <Compile Include="..\Nodejs\Telemetry\TelemetryEvents.cs" Link="Telemetry\TelemetryEvents.cs" />
-    <Compile Include="..\Nodejs\Telemetry\TelemetryHelper.cs" Link="Telemetry\TelemetryHelper.cs" />
     <Compile Include="..\TestAdapter\JavaScriptTestCaseProperties.cs" Link="JavaScriptTestCaseProperties.cs" />
     <Compile Include="..\TestAdapter\SerializationHelpers.cs" Link="SerializationHelpers.cs" />
     <Compile Include="..\TestAdapter\TestDiscovererWorker.cs" Link="TestDiscovererWorker.cs" />

--- a/Nodejs/Product/TestAdapterVsix/TestAdapterVsix.csproj
+++ b/Nodejs/Product/TestAdapterVsix/TestAdapterVsix.csproj
@@ -75,7 +75,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.1597</Version>
+      <Version>17.4.2118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Telemetry right now is reported in the test console, which is running outside of devenv.exe and incapable of actually publishing telemetry. While I find what the proper pattern is for publishing telemetry from a test adapter, I'm moving the reporting to VS. The only item we're publishing is what test framework is being used on discovery.

Issue #

##### Bug


##### Fix


##### Testing
