### PR TITLE
[S360] Fix CVE-2026-33671: Update picomatch to 2.3.2 across mock projects

### DIFF
--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package-lock.json
@@ -294,6 +294,19 @@
         }
       }
     },
+    "node_modules/@angular-devkit/core/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@angular-devkit/schematics": {
       "version": "21.2.3",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.3.tgz",
@@ -2053,9 +2066,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5615,19 +5628,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -5759,9 +5759,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6571,6 +6571,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithAngularTests/package.json
@@ -43,6 +43,7 @@
   "overrides": {
     "brace-expansion": "1.1.13",
     "js-yaml": "3.14.2",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "picomatch": "^2.3.2"
   }
 }

--- a/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredOnProject/package-lock.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredOnProject/package-lock.json
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredOnProject/package.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredOnProject/package.json
@@ -9,9 +9,10 @@
   "dependencies": {
     "mocha": "^10.7.3"
   },
-  "overrides":{
+  "overrides": {
     "js-yaml": "4.1.1",
     "brace-expansion": "2.0.3",
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.3",
+    "picomatch": "^2.3.2"
   }
 }

--- a/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredPerFile/package-lock.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredPerFile/package-lock.json
@@ -4962,9 +4962,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredPerFile/package.json
+++ b/Nodejs/Tests/MockProjects/NodeAppWithTestsConfiguredPerFile/package.json
@@ -19,6 +19,7 @@
     "@babel/runtime": "7.26.10",
     "js-yaml": "4.1.1",
     "brace-expansion": "2.0.3",
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.3",
+    "picomatch": "^2.3.2"
   }
 }

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package-lock.json
@@ -1924,9 +1924,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjesttestsjavascript/package.json
@@ -40,6 +40,7 @@
     "@babel/helpers": "7.26.10",
     "@babel/runtime": "7.26.10",
     "brace-expansion": "1.1.13",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "picomatch": "^2.3.2"
   }
 }

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package-lock.json
@@ -2112,9 +2112,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
+++ b/Nodejs/Tests/MockProjects/reactappwithjestteststypescript/package.json
@@ -46,6 +46,7 @@
     "@babel/runtime": "7.26.10",
     "js-yaml": "4.1.1",
     "brace-expansion": "1.1.13",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "picomatch": "^2.3.2"
   }
 }


### PR DESCRIPTION
## S360 Security Fix

**CVE:** CVE-2026-33671 (picomatch ReDoS via extglob quantifiers)
**Severity:** High
**S360 Due Date:** 2026-06-24

### What changed
- Added picomatch ^2.3.2 override in all 5 mock test projects
- Regenerated package-lock.json files

### Affected projects
- NodeAppWithAngularTests
- NodeAppWithTestsConfiguredPerFile
- NodeAppWithTestsConfiguredOnProject
- reactappwithjesttestsjavascript
- reactappwithjestteststypescript

### References
- S360 Dashboard: https://vnext.s360.msftcloudes.com/blades/security?blade=KPI:SFI-ES5.2~SLA:3~Tab:Details