### PR TITLE
Use non-boxing enum flag checks

### DIFF
--- a/Nodejs/Product/Nodejs/SharedProject/HierarchyNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/HierarchyNode.cs
@@ -300,7 +300,7 @@ namespace Microsoft.VisualStudioTools.Project
         {
             get
             {
-                return this.flags.HasFlag(HierarchyNodeFlags.IsVisible);
+                return (this.flags & HierarchyNodeFlags.IsVisible) == HierarchyNodeFlags.IsVisible;
             }
             set
             {
@@ -412,7 +412,7 @@ namespace Microsoft.VisualStudioTools.Project
         {
             get
             {
-                return this.flags.HasFlag(HierarchyNodeFlags.IsExpanded);
+                return (this.flags & HierarchyNodeFlags.IsExpanded) == HierarchyNodeFlags.IsExpanded;
             }
             set
             {
@@ -457,7 +457,7 @@ namespace Microsoft.VisualStudioTools.Project
         {
             get
             {
-                return this.flags.HasFlag(HierarchyNodeFlags.ExcludeFromScc);
+                return (this.flags & HierarchyNodeFlags.ExcludeFromScc) == HierarchyNodeFlags.ExcludeFromScc;
             }
             set
             {
@@ -480,7 +480,7 @@ namespace Microsoft.VisualStudioTools.Project
         {
             get
             {
-                return this.flags.HasFlag(HierarchyNodeFlags.HasParentNodeNameRelation);
+                return (this.flags & HierarchyNodeFlags.HasParentNodeNameRelation) == HierarchyNodeFlags.HasParentNodeNameRelation;
             }
             set
             {


### PR DESCRIPTION
The `Enum.HasFlag` method boxes its argument. This contributes to GC pauses in VS, as identified in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824260.

Issue AB#1824260