### PR TITLE
Dynamically getting the JSPS version.

### DIFF
--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
@@ -43,6 +40,13 @@ namespace MigrateToJsps
             }
 
             EsprojFile esprojFile = new EsprojFile() { PropertyGroup = propGroup };
+            var sdkVersion = GetSdkVersion();
+
+            // If the SDK version is not found on NuGet fallback folder, keep the one hardcoded on EsProjFileModel
+            if (sdkVersion != null)
+            {
+                esprojFile.Sdk = $"Microsoft.VisualStudio.JavaScript.Sdk/{GetSdkVersion()}";
+            }
 
             XmlSerializer serializer = new XmlSerializer(typeof(EsprojFile));
 
@@ -110,9 +114,9 @@ namespace MigrateToJsps
 
         private static string GetSdkVersion()
         {
-            // TODO: figure out if sdk is installed on machine?
-            // do i need to do that or will VS automatically install given version
-            throw new NotImplementedException();
+            // Use the installed version of JSPS on the NuGet fallback folder.
+            var versions = Directory.GetDirectories(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Shared", "NuGetPackages", "microsoft.visualstudio.javascript.sdk"));
+            return Path.GetFileName(versions.OrderByDescending(v => v).FirstOrDefault());
         }
     }
 }

--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
@@ -116,7 +116,12 @@ namespace MigrateToJsps
         {
             // Use the installed version of JSPS on the NuGet fallback folder.
             var versions = Directory.GetDirectories(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Shared", "NuGetPackages", "microsoft.visualstudio.javascript.sdk"));
-            return Path.GetFileName(versions.OrderByDescending(v => v).FirstOrDefault());
+            var newestVersion = versions
+                .Select(v => new { Path = v, Version = new Version(Path.GetFileName(v)) })
+                .OrderByDescending(v => v.Version)
+                .FirstOrDefault();
+
+            return newestVersion?.Version.ToString();
         }
     }
 }

--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
@@ -117,11 +117,16 @@ namespace MigrateToJsps
             // Use the installed version of JSPS on the NuGet fallback folder.
             var versions = Directory.GetDirectories(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Shared", "NuGetPackages", "microsoft.visualstudio.javascript.sdk"));
             var newestVersion = versions
-                .Select(v => new { Version = new Version(Path.GetFileName(v)) })
-                .OrderByDescending(v => v.Version)
+                .Select(v =>
+                {
+                    Version version;
+                    Version.TryParse(Path.GetFileName(v), out version);
+                    return version;
+                })
+                .OrderByDescending(v => v)
                 .FirstOrDefault();
 
-            return newestVersion?.Version.ToString();
+            return newestVersion?.ToString();
         }
     }
 }

--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
@@ -117,7 +117,7 @@ namespace MigrateToJsps
             // Use the installed version of JSPS on the NuGet fallback folder.
             var versions = Directory.GetDirectories(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Shared", "NuGetPackages", "microsoft.visualstudio.javascript.sdk"));
             var newestVersion = versions
-                .Select(v => new { Path = v, Version = new Version(Path.GetFileName(v)) })
+                .Select(v => new { Version = new Version(Path.GetFileName(v)) })
                 .OrderByDescending(v => v.Version)
                 .FirstOrDefault();
 

--- a/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
+++ b/Nodejs/MigrateToJsps/Jsps/EsprojFileWriter.cs
@@ -45,7 +45,7 @@ namespace MigrateToJsps
             // If the SDK version is not found on NuGet fallback folder, keep the one hardcoded on EsProjFileModel
             if (sdkVersion != null)
             {
-                esprojFile.Sdk = $"Microsoft.VisualStudio.JavaScript.Sdk/{GetSdkVersion()}";
+                esprojFile.Sdk = $"Microsoft.VisualStudio.JavaScript.Sdk/{sdkVersion}";
             }
 
             XmlSerializer serializer = new XmlSerializer(typeof(EsprojFile));
@@ -119,8 +119,7 @@ namespace MigrateToJsps
             var newestVersion = versions
                 .Select(v =>
                 {
-                    Version version;
-                    Version.TryParse(Path.GetFileName(v), out version);
+                    Version.TryParse(Path.GetFileName(v), out var version);
                     return version;
                 })
                 .OrderByDescending(v => v)


### PR DESCRIPTION
Issue #
When we migrate a project we used a hardcoded version of JSPS. I updated that version as a backup but also it's better to dynamically pick it up from the version that VS installs.
