### PR TITLE
fix angular test discovery

### DIFF
--- a/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
+++ b/Nodejs/Product/TestAdapter/TestFrameworks/Angular/karmaConfig.js
@@ -19,6 +19,11 @@ module.exports = function (config) {
     // Replace all reporters
     config.reporters = ['vsKarmaReporter'];
 
+    if (!config.hostname && !config.listenAddress) {
+        // The default address is IPv4 but node 17+ uses IPv6. Update the value to 'localhost' (which works with both IPv4 and IPv6) if it was not set.
+        config.hostname = config.listenAddress = 'localhost';
+    }
+
     setGrep(config);
 };
 


### PR DESCRIPTION
The test settings previously always used IPv4 for the listening endpoint. This meant in Node 17+ the tests would not run since node would probe with IPv6. This PR changes it to use localhost which makes the test use the same address that node would use. I tested this change with Node 16 and Node 18 and they both work. Since the change is only to the default values, the user can pass their own values and they will take precedence.