### PR TITLE
Quick fix on versioning JSPS, better fix coming soon.

### DIFF
--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileModel.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileModel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml;
+﻿using System.Xml;
 using System.Xml.Serialization;
 
 namespace MigrateToJsps
@@ -11,7 +7,7 @@ namespace MigrateToJsps
     public class EsprojFile
     {
         [XmlAttribute(AttributeName = "Sdk")]
-        public string Sdk = @"Microsoft.VisualStudio.JavaScript.Sdk/0.5.89-alpha";
+        public string Sdk = @"Microsoft.VisualStudio.JavaScript.Sdk/1.0.1635611";
 
         [XmlElement(ElementName = "PropertyGroup")]
         public EsprojPropertyGroup PropertyGroup { get; set; }

--- a/Nodejs/MigrateToJsps/MigrationLibrary.cs
+++ b/Nodejs/MigrateToJsps/MigrationLibrary.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.IO;
-using System.Linq;
 using System.Security;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MigrateToJsps
 {


### PR DESCRIPTION
Issue #
The migration tool is hard-coding a JSPS version that is outdated now. Manually updating and also will explore a proper way to solve it. For now this will do it.
Also removing unused libraries.