### PR TITLE
Prevent loading output panes on non-jsts projects

### DIFF
--- a/Nodejs/Product/Nodejs/Workspace/TypeScriptActionProviderFactory.cs
+++ b/Nodejs/Product/Nodejs/Workspace/TypeScriptActionProviderFactory.cs
@@ -60,8 +60,6 @@ namespace Microsoft.NodejsTools.Workspace
             {
                 await this.workspaceContext.JTF.SwitchToMainThreadAsync();
 
-                this.outputPane.InitializeOutputPanes();
-
                 var actions = new List<IFileContextAction>();
 
                 if (TypeScriptHelpers.IsTsJsConfigJsonFile(filePath))
@@ -76,6 +74,11 @@ namespace Microsoft.NodejsTools.Workspace
                     {
                         actions.Add(new BuildTsFileContextAction(filePath, fileContext, this.outputPane));
                     }
+                }
+
+                if (actions.Count > 0)
+                {
+                    this.outputPane.InitializeOutputPanes();
                 }
 
                 return actions;


### PR DESCRIPTION
CMake projects are showing tsc and npm output windows because we are too eager in initializing those panes on any case where a file is opened while building (which is standard for CMake projects). I'm switching to only initialize if we're actually going to include information in the panes.