### PR TITLE
Fix: Validate homepage URL scheme before opening browser (ADO#2982591)

### DIFF
--- a/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmPackageInstallViewModel.cs
@@ -333,13 +333,18 @@ namespace Microsoft.NodejsTools.NpmUI
             }
         }
 
-        internal bool CanOpenHomepage(string homepage) => !string.IsNullOrEmpty(homepage);
+        internal bool CanOpenHomepage(string homepage)
+        {
+            return Uri.TryCreate(homepage, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+        }
 
         internal void OpenHomepage(string homepage)
         {
-            if (!string.IsNullOrEmpty(homepage))
+            if (Uri.TryCreate(homepage, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
             {
-                VsShellUtilities.OpenBrowser(homepage);
+                VsShellUtilities.OpenBrowser(uri.AbsoluteUri);
             }
         }
 

--- a/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
+++ b/Nodejs/Product/Nodejs/NpmUI/NpmWorker.cs
@@ -380,7 +380,12 @@ namespace Microsoft.NodejsTools.NpmUI
             var homepage = links?["homepage"];
             if (homepage != null)
             {
-                builder.AddHomepage((string)homepage);
+                var url = (string)homepage;
+                if (Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                {
+                    builder.AddHomepage(uri.AbsoluteUri);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes ADO#2982591

## Changes

**`NpmPackageInstallViewModel.cs`** — `OpenHomepage()` and `CanOpenHomepage()` now validate that the URL is a well-formed absolute URI with an `http` or `https` scheme before opening it.

**`NpmWorker.cs`** — `AddHomepage()` applies the same validation at data ingestion, so non-http(s) URLs are never stored or displayed as clickable links.

## Test Plan

Added 23 unit tests in `Nodejs/Tests/HomepageValidationTests/` that verify:
- Legitimate http/https URLs are allowed
- Malicious inputs (UNC paths, local executables, protocol handlers, file:// URIs, javascript: URIs) are blocked
- Edge cases (null, empty, whitespace, relative paths, garbage) are blocked

Run with:
\\\
cd Nodejs/Tests/HomepageValidationTests
dotnet restore --source https://api.nuget.org/v3/index.json
dotnet test --no-restore
\\\

All 23 tests pass.