### PR TITLE
Fix A11yMAS Bugs

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -139,14 +139,16 @@
                                            Text="{Binding Author,Mode=OneWay}"
                                            TextTrimming="CharacterEllipsis"
                                            ToolTip="{Binding Author,Mode=OneWay}"
-                                           Opacity="0.6" />
+                                           Opacity="0.6" 
+                                           Visibility="{Binding AuthorVisibility, Mode=OneWay}" />
                             </Grid>
 
                             <TextBlock Grid.Row="1"
                                        Margin="3"
                                        Text="{Binding Description,Mode=OneWay}"
                                        TextWrapping="Wrap" 
-                                       TextTrimming="CharacterEllipsis" Height="30"/>
+                                       TextTrimming="CharacterEllipsis" Height="30"
+                                       Visibility="{Binding DescriptionVisibility, Mode=OneWay}" />
 
                             <Grid Grid.Row="2" Margin="3 6 3 3">
                                 <Grid.ColumnDefinitions>

--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallWindow.xaml
@@ -347,7 +347,8 @@
                               Content="{Binding Path=SelectedPackage}"
                               ContentTemplate="{StaticResource PackageInfoTemplate}"
                               IsTabStop="True" AutomationProperties.Name="{Binding Path=SelectedPackage.Name}"
-                              TabIndex="3" />
+                              TabIndex="3" 
+                              FocusVisualStyle="{DynamicResource OutOfMarginFocusVisualStyle}"/>
 
                 <StackPanel Grid.Row="1"
                             Orientation="Vertical"

--- a/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
+++ b/Nodejs/Product/Nodejs/SharedProject/Wpf/Controls.xaml
@@ -18,6 +18,21 @@
         </Setter>
     </Style>
 
+    <Style x:Key="OutOfMarginFocusVisualStyle" TargetType="{x:Type Control}">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle 
+                        Margin="-2"
+                        RenderOptions.EdgeMode="Aliased"
+                        StrokeThickness="1" 
+                        Stroke="{DynamicResource {x:Static wpf:Controls.ForegroundKey}}"
+                        StrokeDashArray="1 1"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="EllipseFocusVisualStyle" TargetType="{x:Type Control}">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -250,6 +265,7 @@
     <Style x:Key="HyperlinkButton" TargetType="{x:Type vsui:HyperlinkButton}">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Controls.HyperlinkKey}}" />
         <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource OutOfMarginFocusVisualStyle}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">


### PR DESCRIPTION
Fixed couple of A11yMAS bugs:

- **Bug 1831297**: A11y_On Applying In-built Visual studio dark theme keyboard focus around "lodash" dialogue and "Homepage link" is not visible_Accessibility Testing for JSTS in VS_Install new npm packages_AI4D
 This is how it looks now:
![image](https://github.com/microsoft/nodejstools/assets/13305542/88baa5c1-d314-49a8-817a-422a51e2cefc)
![image](https://github.com/microsoft/nodejstools/assets/13305542/96ed59ef-29d6-4516-832e-c55fc4307192)

- **Bug 1831273**: A11y_Section 508 502.3.1: (devenv/text '') An on-screen element must not have a null BoundingRectangle property_Accessibility Testing for JSTS in VS_Install new npm packages_AI4D