### PR TITLE
Fix TestAdapter.Tests target framework to net472

### DIFF
--- a/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/Nodejs/Tests/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The TestAdapter.Tests project targeted net5.0-windows which requires .NET SDK 5.0+, but the build agent only has SDK 3.1. Updated to net472 to match the rest of the solution and resolve NETSDK1013 in the PR pipeline.

Issue #

##### Bug


##### Fix


##### Testing
