### PR TITLE
Ensure symbols are always published during VS insertion

### DIFF
--- a/azure-pipelines/build-insertion.yml
+++ b/azure-pipelines/build-insertion.yml
@@ -78,13 +78,20 @@ extends:
             InsertAutoComplete: true
             ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
             TargetBranch: ${{ parameters.VSInsertTargetBranch }}
+            # Skip optional commit/work-item enrichment; it is not needed for this repo
+            # and can otherwise abort the step after the PR has already been created.
+            AddCommitsToPR: false
+            LinkWorkItemsToPR: false
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         - download: projectSystemBuild
           artifact: symbolsToArchive
           displayName: 🔻 Download symbolsToArchive artifact
+          # Always publish symbols, even if a preceding step reports a non-fatal error.
+          condition: succeededOrFailed()
         - task: MicroBuildArchiveSymbols@6
           displayName: 🔣 Archive symbols to Symweb
+          condition: succeededOrFailed()
           inputs:
             TeamName: Node Tools for Visual Studio
             azureSubscription: 'VSEng-SymbolsUpload'     # SERVICE CONNECTION


### PR DESCRIPTION
Makes the VS insertion pipeline more robust so that debug symbols are always published, even if a later step in the insertion job reports a non-fatal error.

- Skip optional commit/work-item enrichment on the insertion step (not needed for this repo).
- Ensure the symbol download and archive steps always run.