### PR TITLE
Removing moq to avoid potential privacy concerns

### DIFF
--- a/Nodejs/Tests/Core/NodejsTests.csproj
+++ b/Nodejs/Tests/Core/NodejsTests.csproj
@@ -49,9 +49,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1312.1622\lib\net40\Moq.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VSTarget).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/Nodejs/Tests/Core/packages.config
+++ b/Nodejs/Tests/Core/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>

--- a/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.Build" Version="17.0.0-preview-21256-03" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />


### PR DESCRIPTION
moq's maintainers decided to add spyware that logs github accounts to their product. We are not affected because of the versions we use, but removing to avoid issues in the future.