### PR TITLE
Update lodash to 4.18.x

### DIFF
--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/platform-browser": "^21.0.7",
         "@angular/platform-browser-dynamic": "^21.0.7",
         "@angular/router": "^21.0.7",
-        "lodash": "^4.18.1",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.3",
         "zone.js": "~0.14.10"
@@ -4679,6 +4678,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^21.0.7",
         "@angular/platform-browser-dynamic": "^21.0.7",
         "@angular/router": "^21.0.7",
+        "lodash": "^4.18.1",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.3",
         "zone.js": "~0.14.10"
@@ -4675,10 +4676,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
@@ -19,7 +19,6 @@
     "@angular/platform-browser": "^21.0.7",
     "@angular/platform-browser-dynamic": "^21.0.7",
     "@angular/router": "^21.0.7",
-    "lodash": "^4.18.1",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
     "zone.js": "~0.14.10"
@@ -43,6 +42,7 @@
   },
   "overrides": {
     "brace-expansion": "1.1.13",
-    "js-yaml": "3.14.2"
+    "js-yaml": "3.14.2",
+    "lodash": "^4.18.1"
   }
 }

--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "^21.0.7",
     "@angular/platform-browser-dynamic": "^21.0.7",
     "@angular/router": "^21.0.7",
+    "lodash": "^4.18.1",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
     "zone.js": "~0.14.10"

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
         "jest-editor-support": "^31.1.2",
-        "lodash": "^4.18.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "web-vitals": "^4.2.3"

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
         "jest-editor-support": "^31.1.2",
+        "lodash": "^4.18.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "web-vitals": "^4.2.3"
@@ -720,6 +721,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.4.8",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.8.tgz",
@@ -799,6 +820,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.6",
@@ -1195,6 +1223,13 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.265",
@@ -1702,9 +1737,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -1726,6 +1761,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/makeerror": {

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "jest-editor-support": "^31.1.2",
+    "lodash": "^4.18.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "web-vitals": "^4.2.3"

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
@@ -7,7 +7,6 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "jest-editor-support": "^31.1.2",
-    "lodash": "^4.18.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "web-vitals": "^4.2.3"
@@ -40,6 +39,7 @@
     "@babel/core": "7.26.10",
     "@babel/helpers": "7.26.10",
     "@babel/runtime": "7.26.10",
-    "brace-expansion": "1.1.13"
+    "brace-expansion": "1.1.13",
+    "lodash": "^4.18.1"
   }
 }

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^17.0.30",
         "@types/react-dom": "^17.0.9",
         "jest-editor-support": "^30.0.2",
+        "lodash": "^4.18.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "typescript": "^4.4.4",
@@ -1916,9 +1917,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
@@ -16,7 +16,6 @@
         "@types/react": "^17.0.30",
         "@types/react-dom": "^17.0.9",
         "jest-editor-support": "^30.0.2",
-        "lodash": "^4.18.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "typescript": "^4.4.4",

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "jest-editor-support": "^30.0.2",
+    "lodash": "^4.18.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "typescript": "^4.4.4",

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
@@ -11,7 +11,6 @@
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "jest-editor-support": "^30.0.2",
-    "lodash": "^4.18.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "typescript": "^4.4.4",
@@ -46,6 +45,7 @@
     "@babel/helpers": "7.26.10",
     "@babel/runtime": "7.26.10",
     "js-yaml": "4.1.1",
-    "brace-expansion": "1.1.13"
+    "brace-expansion": "1.1.13",
+    "lodash": "^4.18.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "MicrosoftNodejsTools",
       "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "2.6.0",
         "@typescript-eslint/parser": "2.6.0",
@@ -1515,10 +1518,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.unescape": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "name": "MicrosoftNodejsTools",
       "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.18.1"
-      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "2.6.0",
         "@typescript-eslint/parser": "2.6.0",
@@ -1521,6 +1518,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.unescape": {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "eslint-plugin-vue": "^6.0.1",
     "react": "^16.12.0",
     "typescript": "3.6.4"
+  },
+  "dependencies": {
+    "lodash": "^4.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "^16.12.0",
     "typescript": "3.6.4"
   },
-  "dependencies": {
+  "overrides": {
     "lodash": "^4.18.1"
   }
 }


### PR DESCRIPTION
**CVE:** CVE-2026-4800 (lodash)
**Severity:** High

### What changed
- Added lodash override to ensure >= 4.18.x across all test projects

### Why
lodash versions prior to 4.18.x contain known prototype pollution vulnerabilities.

### Testing
- [x] Project builds successfully

### References
- S360 Dashboard: https://vnext.s360.msftcloudes.com/blades/security?blade=KPI:SFI-ES5.2~SLA:3~Tab:Details