### PR TITLE
Persist user choice of dismissing migration gold bar.

### DIFF
--- a/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
+++ b/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
@@ -1,31 +1,25 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Xml.Linq;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using IServiceProvider = System.IServiceProvider;
 
 namespace Microsoft.NodejsTools.Project
 {
-    internal abstract class MigrateToJspsInfoBar
+    internal static class MigrateToJspsInfoBar
     {
         private static IVsInfoBarUIElement CurrentInfoBarElement;
         private const string UserClosedMigrationPrompt = "UserClosedMigrationPrompt";
 
         public static void Show(IVsShell vsShell, IVsInfoBarUIFactory infoBarUiFactory, IVsSolutionPersistence solutionPersistence, string projectFileLocation)
         {
-            var userPreference = new PersistUserPreferences();
             if (ErrorHandler.Failed(vsShell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var tmp)))
             {
                 return;
             }
             var infoBarHost = (IVsInfoBarHost)tmp;
 
+            var userPreference = new PersistUserPreferences();
             if (solutionPersistence != null)
             {
                 // Load the section from the .suo file
@@ -69,6 +63,9 @@ namespace Microsoft.NodejsTools.Project
             }
         }
 
+        /// <summary>
+        /// This class is used to persist the user preferences for the migration prompt using the .suo file.
+        /// </summary>
         private sealed class PersistUserPreferences : IVsPersistSolutionOpts
         {
             public bool dismissedMigration = false;
@@ -81,28 +78,28 @@ namespace Microsoft.NodejsTools.Project
 
             public int SaveUserOptions(IVsSolutionPersistence pPersistence)
             {
-                // Register the section for saving
-                
+                // Register the section for saving user options
                 return pPersistence.SavePackageUserOpts(this, UserClosedMigrationPrompt);
             }
 
             // This method reads the boolean setting from the .suo file
             public int ReadUserOptions(IStream pOptionsStream, string pszKey)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 if (pszKey == UserClosedMigrationPrompt)
                 {
                     // Allocate a buffer to hold the data
                     byte[] buffer = new byte[256]; // Assuming the boolean is stored as a small string
                     uint bytesRead = 0;
 
-                    // Read the data from the IStream (use ref for the bytesRead count)
+                    // Read the data from the IStream 
                     pOptionsStream.Read(buffer, (uint)buffer.Length, out bytesRead);
 
                     // Convert the byte array to a string (only up to the bytes that were read)
                     string booleanValue = System.Text.Encoding.UTF8.GetString(buffer, 0, (int)bytesRead);
 
                     // Parse the string into a boolean value
-                    bool.TryParse(booleanValue, out dismissedMigration);  // Store the boolean value
+                    bool.TryParse(booleanValue, out dismissedMigration);
                 }
 
                 return VSConstants.S_OK;
@@ -111,6 +108,7 @@ namespace Microsoft.NodejsTools.Project
             // This method writes the boolean value to the .suo file
             public int WriteUserOptions(IStream pOptionsStream, string pszKey)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 if (pszKey == UserClosedMigrationPrompt)
                 {
                     uint outBytesWritten = 0;

--- a/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
+++ b/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NodejsTools.Project
                 if (pszKey == UserClosedMigrationPrompt)
                 {
                     // Allocate a buffer to hold the data
-                    byte[] buffer = new byte[1]; // Assuming the boolean is stored as a small string
+                    byte[] buffer = new byte[1]; // Assuming the boolean is stored as 0 and 1
                     uint bytesRead = 0;
 
                     // Read the data from the IStream 

--- a/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
+++ b/Nodejs/Product/Nodejs/Project/MigrateToJspsInfoBar.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NodejsTools.Project
                 if (pszKey == UserClosedMigrationPrompt)
                 {
                     // Allocate a buffer to hold the data
-                    byte[] buffer = new byte[1]; // Assuming the boolean is stored as 0 and 1
+                    byte[] buffer = new byte[1]; // Assuming the boolean is stored as 0 or 1
                     uint bytesRead = 0;
 
                     // Read the data from the IStream 

--- a/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
+++ b/Nodejs/Product/Nodejs/SharedProject/CommonProjectNode.cs
@@ -922,7 +922,8 @@ namespace Microsoft.VisualStudioTools.Project
 
             var shell = GetService(typeof(SVsShell)) as IVsShell;
             var infoBarUiFactory = GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
-            MigrateToJspsInfoBar.Show(shell, infoBarUiFactory, filename);
+            var solutionPersistence = GetService(typeof(SVsSolutionPersistence)) as IVsSolutionPersistence;
+            MigrateToJspsInfoBar.Show(shell, infoBarUiFactory, solutionPersistence, filename);
         }
 
         internal IVsHierarchyItemManager HierarchyManager


### PR DESCRIPTION
Issue #
Currently, if a user dismisses the migration gold bar, the bar comes up again when reloading the project. This change saves this information on the .suo file and checks every time a project is loaded.

I'm also removing old code that was supposed to check the .user file. We don't generate a .user file on our templates, this was rarely checked and was not persisting user actions.