### PR TITLE
Disabling CSV

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -57,6 +57,9 @@ extends:
         timeoutInMinutes: 600
         cancelTimeoutInMinutes: 1
         templateContext:
+          sdl:
+            codeSignValidation:
+              enabled: false
           outputParentDirectory: '$(Build.ArtifactStagingDirectory)'
           outputs:
           - output: pipelineArtifact


### PR DESCRIPTION
Code Sign Validation is done elsewhere. It doesn't need to be performed in this pipeline.